### PR TITLE
Changes to Saml2Client for adding - NameIdPolicyFormat and AuthnContextClassRef when building SAMLRequest 

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/Saml2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/Saml2Client.java
@@ -86,7 +86,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 /**
- * This class is the client to authenticate users with a SAML2 Identity Provider. This implementation relies on the Web 
+ * This class is the client to authenticate users with a SAML2 Identity Provider. This implementation relies on the Web
  * Browser SSO profile with HTTP-POST binding. (http://docs.oasis-open.org/security/saml/v2.0/saml-profiles-2.0-os.pdf).
  * 
  * @author Michael Remond
@@ -161,7 +161,7 @@ public class Saml2Client extends BaseClient<Saml2Credentials, Saml2Profile> {
             CommonHelper.assertNotBlank("privateKeyPassword", this.privateKeyPassword);
 
             // load private key from the keystore and provide it as OpenSAML credentials
-            this.credentialProvider = new CredentialProvider(this.keystorePath, this.keystorePassword, 
+            this.credentialProvider = new CredentialProvider(this.keystorePath, this.keystorePassword,
                     this.privateKeyPassword);
             this.decrypter = new EncryptionProvider(this.credentialProvider).buildDecrypter();
         }
@@ -252,7 +252,7 @@ public class Saml2Client extends BaseClient<Saml2Credentials, Saml2Profile> {
 
         // Do we need binding specific decoder?
         MessageDecoder decoder = new Pac4jHTTPPostDecoder(parserPool);
-        this.handler = new Saml2WebSSOProfileHandler(this.credentialProvider, encoder, decoder, parserPool, 
+        this.handler = new Saml2WebSSOProfileHandler(this.credentialProvider, encoder, decoder, parserPool,
                 destinationBindingType);
 
         // Build provider for digital signature validation and encryption

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/Saml2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/Saml2AuthnRequestBuilder.java
@@ -49,118 +49,118 @@ import org.pac4j.saml.util.SamlUtils;
 @SuppressWarnings("rawtypes")
 public class Saml2AuthnRequestBuilder {
 
-	private boolean forceAuth;
+    private boolean forceAuth;
 
-	private AuthnContextComparisonTypeEnumeration comparisonType;
+    private AuthnContextComparisonTypeEnumeration comparisonType;
 
-	private String bindingType = SAMLConstants.SAML2_POST_BINDING_URI;
+    private String bindingType = SAMLConstants.SAML2_POST_BINDING_URI;
 
-	private String authnContextClassRef = null;
+    private String authnContextClassRef = null;
 
-	private String nameIdPolicyFormat = null;
+    private String nameIdPolicyFormat = null;
 
-	/**
-	 * Default constructor
-	 */
-	public Saml2AuthnRequestBuilder() {
-	}
+    /**
+     * Default constructor
+     */
+    public Saml2AuthnRequestBuilder() {
+    }
 
-	/**
-	 * @param forceAuth
-	 * @param comparisonType
-	 * @param bindingType
-	 * @param authnContextClassRef
-	 * @param nameIdPolicyFormat
-	 */
-	public Saml2AuthnRequestBuilder(boolean forceAuth, String comparisonType, String bindingType, 
-			String authnContextClassRef, String nameIdPolicyFormat) {
-		this.forceAuth = forceAuth;
-		this.comparisonType = getComparisonTypeEnumFromString(comparisonType);
-		this.bindingType = bindingType;
-		this.authnContextClassRef = authnContextClassRef;
-		this.nameIdPolicyFormat = nameIdPolicyFormat;
-	}
+    /**
+     * @param forceAuth
+     * @param comparisonType
+     * @param bindingType
+     * @param authnContextClassRef
+     * @param nameIdPolicyFormat
+     */
+    public Saml2AuthnRequestBuilder(boolean forceAuth, String comparisonType, String bindingType, 
+            String authnContextClassRef, String nameIdPolicyFormat) {
+        this.forceAuth = forceAuth;
+        this.comparisonType = getComparisonTypeEnumFromString(comparisonType);
+        this.bindingType = bindingType;
+        this.authnContextClassRef = authnContextClassRef;
+        this.nameIdPolicyFormat = nameIdPolicyFormat;
+    }
 
-	private final XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
+    private final XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
 
-	public AuthnRequest build(final SAMLMessageContext context) {
+    public AuthnRequest build(final SAMLMessageContext context) {
 
-		SPSSODescriptor spDescriptor = (SPSSODescriptor) context.getLocalEntityRoleMetadata();
-		IDPSSODescriptor idpssoDescriptor = (IDPSSODescriptor) context.getPeerEntityRoleMetadata();
+        SPSSODescriptor spDescriptor = (SPSSODescriptor) context.getLocalEntityRoleMetadata();
+        IDPSSODescriptor idpssoDescriptor = (IDPSSODescriptor) context.getPeerEntityRoleMetadata();
 
-		SingleSignOnService ssoService = SamlUtils.getSingleSignOnService(idpssoDescriptor, bindingType);
-		AssertionConsumerService assertionConsumerService = SamlUtils.getAssertionConsumerService(spDescriptor, null);
+        SingleSignOnService ssoService = SamlUtils.getSingleSignOnService(idpssoDescriptor, bindingType);
+        AssertionConsumerService assertionConsumerService = SamlUtils.getAssertionConsumerService(spDescriptor, null);
 
-		return buildAuthnRequest(context, assertionConsumerService, ssoService);
-	}
+        return buildAuthnRequest(context, assertionConsumerService, ssoService);
+    }
 
