### PR TITLE
Default to require assertions to be signed

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -210,6 +210,12 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
         <!-- for testing -->
     </dependencies>
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -142,7 +142,8 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
         this.responseValidator = new SAML2DefaultResponseValidator(
                 this.signatureTrustEngineProvider,
                 this.decrypter,
-                this.configuration.getMaximumAuthenticationLifetime());
+                this.configuration.getMaximumAuthenticationLifetime(),
+                this.configuration.getWantsAssertionsSigned());
     }
 
     protected void initSignatureTrustEngineProvider(final MetadataResolver metadataManager) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -72,6 +72,7 @@ public final class SAML2ClientConfiguration implements Cloneable {
     private List<String> signatureAlgorithms;
     private List<String> signatureReferenceDigestMethods;
     private String signatureCanonicalizationAlgorithm;
+    private boolean wantsAssertionsSigned = true;
 
     public SAML2ClientConfiguration(final String keystorePath, final String keystorePassword,
                                     final String privateKeyPassword, final String identityProviderMetadataPath) {
@@ -285,6 +286,14 @@ public final class SAML2ClientConfiguration implements Cloneable {
         this.signatureCanonicalizationAlgorithm = signatureCanonicalizationAlgorithm;
     }
 
+    public boolean getWantsAssertionsSigned() {
+        return this.wantsAssertionsSigned;
+    }
+
+    public void setWantsAssertionsSigned(boolean wantsAssertionsSigned) {
+        this.wantsAssertionsSigned = wantsAssertionsSigned;
+    }
+
     @Override
     public SAML2ClientConfiguration clone() {
         try {
@@ -293,7 +302,4 @@ public final class SAML2ClientConfiguration implements Cloneable {
             throw new RuntimeException(e);
         }
     }
-
-
-
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -15,6 +15,7 @@
  */
 package org.pac4j.saml.sso.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import net.shibboleth.utilities.java.support.net.BasicURLComparator;
 import net.shibboleth.utilities.java.support.net.URIComparator;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
@@ -23,7 +24,6 @@ import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
-import org.opensaml.saml.common.messaging.context.SAMLSelfEntityContext;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.criterion.EntityRoleCriterion;
 import org.opensaml.saml.criterion.ProtocolCriterion;
@@ -72,8 +72,6 @@ import org.pac4j.saml.util.UriUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.namespace.QName;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -96,12 +94,14 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
     /** The default maximum authentication lifetime, in seconds. Used for {@link #maximumAuthenticationLifetime} if a meaningless (&lt;=0) value is passed to the constructor. */
     private static final int DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME = 3600;
- 
+
     /* maximum skew in seconds between SP and IDP clocks */
     private int acceptedSkew = 120;
 
     /* maximum lifetime after a successful authentication on an IDP */
     private int maximumAuthenticationLifetime;
+
+    private final boolean wantsAssertionsSigned;
 
     private final SAML2SignatureTrustEngineProvider signatureTrustEngineProvider;
 
@@ -111,18 +111,21 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
     public SAML2DefaultResponseValidator(final SAML2SignatureTrustEngineProvider engine,
                                          final Decrypter decrypter,
-                                         final int maximumAuthenticationLifetime) {
-        this(engine, decrypter, maximumAuthenticationLifetime, new BasicURLComparator());
+                                         final int maximumAuthenticationLifetime,
+                                         final boolean wantsAssertionsSigned) {
+        this(engine, decrypter, maximumAuthenticationLifetime, wantsAssertionsSigned, new BasicURLComparator());
     }
 
     public SAML2DefaultResponseValidator(final SAML2SignatureTrustEngineProvider engine,
                                          final Decrypter decrypter,
                                          final int maximumAuthenticationLifetime,
+                                         final boolean wantsAssertionsSigned,
                                          final URIComparator uriComparator) {
         this.signatureTrustEngineProvider = engine;
         this.decrypter = decrypter;
         this.maximumAuthenticationLifetime = (maximumAuthenticationLifetime > 0 ? maximumAuthenticationLifetime : DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME);
         this.uriComparator = uriComparator;
+        this.wantsAssertionsSigned = wantsAssertionsSigned;
     }
 
     /**
@@ -650,12 +653,18 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             final String entityId = peerContext.getEntityId();
             validateSignature(signature, entityId, engine);
         } else {
-            SPSSODescriptor spDescriptor = (context == null) ? null : context.getSPSSODescriptor();
-            Boolean wantAssertionsSigned = (spDescriptor == null) ? Boolean.FALSE : spDescriptor.getWantAssertionsSigned();
-            if (wantAssertionsSigned && !peerContext.isAuthenticated()) {
+            if (wantsAssertionsSigned(context) && !peerContext.isAuthenticated()) {
                 throw new SAMLException("Assertion or response must be signed");
             }
         }
+    }
+
+    @VisibleForTesting
+    Boolean wantsAssertionsSigned(SAML2MessageContext context) {
+        if (context == null) return wantsAssertionsSigned;
+        SPSSODescriptor spDescriptor = context.getSPSSODescriptor();
+        if (spDescriptor == null) return wantsAssertionsSigned;
+        return spDescriptor.getWantAssertionsSigned();
     }
 
     /**

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTest.java
@@ -1,0 +1,115 @@
+/*
+  Copyright 2012 - 2016 pac4j organization
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.pac4j.saml.sso.impl;
+
+import org.junit.Test;
+import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
+import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.exceptions.SAMLException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SAML2DefaultResponseValidatorTest {
+
+  @Test
+  public void testDoesNotWantAssertionsSignedWithNullContext() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(null));
+  }
+
+  private SAML2DefaultResponseValidator createResponseValidatorWithSigningValidationOf(boolean wantsAssertionsSigned) {
+    SAML2SignatureTrustEngineProvider trustEngineProvider = mock(SAML2SignatureTrustEngineProvider.class);
+    Decrypter decrypter = mock(Decrypter.class);
+    return new SAML2DefaultResponseValidator(trustEngineProvider, decrypter, 0, wantsAssertionsSigned);
+  }
+
+  @Test
+  public void testWantsAssertionsSignedWithNullContext() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(null));
+  }
+
+  @Test
+  public void testDoesNotWantAssertionsSignedWithNullSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    SAML2MessageContext context = new SAML2MessageContext();
+    assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
+    assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test
+  public void testWantsAssertionsSignedWithNullSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    SAML2MessageContext context = new SAML2MessageContext();
+    assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
+    assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test
+  public void testDoesNotWantAssertionsSignedWithValidSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    SAML2MessageContext context = new SAML2MessageContext();
+
+    SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
+    SPSSODescriptor roleDescriptor = mock(SPSSODescriptor.class);
+    when(roleDescriptor.getWantAssertionsSigned()).thenReturn(false);
+    samlSelfMetadataContext.setRoleDescriptor(roleDescriptor);
+
+    assertNotNull("Expected SPSSODescriptor to not be null", context.getSPSSODescriptor());
+    assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test
+  public void testWantsAssertionsSignedWithValidSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    SAML2MessageContext context = new SAML2MessageContext();
+
+    SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
+    SPSSODescriptor roleDescriptor = mock(SPSSODescriptor.class);
+    when(roleDescriptor.getWantAssertionsSigned()).thenReturn(true);
+    samlSelfMetadataContext.setRoleDescriptor(roleDescriptor);
+
+    assertNotNull("Expected SPSSODescriptor to not be null", context.getSPSSODescriptor());
+    assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test(expected = SAMLException.class)
+  public void testAssertionWithoutSignatureThrowsException() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    SAML2MessageContext context = new SAML2MessageContext();
+    SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
+    peerEntityContext.setAuthenticated(false);
+    context.addSubcontext(peerEntityContext);
+    validator.validateAssertionSignature(null, context, null);
+  }
+
+  @Test
+  public void testAssertionWithoutSignatureDoesNotThrowException() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    SAML2MessageContext context = new SAML2MessageContext();
+    SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
+    peerEntityContext.setAuthenticated(false);
+    context.addSubcontext(peerEntityContext);
+    validator.validateAssertionSignature(null, context, null);
+    // expected no exceptions
+  }
+}


### PR DESCRIPTION
This changes the default behavior of SAML2DefaultResponseValidator such that
assertions must be signed, unless the user changes the default configuration in
SAML2ClientConfiguration, or the SPSSODescriptor has `wantAssertionsSigned` set
to false (based on the SP metadata).

The reason why is because this is a security issue where an attacker can forge
a SAML response that does not contain assertion signatures, and they can then
specify any assertions they want. For example, they can specify a different
name or email or group to elevate privileges. This is only possible if the
SPSSODescriptor in the validator is null, but in our specific way of using
pac4j-saml, that seems to always be the case at the time of validating the SAML
response.

In a subsequent PR I will address the issue of the SPSSODescriptor being null within the validator.

Issue #502 SAML2DefaultResponseValidator wantAssertionsSigned cannot evaluate to true