### PR TITLE
Ability to load roles from a list value as well as strings.

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/FromAttributesAuthorizationGenerator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/FromAttributesAuthorizationGenerator.java
@@ -1,6 +1,7 @@
 package org.pac4j.core.authorization.generator;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.StringTokenizer;
 
 import org.pac4j.core.profile.CommonProfile;
@@ -43,20 +44,36 @@ public class FromAttributesAuthorizationGenerator<U extends CommonProfile> imple
         if (attributes != null) {
             for (final String attribute : attributes) {
                 final Object value = profile.getAttribute(attribute);
-                if (value != null && value instanceof String) {
-                    final StringTokenizer st = new StringTokenizer((String) value, this.splitChar);
-                    while (st.hasMoreTokens()) {
-                        if (isRole) {
-                            profile.addRole(st.nextToken());
-                        } else {
-                            profile.addPermission(st.nextToken());
+                if (value != null) {
+                    if(value instanceof String) {
+                        final StringTokenizer st = new StringTokenizer((String) value, this.splitChar);
+                        while (st.hasMoreTokens()) {
+                            setAuth(profile, st.nextToken(), isRole);
+                        }
+                    } else if(value.getClass().isArray() && value.getClass().getComponentType().isAssignableFrom(String.class)) {
+                        for(Object item : (Object[])value) {
+                            setAuth(profile, item.toString(), isRole);
+                        }
+                    } else if(Collection.class.isAssignableFrom(value.getClass())) {
+                        for(Object item : (Collection<?>)value) {
+                            if(item.getClass().isAssignableFrom(String.class)) {
+                                setAuth(profile, item.toString(), isRole);
+                            }
                         }
                     }
                 }
             }
         }
     }
-    
+
+    private void setAuth(final U profile, final String value, final boolean isRole) {
+        if (isRole) {
+            profile.addRole(value);
+        } else {
+            profile.addPermission(value);
+        }
+    }
+
     public String getSplitChar() {
         return this.splitChar;
     }

--- a/pac4j-core/src/test/java/org/pac4j/core/authorization/generator/FromAttributesAuthorizationGeneratorTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/authorization/generator/FromAttributesAuthorizationGeneratorTests.java
@@ -1,5 +1,7 @@
 package org.pac4j.core.authorization.generator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Before;
@@ -21,6 +23,16 @@ public final class FromAttributesAuthorizationGeneratorTests {
     private final static String ATTRIB2 = "attrib2";
     private final static String VALUE2 = "info21,info22";
     private final static String ATTRIB3 = "attrib3";
+    private final static String ATTRIB4 = "attrib4";
+    private final static String ATTRIB5 = "attrib5";
+    private final static String[] ATTRIB_ARRAY = new String[]{"infoA1", "infoA2", "infoA3"};
+    private final static List<String> ATTRIB_LIST = new ArrayList<>();
+
+    static {
+        ATTRIB_LIST.add("infoL1");
+        ATTRIB_LIST.add("infoL2");
+        ATTRIB_LIST.add("infoL3");
+    }
     
     private CommonProfile profile;
     
@@ -29,6 +41,8 @@ public final class FromAttributesAuthorizationGeneratorTests {
         this.profile = new CommonProfile();
         this.profile.addAttribute(ATTRIB1, VALUE1);
         this.profile.addAttribute(ATTRIB2, VALUE2);
+        this.profile.addAttribute(ATTRIB3, ATTRIB_ARRAY);
+        this.profile.addAttribute(ATTRIB4, ATTRIB_LIST);
     }
 
     @Test
@@ -64,7 +78,7 @@ public final class FromAttributesAuthorizationGeneratorTests {
     @Test
     public void testNoRolePermission() {
         final String[] roleAttributes = new String[] {
-            ATTRIB3
+            ATTRIB5
         };
         final String[] permissionAttributes = new String[] {
             ATTRIB2
@@ -86,7 +100,7 @@ public final class FromAttributesAuthorizationGeneratorTests {
             ATTRIB1
         };
         final String[] permissionAttributes = new String[] {
-            ATTRIB3
+            ATTRIB5
         };
         final FromAttributesAuthorizationGenerator<CommonProfile> generator = new FromAttributesAuthorizationGenerator<CommonProfile>(
                                                                                                                                       roleAttributes,
@@ -118,5 +132,37 @@ public final class FromAttributesAuthorizationGeneratorTests {
         final Set<String> permissions = this.profile.getPermissions();
         assertEquals(1, permissions.size());
         assertTrue(permissions.contains(VALUE2));
+    }
+
+    @Test
+    public void testListRolesPermissions() {
+        final String[] roleAttributes = new String[] {
+                ATTRIB3, ATTRIB4
+        };
+        final String[] permissionAttributes = new String[] {
+                ATTRIB3, ATTRIB4
+        };
+
+        final FromAttributesAuthorizationGenerator<CommonProfile> generator = new FromAttributesAuthorizationGenerator<CommonProfile>(
+                roleAttributes,
+                permissionAttributes);
+
+        generator.generate(this.profile);
+        final Set<String> roles = this.profile.getRoles();
+        assertEquals(ATTRIB_ARRAY.length + ATTRIB_LIST.size(), roles.size());
+        for(String value : ATTRIB_ARRAY) {
+            assertTrue(roles.contains(value));
+        }
+        for(String value : ATTRIB_LIST) {
+            assertTrue(roles.contains(value));
+        }
+        final Set<String> permissions = this.profile.getPermissions();
+        assertEquals(ATTRIB_ARRAY.length + ATTRIB_LIST.size(), roles.size());
+        for(String value : ATTRIB_ARRAY) {
+            assertTrue(permissions.contains(value));
+        }
+        for(String value : ATTRIB_LIST) {
+            assertTrue(permissions.contains(value));
+        }
     }
 }


### PR DESCRIPTION
Currently, `FromAttributesAuthorizationGenerator` only loads roles from string attributes with a comma separated list of roles. Sometimes, service (notably CAS), return roles as a list (notably `memberOf` from LDAP). This allows attribute values to be lists or arrays.