### PR TITLE
fixed yahoo client error: use https instead of http

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/YahooClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/YahooClient.java
@@ -67,7 +67,7 @@ public class YahooClient extends BaseOAuth10Client<YahooProfile> {
     
     @Override
     protected String getProfileUrl(final Token accessToken) {
-        return "http://social.yahooapis.com/v1/me/guid?format=xml";
+        return "https://social.yahooapis.com/v1/me/guid?format=xml";
     }
     
     /**
@@ -75,7 +75,7 @@ public class YahooClient extends BaseOAuth10Client<YahooProfile> {
      */
     @Override
     protected YahooProfile retrieveUserProfileFromToken(final Token accessToken) {
-        // get the guid : http://developer.yahoo.com/social/rest_api_guide/introspective-guid-resource.html
+        // get the guid : https://developer.yahoo.com/social/rest_api_guide/introspective-guid-resource.html
         String body = sendRequestForData(accessToken, getProfileUrl(accessToken));
         final String guid = StringUtils.substringBetween(body, "<value>", "</value>");
         logger.debug("guid : {}", guid);
@@ -84,7 +84,7 @@ public class YahooClient extends BaseOAuth10Client<YahooProfile> {
             logger.error(message);
             throw new HttpCommunicationException(message);
         }
-        body = sendRequestForData(accessToken, "http://social.yahooapis.com/v1/user/" + guid + "/profile?format=json");
+        body = sendRequestForData(accessToken, "https://social.yahooapis.com/v1/user/" + guid + "/profile?format=json");
         final YahooProfile profile = extractUserProfile(body);
         addAccessTokenToProfile(profile, accessToken);
         return profile;


### PR DESCRIPTION
This change should fix the Yahoo Client Error described below.

For Yahoo Authentication, the API now requires HTTPS. Please refer to the discussion on the page (https://developer.yahoo.com/forum/OAuth-General-Discussion-YDN-SDKs/http-social-yahooapis-com-Will-be-right-back/1395509802423-89faffa2-1503-486d-bc29-6505719bd774) and the comment from "africa356" on Mar 24, 2014.
