### PR TITLE
Remove incompatible xmltooling dependency

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -163,21 +163,6 @@
             <version>${spring.extensions.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>xmltooling</artifactId>
-            <version>1.4.4</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>joda-time</artifactId>
-                    <groupId>joda-time</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>xmlsec</artifactId>
-                    <groupId>org.apache.santuario</groupId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -20,6 +20,7 @@ import net.shibboleth.utilities.java.support.component.ComponentInitializationEx
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
 import net.shibboleth.utilities.java.support.resource.Resource;
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
@@ -27,7 +28,6 @@ import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
 import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.xml.util.XMLHelper;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.exceptions.SAMLException;
@@ -167,7 +167,7 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
     public String getMetadata() {
         if (getEntityDescriptorElement() != null
                 && getEntityDescriptorElement().getDOM() != null) {
-            return XMLHelper.nodeToString(getEntityDescriptorElement().getDOM());
+            return SerializeSupport.nodeToString(getEntityDescriptorElement().getDOM());
         }
         throw new TechnicalException("Metadata cannot be retrieved because entity descriptor is null");
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
@@ -16,6 +16,7 @@
 
 package org.pac4j.saml.metadata;
 
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
 import org.apache.commons.lang.RandomStringUtils;
 import org.joda.time.DateTime;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
@@ -35,7 +36,6 @@ import org.opensaml.saml.saml2.metadata.NameIDFormat;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.opensaml.security.credential.UsageType;
-import org.opensaml.xml.util.XMLHelper;
 import org.opensaml.xmlsec.signature.KeyInfo;
 import org.pac4j.saml.crypto.CredentialProvider;
 import org.pac4j.saml.util.Configuration;
@@ -93,7 +93,7 @@ public class SAML2MetadataGenerator implements SAMLMetadataGenerator {
     public final String getMetadata() throws Exception {
         final EntityDescriptor md = buildEntityDescriptor();
         final Element entityDescriptorElement = this.marshallerFactory.getMarshaller(md).marshall(md);
-        return XMLHelper.nodeToString(entityDescriptorElement);
+        return SerializeSupport.nodeToString(entityDescriptorElement);
     }
 
     @Override


### PR DESCRIPTION
xmltooling is a part of OpenSAML v2, and is incompatible with OpenSAML v3 (see: https://issues.shibboleth.net/jira/browse/OSJ-152). It appears that it worked fine for most users in the demo projects, because the classloader order happened to place xmltooling after the other opensaml libraries (such as opensaml-core), causing the correct default-config.xml to be loaded, instead of the xmltooling version of the same file.

The xmltooling library is only used in the pac4j-saml module for a convenience method, which is also implemented in the OpenSAML v3 java-tooling library. This change replaces the call with that newer method, and also removes the xmltooling dependency from the pom.

This change resolves #444.