### PR TITLE
Don't swallow CredentialsException in DirectClientV2#getCredentials

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/DirectClientV2.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/DirectClientV2.java
@@ -3,7 +3,6 @@ package org.pac4j.core.client;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.authenticator.LocalCachingAuthenticator;
 import org.pac4j.core.credentials.extractor.CredentialsExtractor;
-import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.credentials.authenticator.Authenticator;
@@ -41,17 +40,12 @@ public abstract class DirectClientV2<C extends Credentials, U extends CommonProf
     @Override
     public C getCredentials(final WebContext context) throws RequiresHttpAction {
         init(context);
-        try {
-            final C credentials = this.credentialsExtractor.extract(context);
-            if (credentials == null) {
-                return null;
-            }
-            this.authenticator.validate(credentials);
-            return credentials;
-        } catch (CredentialsException e) {
-            logger.error("Failed to retrieve or validate credentials", e);
+        final C credentials = this.credentialsExtractor.extract(context);
+        if (credentials == null) {
             return null;
         }
+        this.authenticator.validate(credentials);
+        return credentials;
     }
 
     @Override

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectFormClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectFormClientTests.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.credentials.authenticator.LocalCachingAuthenticator;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.RequiresHttpAction;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileHelper;
@@ -71,9 +72,14 @@ public final class DirectFormClientTests implements TestsConstants {
     @Test
     public void testGetBadCredentials() throws RequiresHttpAction {
         final DirectFormClient formClient = getFormClient();
-        final MockWebContext context = MockWebContext.create();
-        assertNull(formClient.getCredentials(context.addRequestParameter(formClient.getUsernameParameter(), USERNAME)
-                .addRequestParameter(formClient.getPasswordParameter(), PASSWORD)));
+        final MockWebContext context = MockWebContext.create().addRequestParameter(formClient.getUsernameParameter(), USERNAME)
+                .addRequestParameter(formClient.getPasswordParameter(), PASSWORD);
+        try {
+            formClient.getCredentials(context);
+            fail();
+        } catch (CredentialsException e) {
+            assertEquals("Username : '" + USERNAME + "' does not match password", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Any CredentialsException occuring while extracting or validating the credentials should be thrown up by org.pac4j.core.client.DirectClientV2#getCredentials

In order to be able to present an relevant message to the user, we would like the CredentialsException to be thrown a level up, instead of returning null. It will be up to the caller to decide what to do with it.

For instance, if the CredentialsException indicated 'the password does not match' or 'the account is disabled', and should we want to display that message to the user, then we should be able to.