### PR TITLE
Added the Clearable abstraction and applied to Credentials and User Profile per #250

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/client/rest/HttpTGTProfile.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/client/rest/HttpTGTProfile.java
@@ -29,8 +29,8 @@ import org.pac4j.http.profile.HttpProfile;
 public final class HttpTGTProfile extends HttpProfile {
     private static final long serialVersionUID = -1688563185891330018L;
 
-    private final String ticketGrantingTicketId;
     private final String userName;
+    private String ticketGrantingTicketId;
 
     public HttpTGTProfile() {
         this.ticketGrantingTicketId = null;
@@ -45,6 +45,11 @@ public final class HttpTGTProfile extends HttpProfile {
 
     public String getTicketGrantingTicketId() {
         return ticketGrantingTicketId;
+    }
+
+    @Override
+    public void clear() {
+        this.ticketGrantingTicketId = null;
     }
 
     @Override

--- a/pac4j-cas/src/main/java/org/pac4j/cas/credentials/CasCredentials.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/credentials/CasCredentials.java
@@ -28,7 +28,7 @@ public class CasCredentials extends Credentials {
     
     private static final long serialVersionUID = -6006976366005458716L;
     
-    private final String serviceTicket;
+    private String serviceTicket;
     
     public CasCredentials(final String serviceTicket, final String clientName) {
         this.serviceTicket = serviceTicket;
@@ -43,5 +43,11 @@ public class CasCredentials extends Credentials {
     public String toString() {
         return CommonHelper.toString(this.getClass(), "serviceTicket", this.serviceTicket, "clientName",
                                      getClientName());
+    }
+
+    @Override
+    public void clear() {
+        this.serviceTicket = null;
+        this.setClientName(null);
     }
 }

--- a/pac4j-cas/src/test/java/org/pac4j/cas/client/rest/TestHttpTGTProfile.java
+++ b/pac4j-cas/src/test/java/org/pac4j/cas/client/rest/TestHttpTGTProfile.java
@@ -1,0 +1,18 @@
+package org.pac4j.cas.client.rest;
+
+import junit.framework.TestCase;
+
+/**
+ * General test cases for HttpTGTProfile.
+ *
+ * @author  Jacob Severson
+ * @since   1.8.0
+ */
+public class TestHttpTGTProfile extends TestCase {
+
+    public void testClearProfile() {
+        HttpTGTProfile profile = new HttpTGTProfile("testId", "testUser");
+        profile.clear();
+        assertNull(profile.getTicketGrantingTicketId());
+    }
+}

--- a/pac4j-cas/src/test/java/org/pac4j/cas/credentials/TestCasCredentials.java
+++ b/pac4j-cas/src/test/java/org/pac4j/cas/credentials/TestCasCredentials.java
@@ -1,0 +1,24 @@
+package org.pac4j.cas.credentials;
+
+import junit.framework.TestCase;
+import org.pac4j.core.util.TestsConstants;
+
+/**
+ * General test cases for CasCredentials
+ *
+ * @author  Jacob Severson
+ * @since   1.8.0
+ */
+public class TestCasCredentials extends TestCase implements TestsConstants {
+
+    public void testClearCredentials() {
+        CasCredentials casCredentials = new CasCredentials(
+                "testServiceTicket",
+                "TestClientName"
+        );
+        casCredentials.clear();
+        assertNull(casCredentials.getClientName());
+        assertNull(casCredentials.getServiceTicket());
+    }
+
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/Clearable.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/Clearable.java
@@ -1,0 +1,16 @@
+package org.pac4j.core;
+
+/**
+ * Implementing classes have the ability to clear out sensitive
+ * or unnecessary information.
+ *
+ * @author  Jacob Severson
+ * @since   1.8.0
+ */
+public interface Clearable {
+
+    /**
+     * Removes any sensitive or unnecessary information held in the object.
+     */
+    void clear();
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
@@ -15,6 +15,8 @@
  */
 package org.pac4j.core.credentials;
 
+import org.pac4j.core.Clearable;
+
 import java.io.Serializable;
 
 /**
@@ -23,7 +25,7 @@ import java.io.Serializable;
  * @author Jerome Leleu
  * @since 1.4.0
  */
-public abstract class Credentials implements Serializable {
+public abstract class Credentials implements Serializable, Clearable {
 
     private static final long serialVersionUID = 4864923514027378583L;
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.pac4j.core.Clearable;
 import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
  * @author Jerome Leleu
  * @since 1.0.0
  */
-public class UserProfile implements Serializable, Externalizable {
+public class UserProfile implements Serializable, Externalizable, Clearable {
 
     private static final long serialVersionUID = 9020114478664816338L;
 
@@ -260,5 +261,10 @@ public class UserProfile implements Serializable, Externalizable {
         this.isRemembered = (boolean) in.readBoolean();
         this.roles = (List) in.readObject();
         this.permissions = (List) in.readObject();
+    }
+
+    @Override
+    public void clear() {
+        // No-op. Allow subtypes to specify which state should be cleared out.
     }
 }

--- a/pac4j-gae/src/main/java/org/pac4j/gae/credentials/GaeUserCredentials.java
+++ b/pac4j-gae/src/main/java/org/pac4j/gae/credentials/GaeUserCredentials.java
@@ -35,4 +35,10 @@ public class GaeUserCredentials extends Credentials {
 	public User getUser() {
 		return user;
 	}
+
+	@Override
+	public void clear() {
+		this.user = null;
+		this.setClientName(null);
+	}
 }

--- a/pac4j-gae/src/test/java/org/pac4j/gae/credentials/TestGaeUserCredentials.java
+++ b/pac4j-gae/src/test/java/org/pac4j/gae/credentials/TestGaeUserCredentials.java
@@ -1,0 +1,22 @@
+package org.pac4j.gae.credentials;
+
+import com.google.appengine.api.users.User;
+import junit.framework.TestCase;
+import org.pac4j.core.util.TestsConstants;
+
+/**
+ * General test cases for GaeUserCredentials.
+ *
+ * @author  Jacob Severson
+ * @since   1.8.0
+ */
+public class TestGaeUserCredentials extends TestCase implements TestsConstants {
+
+    public void testClearGaeUserCredentials() {
+        GaeUserCredentials gaeUserCredentials = new GaeUserCredentials ();
+        gaeUserCredentials.setUser(new User("testEmail@test.com", "test.com", "testUserId"));
+        gaeUserCredentials.clear();
+        assertNull(gaeUserCredentials.getUser());
+        assertNull(gaeUserCredentials.getClientName());
+    }
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/TokenCredentials.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/TokenCredentials.java
@@ -27,7 +27,7 @@ public class TokenCredentials extends HttpCredentials {
 
     private static final long serialVersionUID = -4270718634364817595L;
 
-    private final String token;
+    private String token;
 
     public TokenCredentials(String token, final String clientName) {
         this.token = token;
@@ -41,5 +41,12 @@ public class TokenCredentials extends HttpCredentials {
     @Override
     public String toString() {
         return CommonHelper.toString(this.getClass(), "token", this.token, "clientName", getClientName());
+    }
+
+    @Override
+    public void clear() {
+        this.token = null;
+        this.setClientName(null);
+        this.setUserProfile(null);
     }
 }

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/UsernamePasswordCredentials.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/UsernamePasswordCredentials.java
@@ -27,9 +27,9 @@ public class UsernamePasswordCredentials extends HttpCredentials {
 
     private static final long serialVersionUID = -7229878989627796565L;
 
-    private final String username;
+    private String username;
 
-    private final String password;
+    private String password;
 
     public UsernamePasswordCredentials(final String username, final String password, final String clientName) {
         this.username = username;
@@ -49,5 +49,13 @@ public class UsernamePasswordCredentials extends HttpCredentials {
     public String toString() {
         return CommonHelper.toString(this.getClass(), "username", this.username, "password", "[PROTECTED]",
                 "clientName", getClientName());
+    }
+
+    @Override
+    public void clear() {
+        this.username = null;
+        this.password = null;
+        this.setClientName(null);
+        this.setUserProfile(null);
     }
 }

--- a/pac4j-http/src/test/java/org/pac4j/http/credentials/TestTokenCredentials.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/credentials/TestTokenCredentials.java
@@ -1,0 +1,20 @@
+package org.pac4j.http.credentials;
+
+import junit.framework.TestCase;
+
+/**
+ * General test cases for TokenCredentials
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestTokenCredentials extends TestCase {
+
+    public void testClearTokenCredentials() {
+        TokenCredentials tokenCredentials = new TokenCredentials("testToken", "testClient");
+        tokenCredentials.clear();
+        assertNull(tokenCredentials.getClientName());
+        assertNull(tokenCredentials.getToken());
+        assertNull(tokenCredentials.getUserProfile());
+    }
+}

--- a/pac4j-http/src/test/java/org/pac4j/http/credentials/TestUsernamePasswordCredentials.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/credentials/TestUsernamePasswordCredentials.java
@@ -1,0 +1,25 @@
+package org.pac4j.http.credentials;
+
+import junit.framework.TestCase;
+
+/**
+ * General test cases for UsernamePasswordCredentials.
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestUsernamePasswordCredentials extends TestCase {
+
+    public void testClearUsernamePasswordCredentials() {
+        UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(
+                "testUsername",
+                "testPassword",
+                "testClient"
+        );
+        credentials.clear();
+        assertNull(credentials.getUserProfile());
+        assertNull(credentials.getClientName());
+        assertNull(credentials.getPassword());
+        assertNull(credentials.getUsername());
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/OAuthCredentials.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/OAuthCredentials.java
@@ -29,11 +29,11 @@ public class OAuthCredentials extends Credentials {
     
     private static final long serialVersionUID = -7705033802712382951L;
     
-    private final Token requestToken;
+    private Token requestToken;
     
-    private final String token;
+    private String token;
     
-    private final String verifier;
+    private String verifier;
     
     public OAuthCredentials(final String verifier, final String clientName) {
         this.requestToken = null;
@@ -65,5 +65,13 @@ public class OAuthCredentials extends Credentials {
     public String toString() {
         return CommonHelper.toString(this.getClass(), "requestToken", this.requestToken, "token", this.token,
                                      "verifier", this.verifier, "clientName", getClientName());
+    }
+
+    @Override
+    public void clear() {
+        this.token = null;
+        this.requestToken = null;
+        this.verifier = null;
+        this.setClientName(null);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/OAuth20Profile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/OAuth20Profile.java
@@ -45,4 +45,9 @@ public abstract class OAuth20Profile extends CommonProfile {
     public String getAccessToken() {
         return (String) getAttribute(OAuthAttributesDefinition.ACCESS_TOKEN);
     }
+
+    @Override
+    public void clear() {
+        this.setAccessToken("");
+    }
 }

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/credentials/TestOAuthCredentials.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/credentials/TestOAuthCredentials.java
@@ -47,4 +47,20 @@ public final class TestOAuthCredentials extends TestCase implements TestsConstan
         assertEquals(credentials.getVerifier(), credentials2.getVerifier());
         assertEquals(credentials.getClientName(), credentials2.getClientName());
     }
+
+    public void testClearOAuthCredentials() {
+        final OAuthCredentials credentials = new OAuthCredentials(REQUEST_TOKEN, TOKEN, VERIFIER, TYPE);
+        final byte[] bytes = TestsHelper.serialize(credentials);
+        final OAuthCredentials credentials2 = (OAuthCredentials) TestsHelper.unserialize(bytes);
+        credentials.clear();
+        credentials2.clear();
+        assertNull(credentials.getToken());
+        assertNull(credentials.getRequestToken());
+        assertNull(credentials.getVerifier());
+        assertNull(credentials.getClientName());
+        assertNull(credentials2.getToken());
+        assertNull(credentials2.getRequestToken());
+        assertNull(credentials2.getVerifier());
+        assertNull(credentials2.getClientName());
+    }
 }

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/github/TestGitHubProfile.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/github/TestGitHubProfile.java
@@ -1,0 +1,20 @@
+package org.pac4j.oauth.profile.github;
+
+import junit.framework.TestCase;
+
+/**
+ * General test cases for GitHubProfile.
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestGitHubProfile extends TestCase {
+
+    public void testClearGitHubProfile() {
+        GitHubProfile profile = new GitHubProfile();
+        profile.setAccessToken("testToken");
+        profile.clear();
+        assertEquals("", profile.getAccessToken());
+    }
+
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
@@ -28,7 +28,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
  */
 public class OidcCredentials extends Credentials {
 
-    private final AuthorizationCode code;
+    private AuthorizationCode code;
 
     public OidcCredentials(AuthorizationCode code) {
         this.code = code;
@@ -40,4 +40,9 @@ public class OidcCredentials extends Credentials {
         return this.code;
     }
 
+    @Override
+    public void clear() {
+        this.code = null;
+        this.setClientName(null);
+    }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -90,6 +90,11 @@ public class OidcProfile extends CommonProfile implements Externalizable {
         this.idTokenString = (String) in.readObject();
     }
 
+    @Override
+    public void clear() {
+        this.accessToken = null;
+    }
+
     private static class BearerAccessTokenBean implements Serializable {
         private String value;
         private long lifetime;

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/TestOidcCredentials.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/TestOidcCredentials.java
@@ -1,0 +1,21 @@
+package org.pac4j.oidc.credentials;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import junit.framework.TestCase;
+
+/**
+ * General test cases for OidcCredentials.
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestOidcCredentials extends TestCase {
+
+    public void testClearOidcCredentials() {
+        OidcCredentials oidcCredentials = new OidcCredentials(new AuthorizationCode());
+        oidcCredentials.setClientName("testClient");
+        oidcCredentials.clear();
+        assertNull(oidcCredentials.getClientName());
+        assertNull(oidcCredentials.getCode());
+    }
+}

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/TestOidcProfile.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/TestOidcProfile.java
@@ -1,0 +1,19 @@
+package org.pac4j.oidc.profile;
+
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import junit.framework.TestCase;
+
+/**
+ * General test cases for OidcProfiles.
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestOidcProfile extends TestCase {
+
+    public void testClearProfile() {
+        OidcProfile profile = new OidcProfile(new BearerAccessToken());
+        profile.clear();
+        assertNull(profile.getAccessToken());
+    }
+}

--- a/pac4j-openid/src/main/java/org/pac4j/openid/credentials/OpenIdCredentials.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/credentials/OpenIdCredentials.java
@@ -31,9 +31,9 @@ public class OpenIdCredentials extends Credentials {
     
     private static final long serialVersionUID = -5934736541999523245L;
     
-    private final ParameterList parameterList;
+    private ParameterList parameterList;
     
-    private final DiscoveryInformation discoveryInformation;
+    private DiscoveryInformation discoveryInformation;
     
     public OpenIdCredentials(final DiscoveryInformation discoveryInformation, final ParameterList parameterList,
                              final String clientName) {
@@ -55,5 +55,12 @@ public class OpenIdCredentials extends Credentials {
     public String toString() {
         return CommonHelper.toString(this.getClass(), "discoveryInformation", this.discoveryInformation,
                                      "parameterList", this.parameterList, "clientName", getClientName());
+    }
+
+    @Override
+    public void clear() {
+        this.parameterList = null;
+        this.discoveryInformation = null;
+        this.setClientName(null);
     }
 }

--- a/pac4j-openid/src/test/java/org/pac4j/openid/credentials/TestOpenIdCredentials.java
+++ b/pac4j-openid/src/test/java/org/pac4j/openid/credentials/TestOpenIdCredentials.java
@@ -1,0 +1,30 @@
+package org.pac4j.openid.credentials;
+
+import junit.framework.TestCase;
+import org.openid4java.discovery.DiscoveryException;
+import org.openid4java.discovery.DiscoveryInformation;
+import org.openid4java.message.ParameterList;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * General test cases for OpenIdCredentials.
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestOpenIdCredentials extends TestCase {
+
+    public void testClearOpenIdCredentials() throws MalformedURLException, DiscoveryException {
+        OpenIdCredentials openIdCredentials = new OpenIdCredentials(
+                new DiscoveryInformation(new URL("http", "test", 8080, "test")),
+                new ParameterList(),
+                "testClient"
+        );
+        openIdCredentials.clear();
+        assertNull(openIdCredentials.getClientName());
+        assertNull(openIdCredentials.getDiscoveryInformation());
+        assertNull(openIdCredentials.getParameterList());
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -33,11 +33,11 @@ public class SAML2Credentials extends Credentials {
 
     private static final long serialVersionUID = 5040516205957826527L;
 
-    private final NameID nameId;
+    private NameID nameId;
 
-    private final List<Attribute> attributes;
+    private List<Attribute> attributes;
     
-    private final Conditions conditions;
+    private Conditions conditions;
 
     public SAML2Credentials(final NameID nameId, final List<Attribute> attributes, final Conditions conditions,
                             final String clientName) {
@@ -64,4 +64,11 @@ public class SAML2Credentials extends Credentials {
         return "SAMLCredential [nameId=" + this.nameId + ", attributes=" + this.attributes + "]";
     }
 
+    @Override
+    public void clear() {
+        this.conditions = null;
+        this.nameId = null;
+        this.attributes = null;
+        this.setClientName(null);
+    }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/TestSAML2Credentials.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/TestSAML2Credentials.java
@@ -1,0 +1,32 @@
+package org.pac4j.saml.credentials;
+
+import java.util.ArrayList;
+
+import junit.framework.TestCase;
+
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.impl.ConditionsBuilder;
+import org.opensaml.saml.saml2.core.impl.NameIDBuilder;
+
+/**
+ * General test cases for SAML2Credentials.
+ *
+ * @author Jacob Severson
+ * @since  1.8.0
+ */
+public class TestSAML2Credentials extends TestCase {
+
+    public void testClearSAML2Credentials() {
+        SAML2Credentials credentials = new SAML2Credentials (
+                new NameIDBuilder().buildObject(),
+                new ArrayList<Attribute>(),
+                new ConditionsBuilder().buildObject(),
+                "testClient"
+        );
+        credentials.clear();
+        assertNull(credentials.getClientName());
+        assertNull(credentials.getAttributes());
+        assertNull(credentials.getConditions());
+        assertNull(credentials.getNameId());
+    }
+}


### PR DESCRIPTION
A Clearable abstraction will be useful for a types such as Credentials and UserProfile that may be
storing sensitive information. This new abstraction will allow implementers to clear out any sensitive
or unneeded information once it is no longer needed after authentication.

* Added the Clearable type

* Added Clearable to Credentials and implemented/test it for all subtypes

* Added Clearable to UserProfile and implemented/tested for OAuth 2