### PR TITLE
Handle null BearerAccessToken/BearerAccessTokenBean in OidcProfile wh…

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -73,7 +73,10 @@ public class OidcProfile extends CommonProfile implements Externalizable {
     @Override
     public void writeExternal(final ObjectOutput out) throws IOException {
         super.writeExternal(out);
-        final BearerAccessTokenBean bean = BearerAccessTokenBean.toBean(getAccessToken());
+        BearerAccessTokenBean bean = null; 
+        if (getAccessToken() != null) {
+            bean = BearerAccessTokenBean.toBean(getAccessToken());
+        }
         out.writeObject(bean);
         out.writeObject(getIdTokenString());
     }
@@ -82,7 +85,9 @@ public class OidcProfile extends CommonProfile implements Externalizable {
     public void readExternal(final ObjectInput in) throws IOException, ClassNotFoundException {
         super.readExternal(in);
         final BearerAccessTokenBean bean = (BearerAccessTokenBean) in.readObject();
-        setAccessToken(BearerAccessTokenBean.fromBean(bean));
+        if (bean != null) {
+            setAccessToken(BearerAccessTokenBean.fromBean(bean));
+        }
         setIdTokenString((String) in.readObject());
     }
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java
@@ -18,11 +18,13 @@ package org.pac4j.oidc.profile;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.apache.commons.lang3.SerializationUtils;
+import org.junit.Before;
 import org.junit.Test;
-import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.TestsConstants;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * General test cases for {@link OidcProfile}.
@@ -33,6 +35,16 @@ import static org.junit.Assert.*;
  */
 public final class OidcProfileTests implements TestsConstants {
 
+    private static final String ID_TOKEN = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbX"
+            + "BsZS5jb20iLCJzdWIiOiJtYWlsdG86cGVyc29uQGV4YW1wbGUuY29tIiwibmJmIjoxNDQwMTEyMDE1LCJleHAiOjE0NDAxMTU2"
+            + "MTUsImlhdCI6MTQ0MDExMjAxNSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0.";
+    private BearerAccessToken populatedAccessToken;
+
+    @Before
+    public void before() {
+        populatedAccessToken = new BearerAccessToken(32, 128, Scope.parse("oidc email"));
+    }
+    
     @Test
     public void testClearProfile() {
         OidcProfile profile = new OidcProfile();
@@ -45,22 +57,62 @@ public final class OidcProfileTests implements TestsConstants {
 
     @Test
     public void testReadWriteObject() throws Exception {
-
-        String idToken = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbXBsZS5jb20iLCJzdWIiOiJtYWlsdG86cGVyc29uQGV4YW1wbGUuY29tIiwibmJmIjoxNDQwMTEyMDE1LCJleHAiOjE0NDAxMTU2MTUsImlhdCI6MTQ0MDExMjAxNSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0.";
-        BearerAccessToken token = new BearerAccessToken(32, 128, Scope.parse("oidc email"));
         OidcProfile profile = new OidcProfile();
-        profile.setAccessToken(token);
-        profile.setIdTokenString(idToken);
+        profile.setAccessToken(populatedAccessToken);
+        profile.setIdTokenString(ID_TOKEN);
 
         byte[] result = SerializationUtils.serialize(profile);
 
         profile = (OidcProfile) SerializationUtils.deserialize(result);
-        CommonHelper.assertNotNull("accessToken", profile.getAccessToken());
-        CommonHelper.assertNotNull("value", profile.getAccessToken().getValue());
-        CommonHelper.assertTrue(profile.getAccessToken().getLifetime() == token.getLifetime(),
-                "lifetimes do not match");
-        CommonHelper.assertTrue(profile.getAccessToken().getScope().equals(token.getScope()),
-                "scopes do not match");
-        CommonHelper.assertTrue(idToken.equals(profile.getIdTokenString()), "id tokens do not match");
+        assertNotNull("accessToken", profile.getAccessToken());
+        assertNotNull("value", profile.getAccessToken().getValue());
+        assertEquals(profile.getAccessToken().getLifetime(), populatedAccessToken.getLifetime());
+        assertEquals(profile.getAccessToken().getScope(), populatedAccessToken.getScope());
+        assertEquals(profile.getIdTokenString(), ID_TOKEN);
+    }
+    
+    /**
+     * Test that serialization and deserialization of the OidcProfile work when the BearerAccessToken is null.
+     */
+    @Test
+    public void testReadWriteObjectNullAccessToken() {
+        OidcProfile profile = new OidcProfile();
+        profile.setIdTokenString(ID_TOKEN);
+        byte[] result = SerializationUtils.serialize(profile);
+        profile = (OidcProfile) SerializationUtils.deserialize(result);
+        assertNull(profile.getAccessToken());
+        assertEquals(profile.getIdTokenString(), ID_TOKEN);
+    }
+    
+    /**
+     * Test that serialization and deserialization of the OidcProfile work when the Id token is null.
+     */
+    @Test
+    public void testReadWriteObjectNullIdToken() {
+        OidcProfile profile = new OidcProfile();
+        profile.setAccessToken(populatedAccessToken);
+        byte[] result = SerializationUtils.serialize(profile);
+        profile = (OidcProfile) SerializationUtils.deserialize(result);
+        assertNotNull("accessToken", profile.getAccessToken());
+        assertNotNull("value", profile.getAccessToken().getValue());
+        assertEquals(profile.getAccessToken().getLifetime(), populatedAccessToken.getLifetime());
+        assertEquals(profile.getAccessToken().getScope(), populatedAccessToken.getScope());
+        assertNull(profile.getIdTokenString());
+    }
+    
+    /**
+     * Test that serialization and deserialization of the OidcProfile work when both tokens are null, after a call
+     * to clearSensitiveData().
+     */
+    @Test
+    public void testReadWriteObjectNullTokens() {
+        OidcProfile profile = new OidcProfile();
+        profile.setAccessToken(populatedAccessToken);
+        profile.clearSensitiveData();
+
+        byte[] result = SerializationUtils.serialize(profile);
+        profile = (OidcProfile) SerializationUtils.deserialize(result);
+        assertNull(profile.getAccessToken());
+        assertNull(profile.getIdTokenString());
     }
 }


### PR DESCRIPTION
…en doing serialization and deserialization. fixes #458

The BearerAccessToken is more often than not null due to spring security’s clearing of credentials from the authentication.