### PR TITLE
Two fixes related to SAML signing

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/Saml2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/Saml2Client.java
@@ -195,6 +195,7 @@ public class Saml2Client extends BaseClient<Saml2Credentials, Saml2Profile> {
         Saml2MetadataGenerator metadataGenerator = new Saml2MetadataGenerator();
         if (this.credentialProvider != null) {
             metadataGenerator.setCredentialProvider(this.credentialProvider);
+            metadataGenerator.setAuthnRequestSigned(true);
         }
         // If the spEntityId is blank, use the callback url
         if (CommonHelper.isBlank(this.spEntityId)) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/Saml2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/Saml2MetadataGenerator.java
@@ -71,7 +71,7 @@ public class Saml2MetadataGenerator {
 
     protected String singleLogoutServiceUrl;
 
-    protected boolean authnRequestSigned = true;
+    protected boolean authnRequestSigned = false;
 
     protected boolean wantAssertionSigned = true;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/Saml2WebSSOProfileHandler.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/Saml2WebSSOProfileHandler.java
@@ -38,6 +38,8 @@ import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.saml.crypto.CredentialProvider;
 import org.pac4j.saml.exceptions.SamlException;
 import org.pac4j.saml.util.SamlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handler capable of sending and receiving SAML messages according to the SAML2 SSO Browser profile.
@@ -47,6 +49,8 @@ import org.pac4j.saml.util.SamlUtils;
  */
 @SuppressWarnings("rawtypes")
 public class Saml2WebSSOProfileHandler {
+
+    private final static Logger logger = LoggerFactory.getLogger(Saml2WebSSOProfileHandler.class);
 
     private final CredentialProvider credentialProvider;
 
@@ -86,13 +90,10 @@ public class Saml2WebSSOProfileHandler {
             context.setRelayState(relayState);
         }
 
-        boolean sign = spDescriptor.isAuthnRequestsSigned() || idpssoDescriptor.getWantAuthnRequestsSigned();
-
-        if (sign) {
-            if (credentialProvider == null) {
-               throw new TechnicalException("Signing of requests was requested, but keystore with signing credentials not provided");
-            }
+        if (spDescriptor.isAuthnRequestsSigned()) {
             context.setOutboundSAMLMessageSigningCredential(credentialProvider.getCredential());
+        } else if (idpssoDescriptor.getWantAuthnRequestsSigned()) {
+            logger.warn("IdP wants authn requests signed, it will perhaps reject your authn requests unless you provide a keystore");
         }
 
         try {


### PR DESCRIPTION
First, we were incorrectly setting SP AuthnRequestSigned always to true even when not signing requests. Secondly, when an IdP says WantAuthnRequestsSigned it simply means that it supports signed requests, but not that requests must be signed, so this fixes it so that those requests complete successfully instead of throwing a TechnicalException
