### PR TITLE
Remove or reduce commons-codec dependency

### DIFF
--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/BasicAuthExtractor.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/BasicAuthExtractor.java
@@ -15,7 +15,6 @@
  */
 package org.pac4j.http.credentials.extractor;
 
-import org.apache.commons.codec.binary.Base64;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.CredentialsException;
@@ -23,6 +22,7 @@ import org.pac4j.http.credentials.TokenCredentials;
 import org.pac4j.http.credentials.UsernamePasswordCredentials;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 
 /**
  * To extract basic auth header.
@@ -52,7 +52,7 @@ public class BasicAuthExtractor implements Extractor<UsernamePasswordCredentials
             return null;
         }
 
-        final byte[] decoded = Base64.decodeBase64(credentials.getToken());
+        final byte[] decoded = Base64.getDecoder().decode(credentials.getToken());
 
         String token;
         try {

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/CookieClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/CookieClientTests.java
@@ -16,7 +16,6 @@
 
 package org.pac4j.http.client.direct;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.MockWebContext;
@@ -27,6 +26,8 @@ import org.pac4j.core.util.TestsHelper;
 import org.pac4j.http.credentials.TokenCredentials;
 import org.pac4j.http.credentials.authenticator.test.SimpleTestTokenAuthenticator;
 import org.pac4j.http.profile.creator.AuthenticatorProfileCreator;
+
+import java.util.Base64;
 
 import static org.junit.Assert.assertEquals;
 
@@ -72,7 +73,7 @@ public class CookieClientTests implements TestsConstants {
         client.setCookieName(USERNAME);
         final MockWebContext context = MockWebContext.create();
 
-        final Cookie c = new Cookie(USERNAME, Base64.encodeBase64String(getClass().getName().getBytes()));
+        final Cookie c = new Cookie(USERNAME, Base64.getEncoder().encodeToString(getClass().getName().getBytes()));
         context.getRequestCookies().add(c);
         final TokenCredentials credentials = client.getCredentials(context);
         final UserProfile profile = client.getUserProfile(credentials, context);

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBasicAuthClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBasicAuthClientTests.java
@@ -14,7 +14,6 @@
    limitations under the License.
  */package org.pac4j.http.client.direct;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.MockWebContext;
@@ -24,6 +23,8 @@ import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
 import org.pac4j.http.credentials.UsernamePasswordCredentials;
 import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator;
+
+import java.util.Base64;
 
 import static org.junit.Assert.*;
 
@@ -58,7 +59,8 @@ public final class DirectBasicAuthClientTests implements TestsConstants {
         final DirectBasicAuthClient client = new DirectBasicAuthClient(new SimpleTestUsernamePasswordAuthenticator());
         final MockWebContext context = MockWebContext.create();
         final String header = USERNAME + ":" + USERNAME;
-        context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER, "Basic " + Base64.encodeBase64String(header.getBytes()));
+        context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
+                "Basic " + Base64.getEncoder().encodeToString(header.getBytes()));
         final UsernamePasswordCredentials credentials = client.getCredentials(context);
         final UserProfile profile = client.getUserProfile(credentials, context);
         assertEquals(USERNAME, profile.getId());

