### PR TITLE
Ensure SAML validator always has SPSSODescriptor

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
@@ -78,6 +78,8 @@ public class SAML2WebSSOMessageReceiver implements SAML2MessageReceiver {
 
         decodedCtx.getProfileRequestContext().setProfileId(SAML2_WEBSSO_PROFILE_URI);
 
+        decodedCtx.getSAMLSelfMetadataContext().setRoleDescriptor(context.getSPSSODescriptor());
+
         return this.validator.validate(decodedCtx);
     }
 }


### PR DESCRIPTION
Previously, the newly constructed decoded context for the validator did not
perform a complete deep copy of the original SAML2MessageContext. This caused
the SPSSODescriptor to be missing from the decoded context, and so the
validator could not retrieve the wantAssertionSigned value set, and would
always use the default value.

This change fixes the issue by ensuring that the decoded context retains the
SPSSODescriptor from the original SAML2MessageContext.

Issue #502 SAML2DefaultResponseValidator wantAssertionsSigned cannot evaluate to true

And related to PR #504 Default to require assertions to be signed.

This was cherry picked from the 1.8.x branch in PR #505.