### PR TITLE
Facebook Graph URLS must be updated to v2.x

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FacebookClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FacebookClient.java
@@ -65,7 +65,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class FacebookClient extends BaseOAuth20Client<FacebookProfile> {
     
-    private static final String EXCHANGE_TOKEN_URL = "https://graph.facebook.com/oauth/access_token?grant_type=fb_exchange_token";
+    private static final String EXCHANGE_TOKEN_URL = "https://graph.facebook.com/v2.2/oauth/access_token?grant_type=fb_exchange_token";
     
     private static final String EXCHANGE_TOKEN_PARAMETER = "fb_exchange_token";
     
@@ -73,7 +73,7 @@ public class FacebookClient extends BaseOAuth20Client<FacebookProfile> {
     
     protected String fields = DEFAULT_FIELDS;
     
-    protected final static String BASE_URL = "https://graph.facebook.com/me";
+    protected final static String BASE_URL = "https://graph.facebook.com/v2.2/me";
     
     public final static String DEFAULT_SCOPE = "user_likes,user_about_me,user_birthday,user_education_history,email,user_hometown,user_relationship_details,user_location,user_religion_politics,user_relationships,user_website,user_work_history";
     

--- a/pac4j-oauth/src/main/java/org/scribe/builder/api/ExtendedFacebookApi.java
+++ b/pac4j-oauth/src/main/java/org/scribe/builder/api/ExtendedFacebookApi.java
@@ -27,12 +27,12 @@ import org.scribe.utils.Preconditions;
  */
 public final class ExtendedFacebookApi extends StateApi20 {
     
-    private static final String AUTHORIZE_URL_WITH_STATE = "https://www.facebook.com/dialog/oauth?client_id=%s&redirect_uri=%s&state=%s";
+    private static final String AUTHORIZE_URL_WITH_STATE = "https://www.facebook.com/v2.2/dialog/oauth?client_id=%s&redirect_uri=%s&state=%s";
     private static final String SCOPED_AUTHORIZE_URL_WITH_STATE = AUTHORIZE_URL_WITH_STATE + "&scope=%s";
     
     @Override
     public String getAccessTokenEndpoint() {
-        return "https://graph.facebook.com/oauth/access_token";
+        return "https://graph.facebook.com/v2.2/oauth/access_token";
     }
     
     @Override


### PR DESCRIPTION
Facebook has started notifying end users about the deprecation of the v1.0 API using the following message:
"You must upgrade this app to Graph API v2.x
v1.0 will be deprecated on April 30, 2015
Learn how to upgrade"

Our end users don't understand this message as it is too technical and IMHO meant for the developers instead. They think the Facebook OAuth login is broken while it is still working. Therefor I have updated all Facebook urls to the new v2.2 API.
