### PR TITLE
findClient(Class class) return the class  by autocasting

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
@@ -122,13 +122,14 @@ public final class Clients extends InitializableObject {
      * Return the right client according to the specific class.
      *
      * @param class
+     * @param C the client class
      * @return the right client
      */
-    public Client findClient(final Class<? extends Client> clazz) {
+    public <C extends Client> C findClient(final Class<C> clazz) {
         init();
         for (final Client client : this.clients) {
             if (client.getClass().equals(clazz)) {
-                return client;
+                return (C) client;
             }
         }
         final String message = "No client found for class: " + clazz;


### PR DESCRIPTION
Change the findClient to cast the return client to the given search class.

It's allow to write code without cast : 

``` java
FacebookClient fb = Clients.findClient(FacebookClient.class);
```
