### PR TITLE
Improvements to pac4j-oidc

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/HttpConstants.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/HttpConstants.java
@@ -37,6 +37,10 @@ public interface HttpConstants {
     int TEMP_REDIRECT = 302;
 
     int DEFAULT_PORT = 80;
+    
+    int DEFAULT_CONNECT_TIMEOUT = 15000;
+    
+    int DEFAULT_READ_TIMEOUT = 15000;
 
     String LOCATION_HEADER = "Location";
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.pac4j.core.client.ClientType;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.client.RedirectAction;
+import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.RequiresHttpAction;
 import org.pac4j.core.exception.TechnicalException;
@@ -137,9 +138,9 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
     private int maxClockSkew = DEFAULT_MAX_CLOCK_SKEW;
 
     /* timeouts for token and userinfo requests */
-    private int connectTimeout = 0;
+    private int connectTimeout = HttpConstants.DEFAULT_CONNECT_TIMEOUT;
 
-    private int readTimeout = 0;
+    private int readTimeout = HttpConstants.DEFAULT_READ_TIMEOUT;
 
     public OidcClient() { }
 
@@ -396,8 +397,8 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
         try {
             // Token request
             HTTPRequest tokenHttpRequest = request.toHTTPRequest();
-            tokenHttpRequest.setConnectTimeout(connectTimeout);
-            tokenHttpRequest.setReadTimeout(readTimeout);
+            tokenHttpRequest.setConnectTimeout(getConnectTimeout());
+            tokenHttpRequest.setReadTimeout(getReadTimeout());
             httpResponse = tokenHttpRequest.send();
             logger.debug("Token response: status={}, content={}", httpResponse.getStatusCode(),
                     httpResponse.getContent());
@@ -421,8 +422,8 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
             if (getProviderMetadata().getUserInfoEndpointURI() != null) {
                 UserInfoRequest userInfoRequest = buildUserInfoRequest(accessToken);
                 HTTPRequest userInfoHttpRequest = userInfoRequest.toHTTPRequest();
-                userInfoHttpRequest.setConnectTimeout(connectTimeout);
-                userInfoHttpRequest.setReadTimeout(readTimeout);
+                userInfoHttpRequest.setConnectTimeout(getConnectTimeout());
+                userInfoHttpRequest.setReadTimeout(getReadTimeout());
                 httpResponse = userInfoHttpRequest.send();
                 logger.debug("Token response: status={}, content={}", httpResponse.getStatusCode(),
                         httpResponse.getContent());

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -50,6 +50,7 @@ import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.http.DefaultResourceRetriever;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.http.ResourceRetriever;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -265,7 +266,7 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
 
         try {
             // Download OIDC metadata
-            DefaultResourceRetriever resourceRetriever = new DefaultResourceRetriever(getConnectTimeout(), getReadTimeout());
+            ResourceRetriever resourceRetriever = createResourceRetriever();
             this.oidcProvider = OIDCProviderMetadata.parse(resourceRetriever.retrieveResource(
                     new URL(getDiscoveryURI())).getContent());
             this.redirectURI = new URI(computedCallbackUrl);
@@ -300,6 +301,10 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
         } else if (ClientAuthenticationMethod.CLIENT_SECRET_BASIC.equals(method)) {
             this.clientAuthentication = new ClientSecretBasic(this._clientID, this._secret);
         }
+    }
+
+    protected ResourceRetriever createResourceRetriever() {
+        return new DefaultResourceRetriever(getConnectTimeout(), getReadTimeout());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -206,12 +206,12 @@
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>oauth2-oidc-sdk</artifactId>
-				<version>5.0-alpha15</version>
+				<version>5.1</version>
 			</dependency>
 			<dependency>
 				<groupId>com.nimbusds</groupId>
 				<artifactId>nimbus-jose-jwt</artifactId>
-				<version>4.9</version>
+				<version>4.11</version>
 			</dependency>
 			<dependency>
 				<groupId>org.bouncycastle</groupId>


### PR DESCRIPTION
This pull request contains 3 minor improvements to the OIDC implementation, vital for our implementation:
 - Upgrade to a the latest, stable SDK (5.1).
 - Allow setting custom timeouts for all socket operations. The defaults are quite high and can cause a DoS in case of a failing or slow OIDC provider.
 - Give the possibility to use a different ResourceRetriever. We need this to add caching and to work around a problem in the discovery metadata returned my Azure AD. https://login.microsoftonline.com/common/.well-known/openid-configuration contains invalid characters in the issuer URL. This is an error on the side of Azure AD, but at the moment cannot be easily worked around. In a custom ResourceRetriever, the invalid characters can be escaped.