### PR TITLE
Updated Google2Client with updated scope values

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
@@ -47,9 +47,9 @@ public class Google2Client extends BaseOAuth20Client<Google2Profile> {
         EMAIL_AND_PROFILE
     }
 
-    protected final String PROFILE_SCOPE = "profile";
+    protected final String PROFILE_SCOPE = "https://www.googleapis.com/auth/userinfo.profile";
 
-    protected final String EMAIL_SCOPE = "email";
+    protected final String EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email";
 
     protected Google2Scope scope = Google2Scope.EMAIL_AND_PROFILE;
 


### PR DESCRIPTION
According the Google's documentation listed at https://developers.google.com/identity/protocols/googlescopes, the OAuth scopes are different from what was listed. 

Updated the file needed for this. 

The older values still work, but the newer values are what are documented further.