### PR TITLE
Authnrequest is optional, do not require it

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -204,13 +204,9 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             throw new SAMLException("Response issue instant is too old or in the future");
         }
 
-        if (response.getInResponseTo() == null) {
-            throw new SAMLException("InResponseTo field cannot be empty");
-        }
-
         AuthnRequest request = null;
         final SAMLMessageStorage messageStorage = context.getSAMLMessageStorage();
-        if (messageStorage != null) {
+        if (messageStorage != null && response.getInResponseTo() != null) {
             final XMLObject xmlObject = messageStorage.retrieveMessage(response.getInResponseTo());
             if (xmlObject == null) {
                 throw new SAMLException("InResponseToField of the Response doesn't correspond to sent message " + response.getInResponseTo());


### PR DESCRIPTION
This check for 'InResponseTo' breaks IDP initiated signon: there is no Authnrequest when using IDP initiated signon. Simply removing the check allows the signon to proceed.