### PR TITLE
Allow to subclass Client

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
@@ -127,10 +127,12 @@ public final class Clients extends InitializableObject {
      */
     public <C extends Client> C findClient(final Class<C> clazz) {
         init();
-        for (final Client client : this.clients) {
-            if (client.getClass().equals(clazz)) {
+        if (clazz != null) {
+          for (final Client client : this.clients) {
+            if (clazz.isAssignableFrom(client.getClass())) {
                 return (C) client;
             }
+          }
         }
         final String message = "No client found for class: " + clazz;
         logger.error(message);


### PR DESCRIPTION
Allow to subclass a client like FormClient, but get the client as it with :

```
Clients.findClient(FormClient.class);
```

You can also get the first oauth client with : 

```
Clients.findClient(BaseOAuth20Client.class);
```
