### PR TITLE
Use idp descriptor to retrieve signature signing parameters

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageSender.java
@@ -74,7 +74,7 @@ public class SAML2WebSSOMessageSender implements SAML2MessageSender<AuthnRequest
         outboundContext.getSAMLPeerEntityContext().setEntityId(context.getSAMLPeerEntityContext().getEntityId());
         outboundContext.getSAMLProtocolContext().setProtocol(context.getSAMLProtocolContext().getProtocol());
         outboundContext.getSecurityParametersContext()
-                .setSignatureSigningParameters(this.signatureSigningParametersProvider.build(spDescriptor));
+                .setSignatureSigningParameters(this.signatureSigningParametersProvider.build(idpssoDescriptor));
 
         if (relayState != null) {
             outboundContext.getSAMLBindingContext().setRelayState(relayState.toString());


### PR DESCRIPTION
In our project which uses pac4j to connect to a saml idp, we had an issue with the DigestMethod used by pac4j to talk to the idp (it's always sha512). The used idp doesn't support sha512 as digest method.

According to the documentation (https://github.com/pac4j/pac4j/wiki/Clients in SAML support/Additional configuration) the signature parameters are determined based on the idp metadata and the pac4j configuration. So we tried to configure pac4j to change the digest method, but the request still used sha512. We also tried to change the idp metadata in order to add information about the supported digest methods but it still failed.

When looking at the code, it seems to us that pac4j was using the sp metadata (which is generated with many supported digest methods, sha512 being the first in the list) instead of the idp metadata. We changed it to use the idp and then it fixed our issue (we can now change the idp metadata to specify the supported digest method or configure pac4j).

This pull request contains the fix we did.

Please tell us if we misunderstood the pac4j code.