### PR TITLE
Token sent to getProfileUrl for dynamic generation

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/BaseOAuthClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/BaseOAuthClient.java
@@ -200,7 +200,7 @@ public abstract class BaseOAuthClient<U extends OAuth20Profile> extends BaseClie
      * @return the user profile
      */
     protected U retrieveUserProfileFromToken(final Token accessToken) {
-        final String body = sendRequestForData(accessToken, getProfileUrl());
+        final String body = sendRequestForData(accessToken, getProfileUrl(accessToken));
         if (body == null) {
             throw new HttpCommunicationException("Not data found for accessToken : " + accessToken);
         }
@@ -211,10 +211,12 @@ public abstract class BaseOAuthClient<U extends OAuth20Profile> extends BaseClie
     
     /**
      * Retrieve the url of the profile of the authenticated user for the provider.
-     * 
+     *
+     * @param accessToken only used when constructing dynamic urls from data in the token
      * @return the url of the user profile given by the provider
      */
-    protected abstract String getProfileUrl();
+    @SuppressWarnings("unused")
+    protected abstract String getProfileUrl(final Token accessToken);
     
     /**
      * Make a request to get the data of the authenticated user for the provider.

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/CasOAuthWrapperClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/CasOAuthWrapperClient.java
@@ -24,6 +24,7 @@ import org.pac4j.oauth.profile.casoauthwrapper.CasOAuthWrapperProfile;
 import org.scribe.builder.api.CasOAuthWrapperApi20;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -77,7 +78,7 @@ public class CasOAuthWrapperClient extends BaseOAuth20Client<CasOAuthWrapperProf
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return this.casOAuthUrl + "/profile";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
@@ -65,7 +65,7 @@ public class DropBoxClient extends BaseOAuth10Client<DropBoxProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://api.dropbox.com/1/account/info";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FacebookClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FacebookClient.java
@@ -125,7 +125,7 @@ public class FacebookClient extends BaseOAuth20Client<FacebookProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         String url = BASE_URL + "?fields=" + this.fields;
         if (this.limit > DEFAULT_LIMIT) {
             url += "&limit=" + this.limit;
@@ -135,7 +135,7 @@ public class FacebookClient extends BaseOAuth20Client<FacebookProfile> {
     
     @Override
     protected FacebookProfile retrieveUserProfileFromToken(final Token accessToken) {
-        String body = sendRequestForData(accessToken, getProfileUrl());
+        String body = sendRequestForData(accessToken, getProfileUrl(accessToken));
         if (body == null) {
             throw new HttpCommunicationException("Not data found for accessToken : " + accessToken);
         }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GitHubClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GitHubClient.java
@@ -22,6 +22,7 @@ import org.pac4j.oauth.profile.github.GitHubProfile;
 import org.scribe.builder.api.GitHubApi;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -72,7 +73,7 @@ public class GitHubClient extends BaseOAuth20Client<GitHubProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://api.github.com/user";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
@@ -24,6 +24,7 @@ import org.pac4j.oauth.profile.google2.Google2Profile;
 import org.scribe.builder.api.GoogleApi20;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -93,7 +94,7 @@ public class Google2Client extends BaseOAuth20Client<Google2Profile> {
     }
 
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://www.googleapis.com/oauth2/v2/userinfo";
     }
 

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedIn2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedIn2Client.java
@@ -26,6 +26,7 @@ import org.scribe.builder.api.LinkedInApi20;
 import org.scribe.builder.api.StateApi20;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.LinkedInOAuth20ServiceImpl;
 
 /**
@@ -98,7 +99,7 @@ public class LinkedIn2Client extends BaseOAuth20Client<LinkedIn2Profile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://api.linkedin.com/v1/people/~:(" + this.fields + ")";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedInClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedInClient.java
@@ -23,6 +23,7 @@ import org.pac4j.oauth.profile.linkedin.LinkedInProfile;
 import org.scribe.builder.api.LinkedInApi;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth10aServiceImpl;
 
 /**
@@ -65,7 +66,7 @@ public class LinkedInClient extends BaseOAuth10Client<LinkedInProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "http://api.linkedin.com/v1/people/~";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/PayPalClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/PayPalClient.java
@@ -24,6 +24,7 @@ import org.pac4j.oauth.profile.paypal.PayPalProfile;
 import org.scribe.builder.api.PayPalApi20;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.PayPalOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -79,7 +80,7 @@ public class PayPalClient extends BaseOAuth20Client<PayPalProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://api.paypal.com/v1/identity/openidconnect/userinfo?schema=openid";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/TwitterClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/TwitterClient.java
@@ -24,6 +24,7 @@ import org.scribe.builder.api.DefaultApi10a;
 import org.scribe.builder.api.TwitterApi;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth10aServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -75,7 +76,7 @@ public class TwitterClient extends BaseOAuth10Client<TwitterProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://api.twitter.com/1.1/account/verify_credentials.json";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/VkClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/VkClient.java
@@ -7,6 +7,7 @@ import org.pac4j.oauth.profile.vk.VkProfile;
 import org.scribe.builder.api.VkApi;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -64,7 +65,7 @@ public class VkClient extends BaseOAuth20Client<VkProfile> {
 	}
 
 	@Override
-	protected String getProfileUrl() {
+	protected String getProfileUrl(final Token accessToken) {
 		String url = BASE_URL + "?fields=" + this.fields;
 		return url;
 	}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WindowsLiveClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WindowsLiveClient.java
@@ -22,6 +22,7 @@ import org.pac4j.oauth.profile.windowslive.WindowsLiveProfile;
 import org.scribe.builder.api.LiveApi;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -63,7 +64,7 @@ public class WindowsLiveClient extends BaseOAuth20Client<WindowsLiveProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://apis.live.net/v5.0/me";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WordPressClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WordPressClient.java
@@ -23,6 +23,7 @@ import org.pac4j.oauth.profile.wordpress.WordPressProfile;
 import org.scribe.builder.api.WordPressApi;
 import org.scribe.model.OAuthConfig;
 import org.scribe.model.SignatureType;
+import org.scribe.model.Token;
 import org.scribe.oauth.ProxyOAuth20ServiceImpl;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -66,7 +67,7 @@ public class WordPressClient extends BaseOAuth20Client<WordPressProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "https://public-api.wordpress.com/rest/v1/me/?pretty=1";
     }
     

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/YahooClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/YahooClient.java
@@ -66,7 +66,7 @@ public class YahooClient extends BaseOAuth10Client<YahooProfile> {
     }
     
     @Override
-    protected String getProfileUrl() {
+    protected String getProfileUrl(final Token accessToken) {
         return "http://social.yahooapis.com/v1/me/guid?format=xml";
     }
     
@@ -76,7 +76,7 @@ public class YahooClient extends BaseOAuth10Client<YahooProfile> {
     @Override
     protected YahooProfile retrieveUserProfileFromToken(final Token accessToken) {
         // get the guid : http://developer.yahoo.com/social/rest_api_guide/introspective-guid-resource.html
-        String body = sendRequestForData(accessToken, getProfileUrl());
+        String body = sendRequestForData(accessToken, getProfileUrl(accessToken));
         final String guid = StringUtils.substringBetween(body, "<value>", "</value>");
         logger.debug("guid : {}", guid);
         if (StringUtils.isBlank(guid)) {


### PR DESCRIPTION
Added a Token-parameter to the getProfileUrl(..) function to add the possibility for clients to create dynamic profile URLs. The Token can be used to carry information from the response received along with the access token response. Currently not used in any of the existing clients, but is necessary in other possible, future integrations with other services.
