### PR TITLE
Path fix for IdP metadata loading

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -75,8 +75,13 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
                     path = "/" + path;
                 }
                 resource = ResourceHelper.of(new ClassPathResource(path));
-            }  else if (this.idpMetadataPath.startsWith("https")) {
-                resource = ResourceHelper.of(new UrlResource(this.idpMetadataPath));
+            }  else if (this.idpMetadataPath.startsWith("http")) {
+                final UrlResource urlResource = new UrlResource(this.idpMetadataPath);
+                if (urlResource.getURL().getProtocol().equalsIgnoreCase("http")) {
+                    logger.warn("IdP metadata is retrieved from an insecure http endpoint [{}]",
+                            urlResource.getURL());
+                }
+                resource = ResourceHelper.of(urlResource);
             } else {
                 resource = ResourceHelper.of(new FileSystemResource(this.idpMetadataPath));
             }


### PR DESCRIPTION
Fixes #212

* Make sure filesystem resources are used as a fallback option when loading metadata.
* Explain failures with a better error message.