### PR TITLE
Remove support for Google OpenID

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ This module is based on the **pac4j-core** module and the [commons-codec](http:/
 
 This module is dedicated to OpenID protocol support:
 
-* the *GoogleOpenIdClient* is the client for Google
+* the *YahooOpenIdClient* is the client for Yahoo
 * the *OpenIdCredentials* class is the credentials for OpenID support
-* the *GoogleOpenIdProfile* class is the associated profile, returned by the client.
+* the *YahooOpenIdProfile* class is the associated profile, returned by the client.
 
 This module is based on the **pac4j-core** module and the [openid4java](http://code.google.com/p/openid4java/) library.
 
@@ -173,7 +173,7 @@ This module is based on the **pac4j-core** module and the [Google App Engine API
 <tr><td>Bitbucket</td><td>OAuth 1.0</td><td>pac4j-oauth</td><td>BitbucketClient</td><td>BitbucketProfile</td></tr>
 <tr><td>Web sites with basic auth authentication</td><td>HTTP</td><td>pac4j-http</td><td>BasicAuthClient</td><td>HttpProfile</td></tr>
 <tr><td>Web sites with form authentication</td><td>HTTP</td><td>pac4j-http</td><td>FormClient</td><td>HttpProfile</td></tr>
-<tr><td>Google</td><td>OpenID</td><td>pac4j-openid</td><td>GoogleOpenIdClient</td><td>GoogleOpenIdProfile</td></tr>
+<tr><td>Google - Deprecated</td><td>OpenID</td><td>pac4j-openid</td><td>GoogleOpenIdClient</td><td>GoogleOpenIdProfile</td></tr>
 <tr><td>Yahoo</td><td>OpenID</td><td>pac4j-openid</td><td>YahooOpenIdClient</td><td>YahooOpenIdProfile</td></tr>
 <tr><td>SAML Identity Provider</td><td>SAML 2.0</td><td>pac4j-saml</td><td>Saml2Client</td><td>Saml2Profile</td></tr>
 <tr><td>Google App Engine User Service</td><td>Gae User Service Mechanism</td><td>pac4j-gae</td><td>GaeUserServiceClient</td><td>GaeUserServiceProfile</td></tr>

--- a/pac4j-openid/src/main/java/org/pac4j/openid/client/GoogleOpenIdClient.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/client/GoogleOpenIdClient.java
@@ -29,6 +29,9 @@ import org.pac4j.openid.profile.google.GoogleOpenIdAttributesDefinition;
 import org.pac4j.openid.profile.google.GoogleOpenIdProfile;
 
 /**
+ * IMPORTANT: Google is removing support for OpenID. OpenID Connect is recommended instead.
+ * https://developers.google.com/+/api/auth-migration
+ * 
  * This class is the OpenID client to authenticate users with their google account.
  * <p />
  * It returns a {@link org.pac4j.openid.profile.google.GoogleOpenIdProfile}.
@@ -37,6 +40,7 @@ import org.pac4j.openid.profile.google.GoogleOpenIdProfile;
  * @author Stephane Gleizes
  * @since 1.4.1
  */
+@Deprecated
 public class GoogleOpenIdClient extends BaseOpenIdClient<GoogleOpenIdProfile> {
 
     public static final String GOOGLE_GENERIC_USER_IDENTIFIER = "https://www.google.com/accounts/o8/id";

--- a/pac4j-openid/src/main/java/org/pac4j/openid/profile/google/GoogleOpenIdAttributesDefinition.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/profile/google/GoogleOpenIdAttributesDefinition.java
@@ -19,11 +19,15 @@ import org.pac4j.core.profile.AttributesDefinition;
 import org.pac4j.core.profile.converter.Converters;
 
 /**
+ * IMPORTANT: Google is removing support for OpenID. OpenID Connect is recommended instead.
+ * https://developers.google.com/+/api/auth-migration
+ * 
  * This class defines the attributes of the {@link GoogleOpenIdProfile}.
  * 
  * @author Stephane Gleizes
  * @since 1.4.1
  */
+@Deprecated
 public class GoogleOpenIdAttributesDefinition extends AttributesDefinition {
     
     public static final String COUNTRY = "country";

--- a/pac4j-openid/src/main/java/org/pac4j/openid/profile/google/GoogleOpenIdProfile.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/profile/google/GoogleOpenIdProfile.java
@@ -22,6 +22,9 @@ import org.pac4j.openid.profile.OpenIdAttributesDefinitions;
 import org.pac4j.openid.profile.OpenIdProfile;
 
 /**
+ * IMPORTANT: Google is removing support for OpenID. OpenID Connect is recommended instead.
+ * https://developers.google.com/+/api/auth-migration
+ * 
  * This class is the user profile for Google using OpenID with appropriate getters.<br />
  * It is returned by the {@link org.pac4j.openid.client.GoogleOpenIdClient}.
  * <p />
@@ -79,6 +82,7 @@ import org.pac4j.openid.profile.OpenIdProfile;
  * @author Stephane Gleizes
  * @since 1.4.1
  */
+@Deprecated
 public class GoogleOpenIdProfile extends OpenIdProfile {
     
     private static final long serialVersionUID = 7866288887408897456L;


### PR DESCRIPTION
Google has deprecated OpenID and you can no longer create a new OpenID client. pac4j supports OAuth 2.0 for Google, which is considered a better way to connect. See https://developers.google.com/accounts/docs/OpenID

Also, the tests are failing for Google OpenID and this would help us reduce the number of failing tests