--- a/pac4j-http/src/test/java/org/pac4j/http/client/indirect/TestIndirectBasicAuthClient.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/indirect/TestIndirectBasicAuthClient.java
@@ -80,6 +80,54 @@ public final class TestIndirectBasicAuthClient implements TestsConstants {
     public void testGetCredentialsMissingHeader() {
         final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
         final MockWebContext context = MockWebContext.create();
+        verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
+    }
+
+    @Test
+    public void testGetCredentialsNotABasicHeader() {
+        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
+        final MockWebContext context = getContextWithAuthorizationHeader("fakeHeader");
+        verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
+    }
+
+    @Test
+    public void testGetCredentialsBadFormatHeader() throws RequiresHttpAction {
+        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
+        final MockWebContext context = getContextWithAuthorizationHeader("Basic fakeHeader");
+        verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
+    }
+
+    @Test
+    public void testGetCredentialsMissingSemiColon() throws RequiresHttpAction {
+        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
+        final MockWebContext context = getContextWithAuthorizationHeader(
+                "Basic " + Base64.encodeBase64String("fake".getBytes()));
+        verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
+    }
+
+    @Test
+    public void testGetCredentialsBadCredentials() {
+        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
+        final String header = USERNAME + ":" + PASSWORD;
+        final MockWebContext context = getContextWithAuthorizationHeader("Basic "
+                + Base64.encodeBase64String(header.getBytes()));
+        verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
+    }
+
+    @Test
+    public void testGetCredentialsGoodCredentials() throws RequiresHttpAction {
+        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
+        final String header = USERNAME + ":" + USERNAME;
+        final UsernamePasswordCredentials credentials = basicAuthClient.getCredentials(
+                getContextWithAuthorizationHeader(
+                        "Basic " + Base64.encodeBase64String(header.getBytes())));
+        assertEquals(USERNAME, credentials.getUsername());
+        assertEquals(USERNAME, credentials.getPassword());
+    }
+
+    private void verifyGetCredentialsFailsWithAuthenticationRequired(
+            IndirectBasicAuthClient basicAuthClient,
+            MockWebContext context) {
         try {
             basicAuthClient.getCredentials(context);
             fail("should throw RequiresHttpAction");
@@ -91,78 +139,8 @@ public final class TestIndirectBasicAuthClient implements TestsConstants {
         }
     }
 
-    @Test
-    public void testGetCredentialsNotABasicHeader() {
-        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
-        final MockWebContext context = MockWebContext.create();
-        try {
-            basicAuthClient.getCredentials(context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER, "fakeHeader"));
-            fail("should throw RequiresHttpAction");
-        } catch (final RequiresHttpAction e) {
-            assertEquals(401, context.getResponseStatus());
-            assertEquals("Basic realm=\"authentication required\"",
-                    context.getResponseHeaders().get(HttpConstants.AUTHENTICATE_HEADER));
-            assertEquals("Requires authentication", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testGetCredentialsBadFormatHeader() throws RequiresHttpAction {
-        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
-        final MockWebContext context = MockWebContext.create();
-        try {
-            basicAuthClient.getCredentials(context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
-                    "Basic fakeHeader"));
-            fail("should throw RequiresHttpAction");
-        } catch (final RequiresHttpAction e) {
-            assertEquals(401, context.getResponseStatus());
-            assertEquals("Basic realm=\"authentication required\"",
-                    context.getResponseHeaders().get(HttpConstants.AUTHENTICATE_HEADER));
-            assertEquals("Requires authentication", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testGetCredentialsMissingSemiColon() throws RequiresHttpAction {
-        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
-        final MockWebContext context = MockWebContext.create();
-        try {
-            basicAuthClient.getCredentials(context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
-                    "Basic " + Base64.encodeBase64String("fake".getBytes())));
-            fail("should throw RequiresHttpAction");
-        } catch (final RequiresHttpAction e) {
-            assertEquals(401, context.getResponseStatus());
-            assertEquals("Basic realm=\"authentication required\"",
-                    context.getResponseHeaders().get(HttpConstants.AUTHENTICATE_HEADER));
-            assertEquals("Requires authentication", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testGetCredentialsBadCredentials() {
-        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
-        final String header = USERNAME + ":" + PASSWORD;
-        final MockWebContext context = MockWebContext.create();
-        try {
-            basicAuthClient.getCredentials(context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER, "Basic "
-                    + Base64.encodeBase64String(header.getBytes())));
-            fail("should throw RequiresHttpAction");
-        } catch (final RequiresHttpAction e) {
-            assertEquals(401, context.getResponseStatus());
-            assertEquals("Basic realm=\"authentication required\"",
-                    context.getResponseHeaders().get(HttpConstants.AUTHENTICATE_HEADER));
-            assertEquals("Requires authentication", e.getMessage());
-        }
-    }
-
-    @Test
-    public void testGetCredentialsGoodCredentials() throws RequiresHttpAction {
-        final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
-        final String header = USERNAME + ":" + USERNAME;
-        final UsernamePasswordCredentials credentials = basicAuthClient.getCredentials(MockWebContext.create()
-                .addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
-                        "Basic " + Base64.encodeBase64String(header.getBytes())));
-        assertEquals(USERNAME, credentials.getUsername());
-        assertEquals(USERNAME, credentials.getPassword());
+    private MockWebContext getContextWithAuthorizationHeader(String value) {
+        MockWebContext context = MockWebContext.create();
+        return context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER, value);
     }
 }

--- a/pac4j-http/src/test/java/org/pac4j/http/client/indirect/TestIndirectBasicAuthClient.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/indirect/TestIndirectBasicAuthClient.java
@@ -15,7 +15,6 @@
  */
 package org.pac4j.http.client.indirect;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.MockWebContext;
@@ -24,6 +23,8 @@ import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
 import org.pac4j.http.credentials.authenticator.test.SimpleTestUsernamePasswordAuthenticator;
 import org.pac4j.http.credentials.UsernamePasswordCredentials;
+
+import java.util.Base64;
 
 import static org.junit.Assert.*;
 
@@ -101,7 +102,7 @@ public final class TestIndirectBasicAuthClient implements TestsConstants {
     public void testGetCredentialsMissingSemiColon() throws RequiresHttpAction {
         final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
         final MockWebContext context = getContextWithAuthorizationHeader(
-                "Basic " + Base64.encodeBase64String("fake".getBytes()));
+                "Basic " + Base64.getEncoder().encodeToString("fake".getBytes()));
         verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
     }
 
@@ -110,7 +111,7 @@ public final class TestIndirectBasicAuthClient implements TestsConstants {
         final IndirectBasicAuthClient basicAuthClient = getBasicAuthClient();
         final String header = USERNAME + ":" + PASSWORD;
         final MockWebContext context = getContextWithAuthorizationHeader("Basic "
-                + Base64.encodeBase64String(header.getBytes()));
+                + Base64.getEncoder().encodeToString(header.getBytes()));
         verifyGetCredentialsFailsWithAuthenticationRequired(basicAuthClient, context);
     }
 
@@ -120,7 +121,7 @@ public final class TestIndirectBasicAuthClient implements TestsConstants {
         final String header = USERNAME + ":" + USERNAME;
         final UsernamePasswordCredentials credentials = basicAuthClient.getCredentials(
                 getContextWithAuthorizationHeader(
-                        "Basic " + Base64.encodeBase64String(header.getBytes())));
+                        "Basic " + Base64.getEncoder().encodeToString(header.getBytes())));
         assertEquals(USERNAME, credentials.getUsername());
         assertEquals(USERNAME, credentials.getPassword());
     }

--- a/pac4j-mongo/pom.xml
+++ b/pac4j-mongo/pom.xml
@@ -56,11 +56,6 @@
 			<groupId>de.flapdoodle.embed</groupId>
 			<artifactId>de.flapdoodle.embed.mongo</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-			<scope>test</scope>
-		</dependency>
 		<!-- for testing -->
 	</dependencies>
 

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -127,10 +127,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>${joda-time.version}</version>

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientIT.java
@@ -23,7 +23,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlInput;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.output.FileWriterWithEncoding;
 import org.apache.commons.lang.NotImplementedException;
 import org.junit.Test;
@@ -42,6 +41,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.net.URL;
+import java.util.Base64;
 
 public final class PostSAML2ClientIT extends SAML2ClientIT implements TestsConstants {
 
@@ -79,7 +79,7 @@ public final class PostSAML2ClientIT extends SAML2ClientIT implements TestsConst
         }
         final HtmlForm form = page.getForms().get(0);
         final HtmlInput samlRequest = form.getInputByName("SAMLRequest");
-        return new String(Base64.decodeBase64(samlRequest.getValueAttribute()));
+        return new String(Base64.getDecoder().decode(samlRequest.getValueAttribute()));
     }
 
     @Test

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientIT.java
@@ -18,7 +18,6 @@ package org.pac4j.saml.client;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
@@ -36,6 +35,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.util.Base64;
 import java.util.List;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
@@ -134,7 +134,7 @@ public final class RedirectSAML2ClientIT extends SAML2ClientIT implements TestsC
     private String getInflatedAuthnRequest(final String location) throws Exception {
         final List<NameValuePair> pairs = URLEncodedUtils.parse(URI.create(location), "UTF-8");
         final Inflater inflater = new Inflater(true);
-        final byte[] decodedRequest = Base64.decodeBase64(pairs.get(0).getValue());
+        final byte[] decodedRequest = Base64.getDecoder().decode(pairs.get(0).getValue());
         final ByteArrayInputStream is = new ByteArrayInputStream(decodedRequest);
         final InflaterInputStream inputStream = new InflaterInputStream(is, inflater);
         final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));

