### PR TITLE
Implement hasBeenCancelled() in Google2Client

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
@@ -15,7 +15,6 @@
  */
 package org.pac4j.oauth.client;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.client.exception.OAuthCredentialsException;
@@ -27,28 +26,29 @@ import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 /**
  * This class is the OAuth client to authenticate users in Google using OAuth protocol version 2.0.
- * <p/>
- * The <i>scope</i> is by default : {@link Google2Scope#EMAIL}, but it can also but set to : {@link
- * Google2Scope#PROFILE} or {@link Google2Scope#EMAIL_AND_PROFILE}.
- * <p/>
+ * <p />
+ * The <i>scope</i> is by default : {@link Google2Scope#EMAIL}, but it can also but set to : {@link Google2Scope#PROFILE} or
+ * {@link Google2Scope#EMAIL_AND_PROFILE}.
+ * <p />
  * It returns a {@link org.pac4j.oauth.profile.google2.Google2Profile}.
- * <p/>
+ * <p />
  * More information at https://developers.google.com/accounts/docs/OAuth2Login
  *
- * @author Jerome Leleu
  * @see org.pac4j.oauth.profile.google2.Google2Profile
+ * @author Jerome Leleu
  * @since 1.2.0
  */
 public class Google2Client extends BaseOAuth20Client<Google2Profile> {
+
     public enum Google2Scope {
         EMAIL,
         PROFILE,
         EMAIL_AND_PROFILE
-    }
-
-    ;
+    };
 
     protected final String PROFILE_SCOPE = "https://www.googleapis.com/auth/userinfo.profile";
 
@@ -84,9 +84,12 @@ public class Google2Client extends BaseOAuth20Client<Google2Profile> {
         } else {
             this.scopeValue = this.PROFILE_SCOPE + " " + this.EMAIL_SCOPE;
         }
-        this.service = new ProxyOAuth20ServiceImpl(new GoogleApi20(),
-                new OAuthConfig(this.key, this.secret, this.callbackUrl, SignatureType.Header, this.scopeValue, null),
-                this.connectTimeout, this.readTimeout, this.proxyHost, this.proxyPort, false, true);
+        this.service = new ProxyOAuth20ServiceImpl(new GoogleApi20(), new OAuthConfig(this.key, this.secret,
+                this.callbackUrl,
+                SignatureType.Header,
+                this.scopeValue, null),
+                this.connectTimeout, this.readTimeout, this.proxyHost,
+                this.proxyPort, false, true);
     }
 
     @Override


### PR DESCRIPTION
Tested in production environment, a little different to FacebookClient as the 

```
context.getRequestParameter(OAuthCredentialsException.ERROR_REASON);
```

just return null, so skip the compare.

Sorry about that I carelessly apply my own code formatter before pushing, and i have to push another commit to fix the format, not know if this is the right way to do in git, hope not in a mess.
