### PR TITLE
Inject client SAML name into the credentials instead of the default.

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -244,7 +244,12 @@ public class SAML2Client extends BaseClient<SAML2Credentials, SAML2Profile> {
     @Override
     protected SAML2Credentials retrieveCredentials(final WebContext wc) throws RequiresHttpAction {
         final SAML2MessageContext context = this.contextProvider.buildContext(wc);
-        return (SAML2Credentials) this.profileHandler.receive(context);
+        final SAML2Credentials credentials = (SAML2Credentials) this.profileHandler.receive(context);
+        final String clientName = getName();
+        if (CommonHelper.isBlank(clientName)) {
+            credentials.setClientName(clientName);
+        }
+        return credentials;
     }
 
     @Override


### PR DESCRIPTION
When the credentials are built by pac4j, it is not with the "real client name" but with the class name : SAML2.class.getSimpleName(). 

This is boring if you specify the name or if you use 2 SAML clients.

This is not the best solution to resolve my problem but it works.
The best solution is to inject the client name when the credentials are built, into the function : #SAML2DefaultResponseValidator.buildSAML2Credentials().

Bye.