### PR TITLE
Issue: 480 applied to branch 1.8.x: 

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/ContextHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/ContextHelper.java
@@ -75,4 +75,24 @@ public final class ContextHelper {
     public static boolean isHttpsOrSecure(final WebContext context) {
         return "HTTPS".equalsIgnoreCase(context.getScheme()) || context.isSecure();
     }
+
+    /**
+     * Whether the request is HTTP.
+     *
+     * @param context the current web context
+     * @return whether the request is HTTP
+     */
+    public static boolean isHttp(final WebContext context) {
+        return "HTTP".equalsIgnoreCase(context.getScheme());
+    }
+
+    /**
+     * Whether the request is HTTPS.
+     *
+     * @param context the current web context
+     * @return whether the request is HTTPS
+     */
+    public static boolean isHttps(final WebContext context) {
+        return "HTTPS".equalsIgnoreCase(context.getScheme());
+    }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/context/HttpConstants.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/HttpConstants.java
@@ -38,6 +38,8 @@ public interface HttpConstants {
 
     int DEFAULT_PORT = 80;
     
+    int DEFAULT_HTTPS_PORT = 443;
+
     int DEFAULT_CONNECT_TIMEOUT = 500;
     
     int DEFAULT_READ_TIMEOUT = 5000;

--- a/pac4j-core/src/main/java/org/pac4j/core/http/RelativeCallbackUrlResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/RelativeCallbackUrlResolver.java
@@ -15,6 +15,7 @@
  */
 package org.pac4j.core.http;
 
+import org.pac4j.core.context.ContextHelper;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 
@@ -33,7 +34,8 @@ public class RelativeCallbackUrlResolver implements CallbackUrlResolver {
 
             sb.append(context.getScheme()).append("://").append(context.getServerName());
 
-            if (context.getServerPort() != HttpConstants.DEFAULT_PORT) {
+            if((ContextHelper.isHttp(context) && context.getServerPort() != HttpConstants.DEFAULT_PORT) || 
+              (ContextHelper.isHttps(context) && context.getServerPort() != HttpConstants.DEFAULT_HTTPS_PORT)) {
                 sb.append(":").append(context.getServerPort());
             }
 

--- a/pac4j-core/src/test/java/org/pac4j/core/http/RelativeCallbackUrlResolverTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/http/RelativeCallbackUrlResolverTests.java
@@ -65,9 +65,24 @@ public final class RelativeCallbackUrlResolverTests {
     public void testCompute_whenRequestIsSecure() {
         final MockWebContext context = MockWebContext.create();
         context.setScheme("https");
+        context.setSecure(true);
+        context.setServerPort(443);
 
         final String result = resolver.compute("/cas/login", context);
 
         assertEquals("https://localhost/cas/login", result);
+    }
+    
+    @Test
+    public void testCompute_whenServerIsNotUsingDefaultHttpsPort() {
+        final MockWebContext context = MockWebContext.create();
+        context.setServerName("pac4j.com");
+        context.setScheme("https");
+        context.setSecure(true);
+        context.setServerPort(8181);
+
+        final String result = resolver.compute("/cas/login", context);
+
+        assertEquals("https://pac4j.com:8181/cas/login", result);
     }
 }


### PR DESCRIPTION
#480 Only include the port in a URL when the port in use is not the default for the selected scheme.