### PR TITLE
Revert "Updated Google2Client with updated scope values"

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/Google2Client.java
@@ -47,9 +47,9 @@ public class Google2Client extends BaseOAuth20Client<Google2Profile> {
         EMAIL_AND_PROFILE
     }
 
-    protected final String PROFILE_SCOPE = "https://www.googleapis.com/auth/userinfo.profile";
+    protected final String PROFILE_SCOPE = "profile";
 
-    protected final String EMAIL_SCOPE = "https://www.googleapis.com/auth/userinfo.email";
+    protected final String EMAIL_SCOPE = "email";
 
     protected Google2Scope scope = Google2Scope.EMAIL_AND_PROFILE;
 


### PR DESCRIPTION
Reverts pac4j/pac4j#412

I was mistaken in the usage of these values. The old values were actually correct and depreciates the ones I provided. I did not read the documentation correctly. 

 