### PR TITLE
PAC4J issue #256

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -90,11 +90,14 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
     private final static Logger logger = LoggerFactory.getLogger(SAML2DefaultResponseValidator.class);
 
+    /** The default maximum authentication lifetime, in seconds. Used for {@link #maximumAuthenticationLifetime} if a meaningless (&lt;=0) value is passed to the constructor. */
+    private static final int DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME = 3600;
+ 
     /* maximum skew in seconds between SP and IDP clocks */
     private int acceptedSkew = 120;
 
     /* maximum lifetime after a successful authentication on an IDP */
-    private int maximumAuthenticationLifetime = 3600;
+    private int maximumAuthenticationLifetime;
 
     private final SAML2SignatureTrustEngineProvider signatureTrustEngineProvider;
 
@@ -114,7 +117,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
                                          final URIComparator uriComparator) {
         this.signatureTrustEngineProvider = engine;
         this.decrypter = decrypter;
-        this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
+        this.maximumAuthenticationLifetime = (maximumAuthenticationLifetime > 0 ? maximumAuthenticationLifetime : DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME);
         this.uriComparator = uriComparator;
     }
 


### PR DESCRIPTION
The maximum authentication lifetime passed to the constructor is only
used if it is positive. Otherwise, the default value is used instead.
This avoids situations where zero is used for the lifetime instead of
the default value because a SAML Client Configuration object has no
explicit value set.