### PR TITLE
Upgrade to Junit 4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,14 +188,8 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.10</version>
+				<version>4.11</version>
 				<scope>test</scope>
-				<exclusions>
-					<exclusion>
-						<groupId>org.hamcrest</groupId>
-						<artifactId>hamcrest-core</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>net.sourceforge.htmlunit</groupId>


### PR DESCRIPTION
Junit 4.10 can often cause problems because it bundled all of its dependencies within its jar instead of specifying them as proper Maven dependencies. Thus you end up with two versions of many libraries on your classpath, which can cause bad things to happen
