### PR TITLE
Remove invalidateSession

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/J2EContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/J2EContext.java
@@ -92,13 +92,6 @@ public class J2EContext implements WebContext {
         return this.request.getSession().getAttribute(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public void invalidateSession() {
-        this.request.getSession().invalidate();
-    }
-
     @Override
     public Object getSessionIdentifier() {
         return this.request.getSession().getId();

--- a/pac4j-core/src/main/java/org/pac4j/core/context/J2ERequestContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/J2ERequestContext.java
@@ -82,13 +82,6 @@ public class J2ERequestContext extends BaseResponseContext {
         return this.request.getSession().getAttribute(name);
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    public void invalidateSession() {
-        this.request.getSession().invalidate();
-    }
-
     @Override
     public Object getSessionIdentifier() {
         return this.request.getSession().getId();

--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
@@ -82,11 +82,6 @@ public interface WebContext {
     Object getSessionAttribute(String name);
 
     /**
-     * Invalidate the current session.
-     */
-    void invalidateSession();
-
-    /**
      * Gets the session id for this context.
      * @return the session identifier
      */

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
@@ -73,11 +73,10 @@ public class ProfileManager<U extends UserProfile> {
     }
 
     /**
-     * Perform a logout by removing the current user profile and invalidating the web session.
+     * Perform a logout by removing the current user profile from the session as well.
      */
     public void logout() {
         remove(true);
-        context.invalidateSession();
     }
 
     /**


### PR DESCRIPTION
After a discussion with @millross, the `invalidateSession` method is overkill as we only need to remove the user profile in session, not the whole session.