### PR TITLE
Code Quality Improvement - Serializable classes should have a version id

### DIFF
--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/AnonymousCredentials.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/AnonymousCredentials.java
@@ -22,6 +22,7 @@ package org.pac4j.http.credentials;
  * @since 1.8.1
  */
 public class AnonymousCredentials extends HttpCredentials {
+    private static final long serialVersionUID = 7526472295622776147L;
 
     @Override
     public boolean equals(Object o) {

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/orcid/OrcidProfile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/orcid/OrcidProfile.java
@@ -70,6 +70,7 @@ import java.util.Locale;
  */
 
 public class OrcidProfile extends OAuth20Profile {
+    private static final long serialVersionUID = 7626472295622786149L;	
 
     @Override
     protected AttributesDefinition getAttributesDefinition() {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -96,6 +96,7 @@ public class OidcProfile extends CommonProfile implements Externalizable {
     }
 
     private static class BearerAccessTokenBean implements Serializable {
+        private static final long serialVersionUID = 7726472295622796149L;
         private String value;
         private long lifetime;
         private List<String> scope;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2057 - “Serializable classes should have a version id”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2057.

Please let me know if you have any questions.

Christian