### PR TITLE
Extended CAS OAuth Wrapper Support

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/CasOAuthWrapperClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/CasOAuthWrapperClient.java
@@ -23,7 +23,7 @@ import org.pac4j.oauth.profile.casoauthwrapper.CasOAuthWrapperProfile;
 import org.scribe.builder.api.CasOAuthWrapperApi20;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
-import org.scribe.oauth.ProxyOAuth20ServiceImpl;
+import org.scribe.oauth.ExtendedOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -64,7 +64,7 @@ public class CasOAuthWrapperClient extends BaseOAuth20Client<CasOAuthWrapperProf
     protected void internalInit() {
         super.internalInit();
         CommonHelper.assertNotBlank("casOAuthUrl", this.casOAuthUrl);
-        this.service = new ProxyOAuth20ServiceImpl(new CasOAuthWrapperApi20(this.casOAuthUrl),
+        this.service = new ExtendedOAuth20ServiceImpl(new CasOAuthWrapperApi20(this.casOAuthUrl),
                                                    new OAuthConfig(this.key, this.secret, this.callbackUrl,
                                                                    SignatureType.Header, null, null),
                                                    this.connectTimeout, this.readTimeout, this.proxyHost,

--- a/pac4j-oauth/src/main/java/org/scribe/builder/api/CasOAuthWrapperApi20.java
+++ b/pac4j-oauth/src/main/java/org/scribe/builder/api/CasOAuthWrapperApi20.java
@@ -16,7 +16,10 @@
 package org.scribe.builder.api;
 
 import org.scribe.model.OAuthConfig;
+import org.scribe.model.Verb;
 import org.scribe.utils.OAuthEncoder;
+import org.scribe.extractors.AccessTokenExtractor;
+import org.scribe.extractors.JsonTokenExtractor;
 
 /**
  * This class represents the OAuth API implementation for the CAS OAuth wrapper.
@@ -33,13 +36,25 @@ public class CasOAuthWrapperApi20 extends DefaultApi20 {
     }
     
     @Override
+    public AccessTokenExtractor getAccessTokenExtractor() {
+        return new JsonTokenExtractor();
+    }
+
+    @Override
     public String getAccessTokenEndpoint() {
         return this.casServerUrl + "/accessToken?";
     }
     
     @Override
     public String getAuthorizationUrl(final OAuthConfig config) {
-        return String.format(this.casServerUrl + "/authorize?client_id=%s&redirect_uri=%s", config.getApiKey(),
-                             OAuthEncoder.encode(config.getCallback()));
+        return String.format(this.casServerUrl + "/authorize?" + 
+                "response_type=code&client_id=%s&redirect_uri=%s",
+                config.getApiKey(),
+                OAuthEncoder.encode(config.getCallback()));
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.PUT;
     }
 }


### PR DESCRIPTION
The wrapper client now uses the extended oauth service to allow for specifying
oauth authorization codes in exchange for tokens. The Cas oauth wrapper now
uses the PUT verb for authorization, as well as using a JSON access token
verifier. These changes allow the demo to utilize new OAuth support in CAS.
