### PR TITLE
Default to require assertions to be signed

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -192,6 +192,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- for testing -->
     </dependencies>
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -125,7 +125,8 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
         this.responseValidator = new SAML2DefaultResponseValidator(
                 this.signatureTrustEngineProvider,
                 this.decrypter,
-                this.configuration.getMaximumAuthenticationLifetime());
+                this.configuration.getMaximumAuthenticationLifetime(),
+                this.configuration.getWantsAssertionsSigned());
     }
 
     protected void initSignatureTrustEngineProvider(final MetadataResolver metadataManager) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -57,6 +57,7 @@ public final class SAML2ClientConfiguration implements Cloneable {
     private List<String> signatureAlgorithms;
     private List<String> signatureReferenceDigestMethods;
     private String signatureCanonicalizationAlgorithm;
+    private boolean wantsAssertionsSigned = true;
 
     public SAML2ClientConfiguration(final String keystorePath, final String keystorePassword,
                                     final String privateKeyPassword, final String identityProviderMetadataPath) {
@@ -268,6 +269,14 @@ public final class SAML2ClientConfiguration implements Cloneable {
 
     public void setSignatureCanonicalizationAlgorithm(final String signatureCanonicalizationAlgorithm) {
         this.signatureCanonicalizationAlgorithm = signatureCanonicalizationAlgorithm;
+    }
+
+    public boolean getWantsAssertionsSigned() {
+        return this.wantsAssertionsSigned;
+    }
+
+    public void setWantsAssertionsSigned(boolean wantsAssertionsSigned) {
+        this.wantsAssertionsSigned = wantsAssertionsSigned;
     }
 
     @Override

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -1,0 +1,100 @@
+package org.pac4j.saml.sso.impl;
+
+import org.junit.Test;
+import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
+import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.exceptions.SAMLException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SAML2DefaultResponseValidatorTests {
+
+  @Test
+  public void testDoesNotWantAssertionsSignedWithNullContext() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(null));
+  }
+
+  private SAML2DefaultResponseValidator createResponseValidatorWithSigningValidationOf(boolean wantsAssertionsSigned) {
+    SAML2SignatureTrustEngineProvider trustEngineProvider = mock(SAML2SignatureTrustEngineProvider.class);
+    Decrypter decrypter = mock(Decrypter.class);
+    return new SAML2DefaultResponseValidator(trustEngineProvider, decrypter, 0, wantsAssertionsSigned);
+  }
+
+  @Test
+  public void testWantsAssertionsSignedWithNullContext() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(null));
+  }
+
+  @Test
+  public void testDoesNotWantAssertionsSignedWithNullSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    SAML2MessageContext context = new SAML2MessageContext();
+    assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
+    assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test
+  public void testWantsAssertionsSignedWithNullSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    SAML2MessageContext context = new SAML2MessageContext();
+    assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
+    assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test
+  public void testDoesNotWantAssertionsSignedWithValidSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    SAML2MessageContext context = new SAML2MessageContext();
+
+    SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
+    SPSSODescriptor roleDescriptor = mock(SPSSODescriptor.class);
+    when(roleDescriptor.getWantAssertionsSigned()).thenReturn(false);
+    samlSelfMetadataContext.setRoleDescriptor(roleDescriptor);
+
+    assertNotNull("Expected SPSSODescriptor to not be null", context.getSPSSODescriptor());
+    assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test
+  public void testWantsAssertionsSignedWithValidSPSSODescriptor() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    SAML2MessageContext context = new SAML2MessageContext();
+
+    SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
+    SPSSODescriptor roleDescriptor = mock(SPSSODescriptor.class);
+    when(roleDescriptor.getWantAssertionsSigned()).thenReturn(true);
+    samlSelfMetadataContext.setRoleDescriptor(roleDescriptor);
+
+    assertNotNull("Expected SPSSODescriptor to not be null", context.getSPSSODescriptor());
+    assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
+  }
+
+  @Test(expected = SAMLException.class)
+  public void testAssertionWithoutSignatureThrowsException() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(true);
+    SAML2MessageContext context = new SAML2MessageContext();
+    SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
+    peerEntityContext.setAuthenticated(false);
+    context.addSubcontext(peerEntityContext);
+    validator.validateAssertionSignature(null, context, null);
+  }
+
+  @Test
+  public void testAssertionWithoutSignatureDoesNotThrowException() throws Exception {
+    SAML2DefaultResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+    SAML2MessageContext context = new SAML2MessageContext();
+    SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
+    peerEntityContext.setAuthenticated(false);
+    context.addSubcontext(peerEntityContext);
+    validator.validateAssertionSignature(null, context, null);
+    // expected no exceptions
+  }
+}


### PR DESCRIPTION
This changes the default behavior of SAML2DefaultResponseValidator such that
assertions must be signed, unless the user changes the default configuration in
SAML2ClientConfiguration, or the SPSSODescriptor has `wantAssertionsSigned` set
to false (based on the SP metadata).

The reason why is because this is a security issue where an attacker can forge
a SAML response that does not contain assertion signatures, and they can then
specify any assertions they want. For example, they can specify a different
name or email or group to elevate privileges. This is only possible if the
SPSSODescriptor in the validator is null, but in our specific way of using
pac4j-saml, that seems to always be the case at the time of validating the SAML
response.

In a subsequent PR I will address the issue of the SPSSODescriptor being null within the validator.

Issue #502 SAML2DefaultResponseValidator wantAssertionsSigned cannot evaluate to true

This was cherry-picked from PR #503 (off the 1.8.x branch). The JUnit test
pattern now uses *Tests, so I've renamed the new test class. I also removed the
copyright header from the test class, since that is the new pattern on master.
And, the mockito-core version is no longer explicitly declared in pac4j-saml's
pom.xml, instead preferring the version from the parent pom.