### PR TITLE
add support for unencrypted JWT

### DIFF
--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
@@ -60,13 +60,13 @@ public class JwtAuthenticator implements TokenAuthenticator {
         SignedJWT signedJWT = null;
 
         try {
+            // Parse the token
             JWT jwt = JWTParser.parse(token);
 
             if (jwt instanceof SignedJWT) {
                 signedJWT = (SignedJWT) jwt;
             } else if (jwt instanceof EncryptedJWT) {
-                // Parse the JWE string
-                JWEObject jweObject = JWEObject.parse(token);
+                JWEObject jweObject = (JWEObject) jwt;
 
                 // Decrypt with shared key
                 jweObject.decrypt(new DirectDecrypter(this.secret.getBytes("UTF-8")));

--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
@@ -18,8 +18,7 @@ package org.pac4j.jwt.credentials.authenticator;
 import com.nimbusds.jose.JWEObject;
 import com.nimbusds.jose.crypto.DirectDecrypter;
 import com.nimbusds.jose.crypto.MACVerifier;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.*;
 import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.ProfileHelper;
@@ -61,14 +60,22 @@ public class JwtAuthenticator implements TokenAuthenticator {
         SignedJWT signedJWT = null;
 
         try {
-            // Parse the JWE string
-            JWEObject jweObject = JWEObject.parse(token);
+            JWT jwt = JWTParser.parse(token);
 
-            // Decrypt with shared key
-            jweObject.decrypt(new DirectDecrypter(this.secret.getBytes("UTF-8")));
+            if (jwt instanceof SignedJWT) {
+                signedJWT = (SignedJWT) jwt;
+            } else if (jwt instanceof EncryptedJWT) {
+                // Parse the JWE string
+                JWEObject jweObject = JWEObject.parse(token);
 
-            // Extract payload
-            signedJWT = jweObject.getPayload().toSignedJWT();
+                // Decrypt with shared key
+                jweObject.decrypt(new DirectDecrypter(this.secret.getBytes("UTF-8")));
+
+                // Extract payload
+                signedJWT = jweObject.getPayload().toSignedJWT();
+            } else {
+                throw new TechnicalException("unsupported unsecured jwt");
+            }
 
             verified = signedJWT.verify(new MACVerifier(this.secret));
         } catch (final Exception e) {

--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/profile/JwtGenerator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/profile/JwtGenerator.java
@@ -39,10 +39,10 @@ public class JwtGenerator<U extends UserProfile> {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final String secret;
-    private final boolean encrypted;
+    private boolean encrypted = true;
 
     public JwtGenerator(String secret) {
-        this(secret, true);
+        this.secret = secret;
     }
 
     public JwtGenerator(final String secret, final boolean encrypted) {
@@ -77,7 +77,7 @@ public class JwtGenerator<U extends UserProfile> {
             final JWTClaimsSet claims = builder.build();
 
             // signed
-            final SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256, JOSEObjectType.JWT, null, null, null, null, null, null, null, null, null, null, null), claims);
+            final SignedJWT signedJWT = new SignedJWT(new JWSHeader(JWSAlgorithm.HS256), claims);
 
             // Apply the HMAC
             signedJWT.sign(signer);

--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/profile/JwtGenerator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/profile/JwtGenerator.java
@@ -41,10 +41,21 @@ public class JwtGenerator<U extends UserProfile> {
     private final String secret;
     private boolean encrypted = true;
 
+    /**
+     * Initializes the generator that will create JWT tokens that are both signed and encrypted.
+     *
+     * @param secret The secret. Must be at least 256 bits long and not {@code null}
+     */
     public JwtGenerator(String secret) {
         this.secret = secret;
     }
 
+    /**
+     * Initializes the generator that will create JWT tokens that is signed and optionally encrypted.
+     *
+     * @param secret    The secret. Must be at least 256 bits long and not {@code null}
+     * @param encrypted whether the JWT will be encrypted or not
+     */
     public JwtGenerator(final String secret, final boolean encrypted) {
         this.secret = secret;
         this.encrypted = encrypted;

--- a/pac4j-jwt/src/test/java/org/pac4j/jwt/JwtTests.java
+++ b/pac4j-jwt/src/test/java/org/pac4j/jwt/JwtTests.java
@@ -17,6 +17,7 @@ package org.pac4j.jwt;
 
 import org.junit.Test;
 import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.http.credentials.TokenCredentials;
 import org.pac4j.jwt.credentials.authenticator.JwtAuthenticator;
@@ -44,11 +45,20 @@ public class JwtTests {
     @Test
     public void testGenerateAuthenticate() {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<FacebookProfile>(KEY);
-        final FacebookProfile profile = new FacebookProfile();
-        profile.setId(ID);
-        profile.addAttribute(FacebookAttributesDefinition.NAME, NAME);
-        profile.addAttribute(FacebookAttributesDefinition.VERIFIED, VERIFIED);
+        final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
+        assertToken(profile, token);
+    }
+
+    @Test
+    public void testGenerateAuthenticateNotEncrypted() {
+        final JwtGenerator<FacebookProfile> generator = new JwtGenerator<FacebookProfile>(KEY, false);
+        final FacebookProfile profile = createProfile();
+        final String token = generator.generate(profile);
+        assertToken(profile, token);
+    }
+
+    private void assertToken(FacebookProfile profile, String token) {
         final TokenCredentials credentials = new TokenCredentials(token, CLIENT_NAME);
         final JwtAuthenticator authenticator = new JwtAuthenticator(KEY);
         authenticator.validate(credentials);
@@ -60,6 +70,14 @@ public class JwtTests {
         assertEquals(profile.getDisplayName(), fbProfile.getDisplayName());
         assertEquals(profile.getFamilyName(), fbProfile.getFamilyName());
         assertEquals(profile.getVerified(), fbProfile.getVerified());
+    }
+
+    private FacebookProfile createProfile() {
+        final FacebookProfile profile = new FacebookProfile();
+        profile.setId(ID);
+        profile.addAttribute(FacebookAttributesDefinition.NAME, NAME);
+        profile.addAttribute(FacebookAttributesDefinition.VERIFIED, VERIFIED);
+        return profile;
     }
 
     @Test(expected = TechnicalException.class)


### PR DESCRIPTION
From https://github.com/pac4j/pac4j/issues/355, this basically is from the example [here](http://connect2id.com/products/nimbus-jose-jwt/examples/jwt-with-hmac) which does not encrypt the payload but still signs it.

You mention documentation in the issue, can you point to where the existing JWT documentation is, or are you only referring to javadoc?