--- a/pac4j-test-cas/src/test/java/org/pac4j/test/cas/client/rest/CasClientRestProtocolIT.java
+++ b/pac4j-test-cas/src/test/java/org/pac4j/test/cas/client/rest/CasClientRestProtocolIT.java
@@ -1,6 +1,5 @@
 package org.pac4j.test.cas.client.rest;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.credentials.authenticator.CasRestAuthenticator;
@@ -12,6 +11,8 @@ import org.pac4j.cas.profile.CasProfile;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.http.credentials.UsernamePasswordCredentials;
 import org.pac4j.test.cas.client.CasClientIT;
+
+import java.util.Base64;
 
 /**
  * The {@link CasClientRestProtocolIT} is responsible for...
@@ -53,7 +54,7 @@ public class CasClientRestProtocolIT extends CasClientIT {
 
         final MockWebContext context = MockWebContext.create();
         final String token = creds.getUsername() + ":" + creds.getPassword();
-        context.addRequestHeader("cas-rest", Base64.encodeBase64String(token.getBytes()));
+        context.addRequestHeader("cas-rest", Base64.getEncoder().encodeToString(token.getBytes()));
 
         final HttpTGTProfile profile = client.requestTicketGrantingTicket(context);
         final CasCredentials casCreds = client.requestServiceTicket("http://www.pac4j.org/", profile);


### PR DESCRIPTION
## Background

While looking into integrating pac4j-saml into our product, my team found conflicts between pac4j-saml's dependencies and existing product dependencies with different versions. One of these was commons-codec, and so I looked into how widely-used it was in pac4j. We were able to exclude the transitive dependency from our product to work around this, but I thought others might appreciate reduced dependencies.

## Details
I found a few classes (mostly tests) were using the Apache commons-codec library to encode and decode Base64 text. I recently found out that Java 8 introduced a [Base64 utility class](http://docs.oracle.com/javase/8/docs/api/java/util/Base64.html).  I found replacing the commons-codec-provided Base64 encoder/decoder with the JRE-provided encoder/decoder to be straightforward and I think it's a relatively easy way to minimize dependencies.

The commons-codec library is still used by pac4j-http and pac4j-oauth for sha512 and hexadecimal encoding, so this PR does not entirely remove commons-codec as a dependency. It does remove it as a dependency for pac4j-mongo; that did not require any code changes, so either the code that depended on it was previously removed or I don't understand why it was included. If it is still required, I can update this PR to reintroduce the dependency with an explanatory comment.

Along the way, I found that one of the test classes that used Base64 encoding had some repeated code, so I refactored it in a way that I found to be more readable. Does that look useful to you? Please let me know if you'd prefer that change separated into its own PR or removed entirely.

## Testing
I ran `mvn test` from the root project and all the tests still pass.