### PR TITLE
make tokenendpoint auth configurable for oidc

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -301,7 +301,7 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
         final List<ClientAuthenticationMethod> methods = getProviderMetadata().getTokenEndpointAuthMethods();
         final ClientAuthenticationMethod method;
 
-        if (methods != null && methods.size() > 0 ) {
+        if (!methods.isEmpty()) {
             if (methods.contains(getClientAuthenticationMethod())) {
                 method = getClientAuthenticationMethod();
             } else {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -123,6 +123,9 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
     /* client authentication object at the token End Point (basic, form or JWT) */
     private ClientAuthentication clientAuthentication;
 
+    /* client authentication method used at token End Point */
+    private ClientAuthenticationMethod clientAuthenticationMethod;
+
     /* clientID object */
     private ClientID _clientID;
 
@@ -294,9 +297,23 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
             throw new TechnicalException(e);
         }
 
-        final ClientAuthenticationMethod method = getProviderMetadata().getTokenEndpointAuthMethods() != null
-                && getProviderMetadata().getTokenEndpointAuthMethods().size() > 0 ? getProviderMetadata()
-                .getTokenEndpointAuthMethods().get(0) : ClientAuthenticationMethod.getDefault();
+        // check authentication methods
+        final List<ClientAuthenticationMethod> methods = getProviderMetadata().getTokenEndpointAuthMethods();
+        final ClientAuthenticationMethod method;
+
+        if (methods != null && methods.size() > 0 ) {
+            if (methods.contains(getClientAuthenticationMethod())) {
+                method = getClientAuthenticationMethod();
+            } else {
+                method = getProviderMetadata().getTokenEndpointAuthMethods().get(0);
+                logger.warn("Preferred token endpoint Authentication method: {} not available. Defaulting to: {}",
+                        getClientAuthenticationMethod(), method);
+            }
+        } else {
+            method = ClientAuthenticationMethod.getDefault();
+            logger.warn("Provider metadata does not provide Token endpoint authentication methods. Defaulting to: {}",
+                    method);
+        }
 
         if (ClientAuthenticationMethod.CLIENT_SECRET_POST.equals(method)) {
             this.clientAuthentication = new ClientSecretPost(this._clientID, this._secret);
@@ -524,5 +541,13 @@ public class OidcClient extends IndirectClient<OidcCredentials, OidcProfile> {
 
     public void setMaxClockSkew(int maxClockSkew) {
         this.maxClockSkew = maxClockSkew;
+    }
+
+    public ClientAuthenticationMethod getClientAuthenticationMethod() {
+        return clientAuthenticationMethod;
+    }
+
+    public void setClientAuthenticationMethod(ClientAuthenticationMethod clientAuthenticationMethod) {
+        this.clientAuthenticationMethod = clientAuthenticationMethod;
     }
 }


### PR DESCRIPTION
Don't pick the first in the metadata list, but let the client set a preferred token endpoint authentication method