### PR TITLE
Client for Microsoft Azure AD

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/azuread/AzureAdClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/azuread/AzureAdClient.java
@@ -1,0 +1,45 @@
+package org.pac4j.oidc.azuread;
+
+import org.pac4j.oidc.client.OidcClient;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.http.ResourceRetriever;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+
+/**
+ * A specialized {@link OidcClient} for authenticating againt Microsoft Azure AD. Microsoft Azure
+ * AD provides authentication for multiple tenants, or, when the tenant is not known prior to
+ * authentication, the speciall common-tenant. For a specific tenant, the following discovery URI
+ * must be used:
+ * {@code https://login.microsoftonline.com/tenantid/.well-known/openid-configuration} or
+ * {@code https://login.microsoftonline.com/tenantid/v2.0/.well-known/openid-configuration} for the
+ * Azure AD v2.0 preview. Replace {@code tenantid} with the ID of the tenant to authenticate
+ * against. To find this ID, fill in your tenant's domain name. Your tenant ID is the UUID in
+ * {@code authorization_endpoint}.
+ * 
+ * For authentication against an unknown (or dynamic tenant), use {@code common} as ID.
+ * Authentication against the common endpoint results in a ID token with a {@code issuer} different
+ * from the {@code issuer} mentioned in the discovery data. This class uses to special validator
+ * to correctly validate the issuer returned by Azure AD.
+ * 
+ * @author Emond Papegaaij
+ * @since 1.8.3
+ */
+public class AzureAdClient extends OidcClient {
+    public AzureAdClient() {
+    }
+	
+    public AzureAdClient(final String clientId, final String secret, final String discoveryURI) {
+        super(clientId, secret, discoveryURI);
+    }
+	
+	protected IDTokenValidator createRSATokenValidator(JWSAlgorithm jwsAlgorithm, ClientID clientID) throws java.net.MalformedURLException {
+		return new AzureAdIdTokenValidator(super.createRSATokenValidator(jwsAlgorithm, clientID));
+	}
+	
+	@Override
+	protected ResourceRetriever createResourceRetriever() {
+		return new AzureAdResourceRetriever();
+	}
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/azuread/AzureAdIdTokenValidator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/azuread/AzureAdIdTokenValidator.java
@@ -1,0 +1,46 @@
+package org.pac4j.oidc.azuread;
+
+import java.text.ParseException;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+
+/**
+ * Specialized ID token validator cabable of handling the {tenantid} placeholder.
+ * 
+ * @author Emond Papegaaij
+ */
+public class AzureAdIdTokenValidator extends IDTokenValidator {
+    private IDTokenValidator base;
+    private String originalIssuer;
+
+    public AzureAdIdTokenValidator(IDTokenValidator base) {
+        super(base.getExpectedIssuer(), base.getClientID());
+        this.base = base;
+        this.originalIssuer = base.getExpectedIssuer().getValue();
+    }
+
+    @Override
+    public IDTokenClaimsSet validate(JWT idToken, Nonce expectedNonce) throws BadJOSEException, JOSEException {
+        try {
+            if (originalIssuer.contains("%7Btenantid%7D")) {
+                Object tid = idToken.getJWTClaimsSet().getClaim("tid");
+                if (tid == null) {
+                    throw new BadJWTException("ID token does not contain the 'tid' claim");
+                }
+                base = new IDTokenValidator(new Issuer(originalIssuer.replace("%7Btenantid%7D", tid.toString())),
+                        base.getClientID(), base.getJWSKeySelector(), base.getJWEKeySelector());
+                base.setMaxClockSkew(getMaxClockSkew());
+            }
+        } catch (ParseException e) {
+            throw new BadJWTException(e.getMessage(), e);
+        }
+        return base.validate(idToken, expectedNonce);
+    }
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/azuread/AzureAdResourceRetriever.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/azuread/AzureAdResourceRetriever.java
@@ -1,0 +1,21 @@
+package org.pac4j.oidc.azuread;
+
+import java.io.IOException;
+import java.net.URL;
+
+import com.nimbusds.oauth2.sdk.http.DefaultResourceRetriever;
+import com.nimbusds.oauth2.sdk.http.Resource;
+import com.nimbusds.oauth2.sdk.http.ResourceRetriever;
+
+/**
+ * Specialized ResourceRetriever which escapes a possibly invalid issuer URI.
+ * 
+ * @author Emond Papegaaij
+ */
+public class AzureAdResourceRetriever extends DefaultResourceRetriever implements ResourceRetriever {
+    @Override
+	public Resource retrieveResource(URL url) throws IOException {
+        Resource ret = super.retrieveResource(url);
+        return new Resource(ret.getContent().replace("{tenantid}", "%7Btenantid%7D"), ret.getContentType());
+    }
+}


### PR DESCRIPTION
This PR contains the specialized OidcClient for Microsoft Azure AD, as requested in #415.

The main problem is the difference in issuer between what's returned by the discovery and what's in the ID token. Unfortunately, IdTokenValidator does not allow changing issuer validation, so I had to wrap the entire class.