### PR TITLE
HTTP Digest Direct Authenticator

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/HttpConstants.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/HttpConstants.java
@@ -48,6 +48,8 @@ public interface HttpConstants {
 
     String BASIC_HEADER_PREFIX = "Basic ";
 
+    String DIGEST_HEADER_PREFIX = "Digest ";
+
     String AUTHENTICATE_HEADER = "WWW-Authenticate";
 
     String CONTENT_TYPE_HEADER = "Content-Type";

--- a/pac4j-core/src/main/java/org/pac4j/core/exception/RequiresHttpAction.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/exception/RequiresHttpAction.java
@@ -90,6 +90,22 @@ public class RequiresHttpAction extends Exception {
         context.setResponseStatus(HttpConstants.UNAUTHORIZED);
         return new RequiresHttpAction(message, HttpConstants.UNAUTHORIZED);
     }
+
+    /**
+     * Build a digest auth popup credentials.
+     *
+     * @param message message
+     * @param context context
+     * @param realmName realm name
+     * @return a digest auth popup credentials
+     */
+    public static RequiresHttpAction unauthorizedDigest(final String message, final WebContext context, final String realmName, final String qop, final String nonce) {
+        if (CommonHelper.isNotBlank(realmName)) {
+            context.setResponseHeader(HttpConstants.AUTHENTICATE_HEADER, "Digest realm=\"" + realmName + "\", qop=\"" + qop + "\", nonce=\"" + nonce + "\"");
+        }
+        context.setResponseStatus(HttpConstants.UNAUTHORIZED);
+        return new RequiresHttpAction(message, HttpConstants.UNAUTHORIZED);
+    }
     
     /**
      * Build a forbidden response.

--- a/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectDigestAuthClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectDigestAuthClient.java
@@ -1,0 +1,77 @@
+package org.pac4j.http.client.direct;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.exception.RequiresHttpAction;
+import org.pac4j.http.credentials.CredentialUtil;
+import org.pac4j.http.credentials.DigestCredentials;
+import org.pac4j.http.credentials.authenticator.DigestAuthenticator;
+import org.pac4j.http.credentials.authenticator.UsernamePasswordAuthenticator;
+import org.pac4j.http.credentials.extractor.BasicAuthExtractor;
+import org.pac4j.http.credentials.extractor.DigestAuthExtractor;
+import org.pac4j.http.profile.creator.ProfileCreator;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Random;
+
+/**
+ * <p>This class is the client to authenticate users directly through HTTP digest auth.</p>
+ * <p>It returns a {@link org.pac4j.http.profile.HttpProfile}.</p>
+ *
+ * @see org.pac4j.http.profile.HttpProfile
+ * @author Mircea Carasel
+ */
+public class DirectDigestAuthClient extends DirectHttpClient<DigestCredentials> {
+    private String realm = "pac4jRealm";
+
+    public DirectDigestAuthClient() {
+    }
+
+    public DirectDigestAuthClient(final DigestAuthenticator digestAuthenticator) {
+        setAuthenticator(digestAuthenticator);
+    }
+
+    public DirectDigestAuthClient(final DigestAuthenticator digestAuthenticator,
+                                 final ProfileCreator profileCreator) {
+        setAuthenticator(digestAuthenticator);
+        setProfileCreator(profileCreator);
+    }
+
+    @Override
+    public DigestCredentials getCredentials(WebContext context) throws RequiresHttpAction {
+        DigestCredentials credentials = super.getCredentials(context);
+        if (credentials == null) {
+            String nonce = calculateNonce();
+            /* Per RFC 2617
+            If a server receives a request for an access-protected object, and an
+            acceptable Authorization header is not sent, the server responds with
+            a "401 Unauthorized" status code, and a WWW-Authenticate header
+             */
+            RequiresHttpAction.unauthorizedDigest("Digest required", context, realm, "auth", nonce);
+        }
+        return credentials;
+    }
+
+    @Override
+    protected void internalInit(final WebContext context) {
+        extractor = new DigestAuthExtractor(getName());
+        super.internalInit(context);
+    }
+
+    public void setRealm(String realm) {
+        this.realm = realm;
+    }
+
+    /**
+     * A server-specified data string which should be uniquely generated each time a 401 response is made (RFC 2617)
+     */
+    private String calculateNonce() {
+        Date d = new Date();
+        SimpleDateFormat f = new SimpleDateFormat("yyyy:MM:dd:hh:mm:ss");
+        String fmtDate = f.format(d);
+        Random rand = new Random(100000);
+        Integer randomInt = rand.nextInt();
+        return CredentialUtil.H(fmtDate + randomInt.toString());
+    }
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectDigestAuthClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectDigestAuthClient.java
@@ -1,13 +1,11 @@
 package org.pac4j.http.client.direct;
 
 import org.pac4j.core.context.WebContext;
-import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.RequiresHttpAction;
+import org.pac4j.core.util.CommonHelper;
 import org.pac4j.http.credentials.CredentialUtil;
 import org.pac4j.http.credentials.DigestCredentials;
 import org.pac4j.http.credentials.authenticator.DigestAuthenticator;
-import org.pac4j.http.credentials.authenticator.UsernamePasswordAuthenticator;
-import org.pac4j.http.credentials.extractor.BasicAuthExtractor;
 import org.pac4j.http.credentials.extractor.DigestAuthExtractor;
 import org.pac4j.http.profile.creator.ProfileCreator;
 
@@ -70,8 +68,6 @@ public class DirectDigestAuthClient extends DirectHttpClient<DigestCredentials> 
         Date d = new Date();
         SimpleDateFormat f = new SimpleDateFormat("yyyy:MM:dd:hh:mm:ss");
         String fmtDate = f.format(d);
-        Random rand = new Random(100000);
-        Integer randomInt = rand.nextInt();
-        return CredentialUtil.H(fmtDate + randomInt.toString());
+        return CredentialUtil.H(fmtDate + CommonHelper.randomString(10));
     }
 }

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/CredentialUtil.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/CredentialUtil.java
@@ -20,12 +20,11 @@ public class CredentialUtil {
      * @param data data
      * @return MD5(data)
      */
-    public static String H(String data) {
+    public static String encryptMD5(String data) {
         try {
             MessageDigest digest = MessageDigest.getInstance("MD5");
             return copyValueOf(Hex.encodeHex(digest.digest(data.getBytes())));
         } catch (NoSuchAlgorithmException ex) {
-            // shouldn't happen
             throw new RuntimeException("Failed to instantiate an MD5 algorithm", ex);
         }
     }
@@ -37,7 +36,7 @@ public class CredentialUtil {
      * @param secret secret
      * @return H(concat(secret, ":", data));
      */
-    public static String KD(String secret, String data) {
-        return H(secret + ":" + data);
+    public static String encryptMD5(String secret, String data) {
+        return encryptMD5(secret + ":" + data);
     }
 }

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/CredentialUtil.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/CredentialUtil.java
@@ -1,5 +1,8 @@
 package org.pac4j.http.credentials;
 
+import static java.lang.String.copyValueOf;
+
+import org.apache.commons.codec.binary.Hex;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -11,10 +14,6 @@ import java.security.NoSuchAlgorithmException;
  */
 public class CredentialUtil {
 
-    private static final char[] toHex = {
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-    };
-
     /**
      * Defined in rfc 2617 as H(data) = MD5(data);
      *
@@ -24,28 +23,11 @@ public class CredentialUtil {
     public static String H(String data) {
         try {
             MessageDigest digest = MessageDigest.getInstance("MD5");
-
-            return toHexString(digest.digest(data.getBytes()));
+            return copyValueOf(Hex.encodeHex(digest.digest(data.getBytes())));
         } catch (NoSuchAlgorithmException ex) {
             // shouldn't happen
             throw new RuntimeException("Failed to instantiate an MD5 algorithm", ex);
         }
-    }
-
-    /**
-     * Converts b[] to hex string.
-     *
-     * @param b the bte array to convert
-     * @return a Hex representation of b.
-     */
-    public static String toHexString(byte b[]) {
-        int pos = 0;
-        char[] c = new char[b.length * 2];
-        for (int i = 0; i < b.length; i++) {
-            c[pos++] = toHex[(b[i] >> 4) & 0x0F];
-            c[pos++] = toHex[b[i] & 0x0f];
-        }
-        return new String(c);
     }
 
     /**

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/CredentialUtil.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/CredentialUtil.java
@@ -1,0 +1,61 @@
+package org.pac4j.http.credentials;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * This class contains utility methods related to credential encryption algorithms
+ * (MD5 for http digest)
+ *
+ * @author Mircea Carasel
+ */
+public class CredentialUtil {
+
+    private static final char[] toHex = {
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    };
+
+    /**
+     * Defined in rfc 2617 as H(data) = MD5(data);
+     *
+     * @param data data
+     * @return MD5(data)
+     */
+    public static String H(String data) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("MD5");
+
+            return toHexString(digest.digest(data.getBytes()));
+        } catch (NoSuchAlgorithmException ex) {
+            // shouldn't happen
+            throw new RuntimeException("Failed to instantiate an MD5 algorithm", ex);
+        }
+    }
+
+    /**
+     * Converts b[] to hex string.
+     *
+     * @param b the bte array to convert
+     * @return a Hex representation of b.
+     */
+    public static String toHexString(byte b[]) {
+        int pos = 0;
+        char[] c = new char[b.length * 2];
+        for (int i = 0; i < b.length; i++) {
+            c[pos++] = toHex[(b[i] >> 4) & 0x0F];
+            c[pos++] = toHex[b[i] & 0x0f];
+        }
+        return new String(c);
+    }
+
+    /**
+     * Defined in rfc 2617 as KD(secret, data) = H(concat(secret, ":", data))
+     *
+     * @param data data
+     * @param secret secret
+     * @return H(concat(secret, ":", data));
+     */
+    public static String KD(String secret, String data) {
+        return H(secret + ":" + data);
+    }
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/DigestCredentials.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/DigestCredentials.java
@@ -1,0 +1,136 @@
+package org.pac4j.http.credentials;
+
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.util.CommonHelper;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/**
+ * <p>This credentials is retrieved from a HTTP request.</p>
+ * <p>A user profile can be attached with the credentials if it has been created by a {@link org.pac4j.http.credentials.authenticator.Authenticator}.
+ * In that case, the {@link org.pac4j.http.profile.creator.AuthenticatorProfileCreator} must be used to retrieve the attached user profile.</p>
+ *
+ * @author Mircea Carasel
+ */
+public class DigestCredentials extends TokenCredentials {
+
+    private String username;
+    private String response;
+
+    private String realm;
+    private String nonce;
+    private String uri;
+    private String cnonce;
+    private String nc;
+    private String qop;
+
+    private String httpMethod;
+
+    public DigestCredentials(final String token, final String httpMethod, final String clientName) {
+        super(token, clientName);
+        Map<String, String> valueMap = parseTokenValue(token);
+
+        username = valueMap.get("username");
+        response = valueMap.get("response");
+
+        if (CommonHelper.isBlank(username) || CommonHelper.isBlank(response)) {
+            throw new CredentialsException("Bad format of the digest auth header");
+        }
+        realm = valueMap.get("realm");
+        nonce = valueMap.get("nonce");
+        uri = valueMap.get("uri");
+        cnonce = valueMap.get("cnonce");
+        nc = valueMap.get("nc");
+        qop = valueMap.get("qop");
+        this.httpMethod = httpMethod;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public String calculateServerDigest(boolean passwordAlreadyEncoded, String password) {
+        return generateDigest(passwordAlreadyEncoded, username,
+                realm, password, httpMethod, uri, qop, nonce, nc, cnonce);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        DigestCredentials that = (DigestCredentials) o;
+
+        if (username != null ? !username.equals(that.username) : that.username != null) return false;
+        return !(response != null ? !response.equals(that.response) : that.response != null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = username != null ? username.hashCode() : 0;
+        result = 31 * result + (response != null ? response.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return CommonHelper.toString(this.getClass(), "username", this.username, "response", "[PROTECTED]",
+                "clientName", getClientName());
+    }
+
+    private Map<String, String> parseTokenValue(String token) {
+        StringTokenizer tokenizer = new StringTokenizer(token, ", ");
+        String keyval;
+        Map map = new HashMap<String, String>();
+        while (tokenizer.hasMoreElements()) {
+            keyval = tokenizer.nextToken();
+            if (keyval.contains("=")) {
+                String key = keyval.substring(0, keyval.indexOf("="));
+                String value = keyval.substring(keyval.indexOf("=") + 1);
+                map.put(key.trim(), value.replaceAll("\"", "").trim());
+            }
+        }
+        return map;
+    }
+
+    private String generateDigest(boolean passwordAlreadyEncoded, String username,
+                                 String realm, String password, String httpMethod, String uri, String qop,
+                                 String nonce, String nc, String cnonce) throws IllegalArgumentException {
+        String ha1;
+        String a2 = httpMethod + ":" + uri;
+        String ha2 = CredentialUtil.H(a2);
+
+        if (passwordAlreadyEncoded) {
+            ha1 = password;
+        }
+        else {
+            ha1 = CredentialUtil.H(username + ":" + realm + ":" +password);
+        }
+
+        String digest;
+
+        if (qop == null) {
+            // as per RFC 2069 compliant clients (also reaffirmed by RFC 2617)
+            digest = CredentialUtil.KD(ha1, nonce + ":" + ha2);
+        }
+        else if ("auth".equals(qop)) {
+            // As per RFC 2617 compliant clients
+            digest = CredentialUtil.KD(ha1, nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" + ha2);
+        }
+        else {
+            throw new IllegalArgumentException("Invalid qop: '"
+                    + qop + "'");
+        }
+
+        return digest;
+    }
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/DigestAuthenticator.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/DigestAuthenticator.java
@@ -1,0 +1,15 @@
+package org.pac4j.http.credentials.authenticator;
+
+import org.pac4j.http.credentials.DigestCredentials;
+import org.pac4j.http.credentials.UsernamePasswordCredentials;
+
+/**
+ * This interface represents the contract to validate digest credentials.
+ *
+ * @author Mircea Carasel
+ */
+public interface DigestAuthenticator extends Authenticator<DigestCredentials> {
+
+    @Override
+    void validate(DigestCredentials credentials);
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/DigestAuthenticator.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/DigestAuthenticator.java
@@ -1,7 +1,6 @@
 package org.pac4j.http.credentials.authenticator;
 
 import org.pac4j.http.credentials.DigestCredentials;
-import org.pac4j.http.credentials.UsernamePasswordCredentials;
 
 /**
  * This interface represents the contract to validate digest credentials.

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/DigestAuthExtractor.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/DigestAuthExtractor.java
@@ -1,0 +1,52 @@
+package org.pac4j.http.credentials.extractor;
+
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.http.credentials.DigestCredentials;
+import org.pac4j.http.credentials.TokenCredentials;
+import org.pac4j.http.credentials.UsernamePasswordCredentials;
+
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+/**
+ * To extract digest auth header.
+ *
+ * @author Mircea Carasel
+ */
+public class DigestAuthExtractor implements Extractor<DigestCredentials> {
+
+    private final HeaderExtractor extractor;
+
+    private final String clientName;
+
+    public DigestAuthExtractor(final String clientName) {
+        this(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.DIGEST_HEADER_PREFIX, clientName);
+    }
+
+    public DigestAuthExtractor(final String headerName, final String prefixHeader, final String clientName) {
+        this.extractor = new HeaderExtractor(headerName, prefixHeader, clientName);
+        this.clientName = clientName;
+    }
+
+    @Override
+    public DigestCredentials extract(WebContext context) {
+        final TokenCredentials credentials = this.extractor.extract(context);
+
+        if (credentials == null) {
+            return null;
+        }
+
+        String value = credentials.getToken();
+        String method = context.getRequestMethod();
+
+        return new DigestCredentials(value, method, clientName);
+    }
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/DigestAuthExtractor.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/DigestAuthExtractor.java
@@ -6,12 +6,7 @@ import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.http.credentials.DigestCredentials;
 import org.pac4j.http.credentials.TokenCredentials;
-import org.pac4j.http.credentials.UsernamePasswordCredentials;
 
-import java.io.UnsupportedEncodingException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -36,6 +31,23 @@ public class DigestAuthExtractor implements Extractor<DigestCredentials> {
         this.clientName = clientName;
     }
 
+    /**
+     * Extracts digest Authorization header components.
+     * As per RFC 2617 :
+     * username is the user's name in the specified realm
+     * qop is quality of protection
+     * uri is the request uri
+     * response is the client response
+     * nonce is a server-specified data string which should be uniquely generated
+     *   each time a 401 response is made
+     * cnonce is the client nonce
+     * nc is the nonce count
+     * If in the Authorization header it is not specified a username and response, we throw CredentialsException because
+     * the client uses an username and a password to authenticate. response is just a MD5 encoded value
+     * based on user provided password and RFC 2617 digest authentication encoding rules
+     * @param context the current web context
+     * @return
+     */
     @Override
     public DigestCredentials extract(WebContext context) {
         final TokenCredentials credentials = this.extractor.extract(context);


### PR DESCRIPTION
-implement RFC 2617 for digest authentication
Create DigestCredentials given Digest Authorization header
This has to be used similar as the Direct Basic Authenticator is used
Create new DigestAuthenticator intervace to validate DigestCredentials retrieved from the authenticator

The realm value is configurable:

 DirectDigestAuthClient digestAuthClient = new DirectDigestAuthClient(new SecurityDigestAuthenticator());
 digestAuthClient.setRealm("myRealm");

In order to validate that Digest authentication is successful is needed that:

digestCredentials.getResponse().equals(digestCredentials.calculateServerDigest(true, pwd))

where pwd is the user password kept in database.
According to RFC 2617 the user may keep HA1 encoded format
of the password in database: HA1=MD5(username-value + ":" + realm-value + ":" + passwd)
If the user keeps password in clear (not recommended) then the digest validation should be performed like this:

digestCredentials.getResponse().equals(digestCredentials.calculateServerDigest(false, pwd))

digestCredentials.getResponse() represents the client response digest
digestCredentials.calculcateServerDigest represents the server digest. These two must be equal for a successful digest authentication