-	@SuppressWarnings("unchecked")
-	protected AuthnRequest buildAuthnRequest(final SAMLMessageContext context, 
-			final AssertionConsumerService assertionConsumerService, final SingleSignOnService ssoService) {
+    @SuppressWarnings("unchecked")
+    protected AuthnRequest buildAuthnRequest(final SAMLMessageContext context, 
+            final AssertionConsumerService assertionConsumerService, final SingleSignOnService ssoService) {
 
-		SAMLObjectBuilder<AuthnRequest> builder = (SAMLObjectBuilder<AuthnRequest>) this.builderFactory
-				.getBuilder(AuthnRequest.DEFAULT_ELEMENT_NAME);
-		AuthnRequest request = builder.buildObject();
-		if (comparisonType != null) {
-			RequestedAuthnContext authnContext = new RequestedAuthnContextBuilder().buildObject();
-			authnContext.setComparison(comparisonType);
+        SAMLObjectBuilder<AuthnRequest> builder = (SAMLObjectBuilder<AuthnRequest>) this.builderFactory
+                .getBuilder(AuthnRequest.DEFAULT_ELEMENT_NAME);
+        AuthnRequest request = builder.buildObject();
+        if (comparisonType != null) {
+            RequestedAuthnContext authnContext = new RequestedAuthnContextBuilder().buildObject();
+            authnContext.setComparison(comparisonType);
 
-			if (authnContextClassRef != null) {
-				AuthnContextClassRef classRef = new AuthnContextClassRefBuilder().buildObject();
-				classRef.setAuthnContextClassRef(authnContextClassRef);
-				authnContext.getAuthnContextClassRefs().add(classRef);
-			}
-			request.setRequestedAuthnContext(authnContext);
-		}
+            if (authnContextClassRef != null) {
+                AuthnContextClassRef classRef = new AuthnContextClassRefBuilder().buildObject();
+                classRef.setAuthnContextClassRef(authnContextClassRef);
+                authnContext.getAuthnContextClassRefs().add(classRef);
+            }
+            request.setRequestedAuthnContext(authnContext);
+        }
 
-		request.setID(generateID());
-		request.setIssuer(getIssuer(context.getLocalEntityId()));
-		request.setIssueInstant(new DateTime());
-		request.setVersion(SAMLVersion.VERSION_20);
-		request.setIsPassive(false);
-		request.setForceAuthn(this.forceAuth);
-		request.setProviderName("pac4j-saml");
+        request.setID(generateID());
+        request.setIssuer(getIssuer(context.getLocalEntityId()));
+        request.setIssueInstant(new DateTime());
+        request.setVersion(SAMLVersion.VERSION_20);
+        request.setIsPassive(false);
+        request.setForceAuthn(this.forceAuth);
+        request.setProviderName("pac4j-saml");
 
-		if (nameIdPolicyFormat != null) {
-			NameIDPolicy nameIdPolicy = new NameIDPolicyBuilder().buildObject();
-			nameIdPolicy.setAllowCreate(true);
-			nameIdPolicy.setFormat(nameIdPolicyFormat);
-			request.setNameIDPolicy(nameIdPolicy);
-		}
+        if (nameIdPolicyFormat != null) {
+            NameIDPolicy nameIdPolicy = new NameIDPolicyBuilder().buildObject();
+            nameIdPolicy.setAllowCreate(true);
+            nameIdPolicy.setFormat(nameIdPolicyFormat);
+            request.setNameIDPolicy(nameIdPolicy);
+        }
 
-		request.setDestination(ssoService.getLocation());
-		request.setAssertionConsumerServiceURL(assertionConsumerService.getLocation());
-		request.setProtocolBinding(assertionConsumerService.getBinding());
+        request.setDestination(ssoService.getLocation());
+        request.setAssertionConsumerServiceURL(assertionConsumerService.getLocation());
+        request.setProtocolBinding(assertionConsumerService.getBinding());
 
-		return request;
+        return request;
 
-	}
+    }
 
-	@SuppressWarnings("unchecked")
-	protected Issuer getIssuer(final String spEntityId) {
-		SAMLObjectBuilder<Issuer> issuerBuilder = (SAMLObjectBuilder<Issuer>) this.builderFactory
-				.getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
-		Issuer issuer = issuerBuilder.buildObject();
-		issuer.setValue(spEntityId);
-		return issuer;
-	}
+    @SuppressWarnings("unchecked")
+    protected Issuer getIssuer(final String spEntityId) {
+        SAMLObjectBuilder<Issuer> issuerBuilder = (SAMLObjectBuilder<Issuer>) this.builderFactory
+                .getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
+        Issuer issuer = issuerBuilder.buildObject();
+        issuer.setValue(spEntityId);
+        return issuer;
+    }
 
