### PR TITLE
Issue #299 - Failure when verifying Recipient URL with default port in SAML response

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -68,10 +68,14 @@ import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.sso.SAML2ResponseValidator;
 import org.pac4j.saml.storage.SAMLMessageStorage;
+import org.pac4j.saml.util.UriUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.xml.namespace.QName;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -523,23 +527,29 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             return false;
         }
 
-        if (data.getRecipient() == null) {
-            logger.debug("SubjectConfirmationData recipient cannot be null for Bearer confirmation");
+        try {
+            if (data.getRecipient() == null) {
+                logger.debug("SubjectConfirmationData recipient cannot be null for Bearer confirmation");
+                return false;
+            } else {
+                final Endpoint endpoint = context.getSAMLEndpointContext().getEndpoint();
+                if (endpoint == null) {
+                    logger.warn("No endpoint was found in the SAML endpoint context");
+                    return false;
+                }
+    
+                final URI recipientUri = new URI(data.getRecipient());
+                final URI appEndpointUri = new URI(endpoint.getLocation());
+                if (!UriUtils.urisEqualAfterPortNormalization(recipientUri, appEndpointUri)) {
+                    logger.debug("SubjectConfirmationData recipient {} does not match SP assertion consumer URL, found. SP ACS URL from context: {}", recipientUri, appEndpointUri);
+                    return false;
+                }
+            }
+        } catch (URISyntaxException use) {
+            logger.error("Unable to check SubjectConfirmationData recipient, a URI has invalid syntax.", use);
             return false;
-        } else {
-            final Endpoint endpoint = context.getSAMLEndpointContext().getEndpoint();
-            if (endpoint == null) {
-                logger.warn("No endpoint was found in the SAML endpoint context");
-                return false;
-            }
-
-            final String url = endpoint.getLocation();
-            if (!data.getRecipient().equals(url)) {
-                logger.debug("SubjectConfirmationData recipient {} does not match SP assertion consumer URL, found",
-                        data.getRecipient());
-                return false;
-            }
         }
+        
         return true;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/UriUtils.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/UriUtils.java
@@ -1,0 +1,105 @@
+package org.pac4j.saml.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * URI utilities.
+ * 
+ * @author jkacer
+ */
+public class UriUtils {
+
+    /** HTTP scheme. */
+    private static final String SCHEME_HTTP = "http";
+    /** HTTPS scheme. */
+    private static final String SCHEME_HTTPS = "https";
+    
+    /** Default HTTP port. */
+    private static final int DEFAULT_PORT_HTTP = 80;
+    /** Default HTTPS port. */
+    private static final int DEFAULT_PORT_HTTPS = 443;
+    
+    /** SLF4J logger. */
+    private static final Logger logger = LoggerFactory.getLogger(UriUtils.class);
+    
+    
+    // ------------------------------------------------------------------------------------------------------------------------------------
+
+    
+    /**
+     * Private constructor, to prevent instantiation of this utility class.
+     */
+    private UriUtils() {
+        super();
+    }
+
+
+    
+    /**
+     * Compares two URIs for equality, ignoring default port numbers for selected protocols.
+     * 
+     * By default, {@link URI#equals(Object)} doesn't take into account default port numbers, so http://server:80/resource is a different
+     * URI than http://server/resource.
+     * 
+     * And URLs should not be used for comparison, as written here:
+     * http://stackoverflow.com/questions/3771081/proper-way-to-check-for-url-equality
+     * 
+     * @param uri1
+     *            URI 1 to be compared.
+     * @param uri2
+     *            URI 2 to be compared.
+     * 
+     * @return True if both URIs are equal.
+     */
+    public static boolean urisEqualAfterPortNormalization(final URI uri1, final URI uri2) {
+        if ((uri1 == null) && (uri2 == null)) {
+            return true;
+        }
+        if (((uri1 == null) && (uri2 != null)) || ((uri1 != null) && (uri2 == null))) {
+            return false;
+        }
+        
+        try {
+            URI normalizedUri1 = normalizePortNumbersInUri(uri1);
+            URI normalizedUri2 = normalizePortNumbersInUri(uri2);
+            boolean eq = normalizedUri1.equals(normalizedUri2);
+            return eq;
+        } catch (URISyntaxException use) {
+            logger.error("Cannot compare 2 URIs.", use);
+            return false;    
+        }
+    }
+
+    
+    /**
+     * Normalizes a URI. If it contains the default port for the used scheme, the method replaces the port with "default".
+     * 
+     * @param uri
+     *            The URI to normalize.
+     * 
+     * @return A normalized URI.
+     * 
+     * @throws URISyntaxException
+     *             If a URI cannot be created because of wrong syntax.
+     */
+    private static URI normalizePortNumbersInUri(final URI uri) throws URISyntaxException {
+        int port = uri.getPort();
+        final String scheme = uri.getScheme();
+        
+        if (SCHEME_HTTP.equals(scheme) && (port == DEFAULT_PORT_HTTP)) {
+            port = -1;
+        }
+        if (SCHEME_HTTPS.equals(scheme) && (port == DEFAULT_PORT_HTTPS)) {
+            port = -1;
+        }
+        
+        final URI result = new URI(scheme, uri.getUserInfo(), uri.getHost(), port, uri.getPath(), uri.getQuery(), uri.getFragment());
+        return result;
+    }
+    
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/util/UriUtilsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/util/UriUtilsTest.java
@@ -1,0 +1,85 @@
+package org.pac4j.saml.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+
+/**
+ * Unit test for class {@link UriUtils}.
+ * 
+ * @author jkacer
+ */
+public class UriUtilsTest {
+
+    @Test
+    public void twoNullUrisMustEqual() {
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(null, null));
+    }
+    
+    @Test
+    public void nullUriAndNonNullUriMustNotEqual() throws URISyntaxException {
+        final URI uri = new URI("http://somewhere/something");
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri, null));
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(null, uri));
+    }
+    
+    @Test
+    public void uriMustEqualItself() throws URISyntaxException {
+        final URI uri = new URI("http://somewhere/something");
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri, uri));
+    }
+    
+    @Test
+    public void twoSameUrisMustEqual() throws URISyntaxException {
+        final URI uri1 = new URI("http://somewhere/something");
+        final URI uri2 = new URI("http://somewhere/something");
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri1, uri2));
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri2, uri1));
+    }
+    
+    @Test
+    public void twoDifferntUrisMustNotEqual() throws URISyntaxException {
+        final URI uri1 = new URI("http://somewhere/something1");
+        final URI uri2 = new URI("http://somewhere/something2");
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri1, uri2));
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri2, uri1));
+    }
+    
+    @Test
+    public void sameUrisWithImplicitAndExplicitHttpPortMustEqual() throws URISyntaxException {
+        final URI uri1 = new URI("http://somewhere:80/something");
+        final URI uri2 = new URI("http://somewhere/something");
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri1, uri2));
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri2, uri1));
+    }
+
+    @Test
+    public void sameUrisWithImplicitAndExplicitHttpsPortMustEqual() throws URISyntaxException {
+        final URI uri1 = new URI("https://somewhere:443/something");
+        final URI uri2 = new URI("https://somewhere/something");
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri1, uri2));
+        assertTrue(UriUtils.urisEqualAfterPortNormalization(uri2, uri1));
+    }
+    
+    @Test
+    public void differentUrisWithImplicitAndExplicitHttpPortMustNotEqual() throws URISyntaxException {
+        final URI uri1 = new URI("http://somewhere:80/something1");
+        final URI uri2 = new URI("http://somewhere/something2");
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri1, uri2));
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri2, uri1));
+    }
+
+    @Test
+    public void differentUrisWithImplicitAndExplicitHttpsPortMustNotEqual() throws URISyntaxException {
+        final URI uri1 = new URI("https://somewhere:443/something1");
+        final URI uri2 = new URI("https://somewhere/something2");
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri1, uri2));
+        assertFalse(UriUtils.urisEqualAfterPortNormalization(uri2, uri1));
+    }
+    
+}


### PR DESCRIPTION
Changed the way how the SubjectConfirmationData/Recipient is verified -
default port numbers (80 for HTTP and 443 for HTTPS) are now ignored.