### PR TITLE
Make signing of SAML requests optional

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/Saml2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/Saml2MetadataGenerator.java
@@ -133,8 +133,10 @@ public class Saml2MetadataGenerator {
                 getAssertionConsumerService(SAMLConstants.SAML2_POST_BINDING_URI, index++,
                         this.defaultACSIndex == index));
 
-        spDescriptor.getKeyDescriptors().add(getKeyDescriptor(UsageType.SIGNING, getKeyInfo()));
-        spDescriptor.getKeyDescriptors().add(getKeyDescriptor(UsageType.ENCRYPTION, getKeyInfo()));
+        if (credentialProvider != null) {
+          spDescriptor.getKeyDescriptors().add(getKeyDescriptor(UsageType.SIGNING, getKeyInfo()));
+          spDescriptor.getKeyDescriptors().add(getKeyDescriptor(UsageType.ENCRYPTION, getKeyInfo()));
+        }
 
         return spDescriptor;
 
@@ -192,7 +194,7 @@ public class Saml2MetadataGenerator {
         return descriptor;
     }
 
-    protected KeyInfo getKeyInfo() {
+    private KeyInfo getKeyInfo() {
         Credential serverCredential = this.credentialProvider.getCredential();
         return generateKeyInfoForCredential(serverCredential);
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/Saml2WebSSOProfileHandler.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/Saml2WebSSOProfileHandler.java
@@ -34,6 +34,7 @@ import org.opensaml.ws.security.provider.StaticSecurityPolicyResolver;
 import org.opensaml.xml.parse.StaticBasicParserPool;
 import org.opensaml.xml.security.SecurityException;
 import org.opensaml.xml.signature.SignatureTrustEngine;
+import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.saml.crypto.CredentialProvider;
 import org.pac4j.saml.exceptions.SamlException;
 import org.pac4j.saml.util.SamlUtils;
@@ -43,7 +44,6 @@ import org.pac4j.saml.util.SamlUtils;
  * 
  * @author Michael Remond
  * @since 1.5.0
- *
  */
 @SuppressWarnings("rawtypes")
 public class Saml2WebSSOProfileHandler {
@@ -89,6 +89,9 @@ public class Saml2WebSSOProfileHandler {
         boolean sign = spDescriptor.isAuthnRequestsSigned() || idpssoDescriptor.getWantAuthnRequestsSigned();
 
         if (sign) {
+            if (credentialProvider == null) {
+               throw new TechnicalException("Signing of requests was requested, but keystore with signing credentials not provided");
+            }
             context.setOutboundSAMLMessageSigningCredential(credentialProvider.getCredential());
         }
 


### PR DESCRIPTION
The majority of IdPs do not require this, so it makes setup substantially more difficult than necessary. You can signup for a free 30 day trial with Okta or OneLogin to verify (or I can send screenshots showing this is the case).

For a service provider (SP), failing to sign requests makes the whole process worthless. On the IdP side, it's less important. It is only necessary if the IdP wishes to verify that the request really comes from an SP it trusts. E.g. if the SP requests certain confidential attributes to be disclosed (that not all SPs should see), and possibly to encrypt those attributes in the response so that only this SP can read it.

Here's [a really good overview of SAML](https://www.oasis-open.org/committees/download.php/12958/SAMLV2.0-basics.pdf). The IdP is going to say something like "Joe authenticated with a password at 9:00am and is a member of the Engineering group". An SP can then take that information and give the user access to it's application knowing that the user is authenticated to the IdP. If a malicious actor were to find out that Joe is logged in to the IdP then in general there is not much they can do with that information. For that reason, most IdPs do not make attempts to protect this knowledge given the extra setup burden it requires. If the end user wishes to set this up for extra security, they may, but in the general case it isn't asked for.
