### PR TITLE
Resolving concurrency issue in SAML2IdentityProviderMetadataResolver -Closes #290

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -59,7 +59,6 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
 
     private final String idpMetadataPath;
     private String idpEntityId;
-    private DOMMetadataResolver idpMetadataProvider;
 
     public SAML2IdentityProviderMetadataResolver(final String idpMetadataPath,
                                                  @Nullable final String idpEntityId) {
@@ -69,7 +68,7 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
 
     @Override
     public final MetadataResolver resolve() {
-
+    	DOMMetadataResolver idpMetadataProvider = null;
         try {
             Resource resource = null;
             if (this.idpMetadataPath.startsWith(CommonHelper.RESOURCE_PREFIX)) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -59,7 +59,7 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
 
     private final String idpMetadataPath;
     private String idpEntityId;
-    private DOMMetadataResolver idpMetadataProvider = null;
+    private DOMMetadataResolver idpMetadataProvider;
 
     public SAML2IdentityProviderMetadataResolver(final String idpMetadataPath,
                                                  @Nullable final String idpEntityId) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -59,6 +59,7 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
 
     private final String idpMetadataPath;
     private String idpEntityId;
+    private DOMMetadataResolver idpMetadataProvider = null;
 
     public SAML2IdentityProviderMetadataResolver(final String idpMetadataPath,
                                                  @Nullable final String idpEntityId) {
@@ -67,8 +68,15 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
     }
 
     @Override
-    public final MetadataResolver resolve() {
-    	DOMMetadataResolver idpMetadataProvider = null;
+    public  final MetadataResolver resolve() {
+    	
+    	// No locks are used since saml2client's init does in turn invoke resolve and idpMetadataProvider is set.
+    	// idpMetadataProvider is initialized by Saml2Client::internalInit->MetadataResolver::initIdentityProviderMetadataResolve->resolve
+    	// Usage of locks will adversly impact performance.
+    	if(idpMetadataProvider != null) {
+    		return idpMetadataProvider;
+    	}
+    	
         try {
             Resource resource = null;
             if (this.idpMetadataPath.startsWith(CommonHelper.RESOURCE_PREFIX)) {


### PR DESCRIPTION
Making the class thread safe since concurrent request to retreiving the user profile while processing the saml assertion was resulting in concurrency issues. 

See issue #290 