### PR TITLE
SAML: mark log4j-over-slf4j as test scope and remove unused javax.servlet dependency

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -36,14 +36,6 @@
             <groupId>xml-security</groupId>
             <artifactId>xmlsec</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-        </dependency>
         <!-- for testing -->
         <dependency>
             <groupId>org.pac4j</groupId>
@@ -59,11 +51,6 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Glad we had an RC since it helped me find this bug :-)  Thought I fixed that slf4j problem everywhere, but looks like I missed one. Hopefully I'll be able to upgrade my Jenkins plugin to use the RC now. Also submitted a pull request to https://github.com/mesosphere/chaos to use shiro and the pac4j RC, so we'll see how that goes (Chaos is the framework that Marathon and Chronos are built on)