-	protected String generateID() {
-		Random r = new Random();
-		return '_' + Long.toString(Math.abs(r.nextLong()), 16) + Long.toString(Math.abs(r.nextLong()), 16);
-	}
+    protected String generateID() {
+        Random r = new Random();
+        return '_' + Long.toString(Math.abs(r.nextLong()), 16) + Long.toString(Math.abs(r.nextLong()), 16);
+    }
 
-	protected AuthnContextComparisonTypeEnumeration getComparisonTypeEnumFromString(String comparisonType) {
-		if ("exact".equals(comparisonType)) {
-			return AuthnContextComparisonTypeEnumeration.EXACT;
-		} else if ("minimum".equals(comparisonType)) {
-			return AuthnContextComparisonTypeEnumeration.MINIMUM;
-		} else if ("maximum".equals(comparisonType)) {
-			return AuthnContextComparisonTypeEnumeration.MAXIMUM;
-		} else if ("better".equals(comparisonType)) {
-			return AuthnContextComparisonTypeEnumeration.BETTER;
-		} else {
-			return null;
-		}
-	}
+    protected AuthnContextComparisonTypeEnumeration getComparisonTypeEnumFromString(String comparisonType) {
+        if ("exact".equals(comparisonType)) {
+            return AuthnContextComparisonTypeEnumeration.EXACT;
+        } else if ("minimum".equals(comparisonType)) {
+            return AuthnContextComparisonTypeEnumeration.MINIMUM;
+        } else if ("maximum".equals(comparisonType)) {
+            return AuthnContextComparisonTypeEnumeration.MAXIMUM;
+        } else if ("better".equals(comparisonType)) {
+            return AuthnContextComparisonTypeEnumeration.BETTER;
+        } else {
+            return null;
+        }
+    }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSaml2ClientIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSaml2ClientIT.java
@@ -54,39 +54,39 @@ public final class RedirectSaml2ClientIT extends Saml2ClientIT implements TestsC
 
     @Test
     public void testForceAuthIsSetForRedirectBinding() throws Exception {
-    	Saml2Client client = getClient();
-    	client.setForceAuth(true);
-    	WebContext context = MockWebContext.create();
-    	RedirectAction action = client.getRedirectAction(context, true, false);
-    	assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("ForceAuthn=\"true\""));
+        Saml2Client client = getClient();
+        client.setForceAuth(true);
+        WebContext context = MockWebContext.create();
+        RedirectAction action = client.getRedirectAction(context, true, false);
+        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("ForceAuthn=\"true\""));
     }
-    
+
     @Test
     public void testSetComparisonTypeWithRedirectBinding() throws Exception {
-    	Saml2Client client = getClient();
-    	client.setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
-    	WebContext context = MockWebContext.create();
-    	RedirectAction action = client.getRedirectAction(context, true, false);
-    	assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("Comparison=\"exact\""));
+        Saml2Client client = getClient();
+        client.setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
+        WebContext context = MockWebContext.create();
+        RedirectAction action = client.getRedirectAction(context, true, false);
+        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("Comparison=\"exact\""));
     }
-    
+
     @Test
     public void testNameIdPolicyFormat() throws Exception{
-    	Saml2Client client = getClient();
-    	client.setNameIdPolicyFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
-    	WebContext context = MockWebContext.create();
-    	RedirectAction action = client.getRedirectAction(context, true, false);
-    	assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("<saml2p:NameIDPolicy AllowCreate=\"true\" Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\"/></saml2p:AuthnRequest>"));
+        Saml2Client client = getClient();
+        client.setNameIdPolicyFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
+        WebContext context = MockWebContext.create();
+        RedirectAction action = client.getRedirectAction(context, true, false);
+        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("<saml2p:NameIDPolicy AllowCreate=\"true\" Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\"/></saml2p:AuthnRequest>"));
     }
-    
+
     @Test
     public void testAuthnContextClassRef() throws Exception {
-    	Saml2Client client = getClient();
-    	client.setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
-    	client.setAuthnContextClassRef("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport");
-    	WebContext context = MockWebContext.create();
-    	RedirectAction action = client.getRedirectAction(context, true, false);
-    	assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("<saml2p:RequestedAuthnContext Comparison=\"exact\"><saml2:AuthnContextClassRef xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>"));
+        Saml2Client client = getClient();
+        client.setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
+        client.setAuthnContextClassRef("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport");
+        WebContext context = MockWebContext.create();
+        RedirectAction action = client.getRedirectAction(context, true, false);
+        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("<saml2p:RequestedAuthnContext Comparison=\"exact\"><saml2:AuthnContextClassRef xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>"));
     }
 
     @Test


### PR DESCRIPTION
I have made the changes to incorporate the following in SAMLRequest:
-  <b>NameIdPolicy</b><br/>
  Example : `<saml2p:NameIDPolicy
      Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
      AllowCreate="true"></saml2p:NameIDPolicy>`
- <b>AuthnContextClassRef when using Comparison Type</b> <br/>
  Example: `<saml2p:RequestedAuthnContext Comparison="exact">
      <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
  </saml2p:RequestedAuthnContext>`
