### PR TITLE
Added support for enumerated properties

### DIFF
--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConfigFactory.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConfigFactory.java
@@ -25,36 +25,38 @@ import java.util.Map;
  */
 public class PropertiesConfigFactory implements ConfigFactory {
 
-    public final static String FACEBOOK_ID = "facebook.id";
-    public final static String FACEBOOK_SECRET = "facebook.secret";
-    public final static String FACEBOOK_SCOPE = "facebook.scope";
-    public final static String FACEBOOK_FIELDS = "facebook.fields";
+    public static final String FACEBOOK_ID = "facebook.id";
+    public static final String FACEBOOK_SECRET = "facebook.secret";
+    public static final String FACEBOOK_SCOPE = "facebook.scope";
+    public static final String FACEBOOK_FIELDS = "facebook.fields";
 
-    public final static String TWITTER_ID = "twitter.id";
-    public final static String TWITTER_SECRET = "twitter.secret";
+    public static final String TWITTER_ID = "twitter.id";
+    public static final String TWITTER_SECRET = "twitter.secret";
 
-    public final static String SAML_KEYSTORE_PASSWORD = "saml.keystorePassword";
-    public final static String SAML_PRIVATE_KEY_PASSWORD = "saml.privateKeyPassword";
-    public final static String SAML_KEYSTORE_PATH = "saml.keystorePath";
-    public final static String SAML_IDENTITY_PROVIDER_METADATA_PATH = "saml.identityProviderMetadataPath";
-    public final static String SAML_MAXIMUM_AUTHENTICATION_LIFETIME = "saml.maximumAuthenticationLifetime";
-    public final static String SAML_SERVICE_PROVIDER_ENTITY_ID = "saml.serviceProviderEntityId";
-    public final static String SAML_SERVICE_PROVIDER_METADATA_PATH = "saml.serviceProviderMetadataPath";
+    public static final String SAML_KEYSTORE_PASSWORD = "saml.keystorePassword";
+    public static final String SAML_PRIVATE_KEY_PASSWORD = "saml.privateKeyPassword";
+    public static final String SAML_KEYSTORE_PATH = "saml.keystorePath";
+    public static final String SAML_IDENTITY_PROVIDER_METADATA_PATH = "saml.identityProviderMetadataPath";
+    public static final String SAML_MAXIMUM_AUTHENTICATION_LIFETIME = "saml.maximumAuthenticationLifetime";
+    public static final String SAML_SERVICE_PROVIDER_ENTITY_ID = "saml.serviceProviderEntityId";
+    public static final String SAML_SERVICE_PROVIDER_METADATA_PATH = "saml.serviceProviderMetadataPath";
 
-    public final static String CAS_LOGIN_URL = "cas.loginUrl";
-    public final static String CAS_PROTOCOL = "cas.protocol";
+    public static final String CAS_LOGIN_URL = "cas.loginUrl";
+    public static final String CAS_PROTOCOL = "cas.protocol";
 
-    public final static String OIDC_ID = "oidc.id";
-    public final static String OIDC_SECRET = "oidc.secret";
-    public final static String OIDC_DISCOVERY_URI = "oidc.discoveryUri";
-    public final static String OIDC_USE_NONCE = "oidc.useNonce";
-    public final static String OIDC_PREFERRED_JWS_ALGORITHM = "oidc.preferredJwsAlgorithm";
-    public final static String OIDC_MAX_CLOCK_SKEW = "oidc.maxClockSkew";
-    public final static String OIDC_CLIENT_AUTHENTICATION_METHOD = "oidc.clientAuthenticationMethod";
-    public final static String OIDC_CUSTOM_PARAM_KEY1 = "oidc.customParamKey1";
-    public final static String OIDC_CUSTOM_PARAM_VALUE1 = "oidc.customParamValue1";
-    public final static String OIDC_CUSTOM_PARAM_KEY2 = "oidc.customParamKey2";
-    public final static String OIDC_CUSTOM_PARAM_VALUE2 = "oidc.customParamValue2";
+    public static final String OIDC_ID = "oidc.id";
+    public static final String OIDC_SECRET = "oidc.secret";
+    public static final String OIDC_DISCOVERY_URI = "oidc.discoveryUri";
+    public static final String OIDC_USE_NONCE = "oidc.useNonce";
+    public static final String OIDC_PREFERRED_JWS_ALGORITHM = "oidc.preferredJwsAlgorithm";
+    public static final String OIDC_MAX_CLOCK_SKEW = "oidc.maxClockSkew";
+    public static final String OIDC_CLIENT_AUTHENTICATION_METHOD = "oidc.clientAuthenticationMethod";
+    public static final String OIDC_CUSTOM_PARAM_KEY1 = "oidc.customParamKey1";
+    public static final String OIDC_CUSTOM_PARAM_VALUE1 = "oidc.customParamValue1";
+    public static final String OIDC_CUSTOM_PARAM_KEY2 = "oidc.customParamKey2";
+    public static final String OIDC_CUSTOM_PARAM_VALUE2 = "oidc.customParamValue2";
+    
+    private static final int MAX_NUM_CLIENTS = 10;
 
     private final String callbackUrl;
 
@@ -110,76 +112,95 @@ public class PropertiesConfigFactory implements ConfigFactory {
     }
 
     private void tryCreateSaml2Client(final List<Client> clients) {
-        final String keystorePassword = getProperty(SAML_KEYSTORE_PASSWORD);
-        final String privateKeyPassword = getProperty(SAML_PRIVATE_KEY_PASSWORD);
-        final String keystorePath = getProperty(SAML_KEYSTORE_PATH);
-        final String ientityProviderMetadataPath = getProperty(SAML_IDENTITY_PROVIDER_METADATA_PATH);
-        final String maximumAuthenticationLifetime = getProperty(SAML_MAXIMUM_AUTHENTICATION_LIFETIME);
-        final String serviceProviderEntityId = getProperty(SAML_SERVICE_PROVIDER_ENTITY_ID);
-        final String serviceProviderMetadataPath = getProperty(SAML_SERVICE_PROVIDER_METADATA_PATH);
-        if (CommonHelper.isNotBlank(keystorePassword) && CommonHelper.isNotBlank(privateKeyPassword)
-                && CommonHelper.isNotBlank(keystorePath) && CommonHelper.isNotBlank(ientityProviderMetadataPath)) {
-            final SAML2ClientConfiguration cfg = new SAML2ClientConfiguration(keystorePath, keystorePassword,
-                    privateKeyPassword, ientityProviderMetadataPath);
-            if (CommonHelper.isNotBlank(maximumAuthenticationLifetime)) {
-                cfg.setMaximumAuthenticationLifetime(Integer.parseInt(maximumAuthenticationLifetime));
+        for (int i = 0; i <= MAX_NUM_CLIENTS; i++) {
+            final String keystorePassword = getProperty(SAML_KEYSTORE_PASSWORD.concat(i == 0 ? "" : "." + i));
+            final String privateKeyPassword = getProperty(SAML_PRIVATE_KEY_PASSWORD.concat(i == 0 ? "" : "." + i));
+            final String keystorePath = getProperty(SAML_KEYSTORE_PATH.concat(i == 0 ? "" : "." + i));
+            final String ientityProviderMetadataPath = getProperty(SAML_IDENTITY_PROVIDER_METADATA_PATH.concat(i == 0 ? "" : "." + i));
+            final String maximumAuthenticationLifetime = getProperty(SAML_MAXIMUM_AUTHENTICATION_LIFETIME.concat(i == 0 ? "" : "." + i));
+            final String serviceProviderEntityId = getProperty(SAML_SERVICE_PROVIDER_ENTITY_ID.concat(i == 0 ? "" : "." + i));
+            final String serviceProviderMetadataPath = getProperty(SAML_SERVICE_PROVIDER_METADATA_PATH.concat(i == 0 ? "" : "." + i));
+            
+            if (CommonHelper.isNotBlank(keystorePassword) && CommonHelper.isNotBlank(privateKeyPassword)
+                    && CommonHelper.isNotBlank(keystorePath) && CommonHelper.isNotBlank(ientityProviderMetadataPath)) {
+                final SAML2ClientConfiguration cfg = new SAML2ClientConfiguration(keystorePath, keystorePassword,
+                        privateKeyPassword, ientityProviderMetadataPath);
+                if (CommonHelper.isNotBlank(maximumAuthenticationLifetime)) {
+                    cfg.setMaximumAuthenticationLifetime(Integer.parseInt(maximumAuthenticationLifetime));
+                }
+                if (CommonHelper.isNotBlank(serviceProviderEntityId)) {
+                    cfg.setServiceProviderEntityId(serviceProviderEntityId);
+                }
+                if (CommonHelper.isNotBlank(serviceProviderMetadataPath)) {
+                    cfg.setServiceProviderMetadataPath(serviceProviderMetadataPath);
+                }
+                final SAML2Client saml2Client = new SAML2Client(cfg);
+
+                if (i != 0) {
+                    saml2Client.setName(saml2Client.getName().concat("." + i));
+                }
+                
+                clients.add(saml2Client);
             }
-            if (CommonHelper.isNotBlank(serviceProviderEntityId)) {
-                cfg.setServiceProviderEntityId(serviceProviderEntityId);
-            }
-            if (CommonHelper.isNotBlank(serviceProviderMetadataPath)) {
-                cfg.setServiceProviderMetadataPath(serviceProviderMetadataPath);
-            }
-            final SAML2Client saml2Client = new SAML2Client(cfg);
-            clients.add(saml2Client);
         }
     }
 
     private void tryCreateCasClient(final List<Client> clients) {
-        final String loginUrl = getProperty(CAS_LOGIN_URL);
-        final String protocol = getProperty(CAS_PROTOCOL);
-        if (CommonHelper.isNotBlank(loginUrl)) {
-            final CasClient casClient = new CasClient(loginUrl);
-            if (CommonHelper.isNotBlank(protocol)) {
-                casClient.setCasProtocol(CasClient.CasProtocol.valueOf(protocol));
+        for (int i = 0; i <= MAX_NUM_CLIENTS; i++) {
+            final String loginUrl = getProperty(CAS_LOGIN_URL.concat(i == 0 ? "" : "." + i));
+            final String protocol = getProperty(CAS_PROTOCOL.concat(i == 0 ? "" : "." + i));
+            if (CommonHelper.isNotBlank(loginUrl)) {
+                final CasClient casClient = new CasClient(loginUrl);
+                if (CommonHelper.isNotBlank(protocol)) {
+                    casClient.setCasProtocol(CasClient.CasProtocol.valueOf(protocol));
+                }
+                if (i != 0) {
+                    casClient.setName(casClient.getName().concat("." + i));
+                }
+                clients.add(casClient);
             }
-            clients.add(casClient);
         }
     }
-
+        
     private void tryCreateOidcClient(final List<Client> clients) {
-        final String id = getProperty(OIDC_ID);
-        final String secret = getProperty(OIDC_SECRET);
-        final String discoveryUri = getProperty(OIDC_DISCOVERY_URI);
-        if (CommonHelper.isNotBlank(id) && CommonHelper.isNotBlank(secret) && CommonHelper.isNotBlank(discoveryUri)) {
-            final OidcClient oidcClient = new OidcClient(id, secret, discoveryUri);
-            final String useNonce = getProperty(OIDC_USE_NONCE);
-            if (CommonHelper.isNotBlank(useNonce)) {
-                oidcClient.setUseNonce(Boolean.parseBoolean(useNonce));
+        for (int i = 0; i <= MAX_NUM_CLIENTS; i++) {
+            final String id = getProperty(OIDC_ID.concat(i == 0 ? "" : "." + i));
+            final String secret = getProperty(OIDC_SECRET.concat(i == 0 ? "" : "." + i));
+            final String discoveryUri = getProperty(OIDC_DISCOVERY_URI.concat(i == 0 ? "" : "." + i));
+            if (CommonHelper.isNotBlank(id) && CommonHelper.isNotBlank(secret) && CommonHelper.isNotBlank(discoveryUri)) {
+                final OidcClient oidcClient = new OidcClient(id, secret, discoveryUri);
+                final String useNonce = getProperty(OIDC_USE_NONCE.concat(i == 0 ? "" : "." + i));
+                if (CommonHelper.isNotBlank(useNonce)) {
+                    oidcClient.setUseNonce(Boolean.parseBoolean(useNonce));
+                }
+                final String jwsAlgo = getProperty(OIDC_PREFERRED_JWS_ALGORITHM.concat(i == 0 ? "" : "." + i));
+                if (CommonHelper.isNotBlank(jwsAlgo)) {
+                    oidcClient.setPreferredJwsAlgorithm(JWSAlgorithm.parse(jwsAlgo));
+                }
+                final String maxClockSkew = getProperty(OIDC_MAX_CLOCK_SKEW.concat(i == 0 ? "" : "." + i));
+                if (CommonHelper.isNotBlank(maxClockSkew)) {
+                    oidcClient.setMaxClockSkew(Integer.parseInt(maxClockSkew));
+                }
+                final String clientAuthenticationMethod = getProperty(OIDC_CLIENT_AUTHENTICATION_METHOD.concat(i == 0 ? "" : "." + i));
+                if (CommonHelper.isNotBlank(clientAuthenticationMethod)) {
+                    oidcClient.setClientAuthenticationMethod(ClientAuthenticationMethod.parse(clientAuthenticationMethod));
+                }
+                final String key1 = getProperty(OIDC_CUSTOM_PARAM_KEY1.concat(i == 0 ? "" : "." + i));
+                final String value1 = getProperty(OIDC_CUSTOM_PARAM_VALUE1.concat(i == 0 ? "" : "." + i));
+                if (CommonHelper.isNotBlank(key1)) {
+                    oidcClient.addCustomParam(key1, value1);
+                }
+                final String key2 = getProperty(OIDC_CUSTOM_PARAM_KEY2.concat(i == 0 ? "" : "." + i));
+                final String value2 = getProperty(OIDC_CUSTOM_PARAM_VALUE2.concat(i == 0 ? "" : "." + i));
+                if (CommonHelper.isNotBlank(key2)) {
+                    oidcClient.addCustomParam(key2, value2);
+                }
+
+                if (i != 0) {
+                    oidcClient.setName(oidcClient.getName().concat("." + i));
+                }
+                clients.add(oidcClient);
             }
-            final String jwsAlgo = getProperty(OIDC_PREFERRED_JWS_ALGORITHM);
-            if (CommonHelper.isNotBlank(jwsAlgo)) {
-                oidcClient.setPreferredJwsAlgorithm(JWSAlgorithm.parse(jwsAlgo));
-            }
-            final String maxClockSkew = getProperty(OIDC_MAX_CLOCK_SKEW);
-            if (CommonHelper.isNotBlank(maxClockSkew)) {
-                oidcClient.setMaxClockSkew(Integer.parseInt(maxClockSkew));
-            }
-            final String clientAuthenticationMethod = getProperty(OIDC_CLIENT_AUTHENTICATION_METHOD);
-            if (CommonHelper.isNotBlank(clientAuthenticationMethod)) {
-                oidcClient.setClientAuthenticationMethod(ClientAuthenticationMethod.parse(clientAuthenticationMethod));
-            }
-            final String key1 = getProperty(OIDC_CUSTOM_PARAM_KEY1);
-            final String value1 = getProperty(OIDC_CUSTOM_PARAM_VALUE1);
-            if (CommonHelper.isNotBlank(key1)) {
-                oidcClient.addCustomParam(key1, value1);
-            }
-            final String key2 = getProperty(OIDC_CUSTOM_PARAM_KEY2);
-            final String value2 = getProperty(OIDC_CUSTOM_PARAM_VALUE2);
-            if (CommonHelper.isNotBlank(key2)) {
-                oidcClient.addCustomParam(key2, value2);
-            }
-            clients.add(oidcClient);
         }
     }
 }

--- a/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
+++ b/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
@@ -47,10 +47,14 @@ public final class PropertiesConfigFactoryTests implements TestsConstants {
         properties.put(OIDC_CLIENT_AUTHENTICATION_METHOD, "CLIENT_SECRET_POST");
         properties.put(OIDC_CUSTOM_PARAM_KEY1, KEY);
         properties.put(OIDC_CUSTOM_PARAM_VALUE1, VALUE);
+
+        properties.put(CAS_LOGIN_URL.concat(".1"), CALLBACK_URL);
+        properties.put(CAS_PROTOCOL.concat(".1"), CasClient.CasProtocol.CAS30.toString());
+        
         final PropertiesConfigFactory factory = new PropertiesConfigFactory(CALLBACK_URL, properties);
         final Config config = factory.build();
         final Clients clients = config.getClients();
-        assertEquals(5, clients.getClients().size());
+        assertEquals(6, clients.getClients().size());
         final FacebookClient fbClient = (FacebookClient) clients.findClient("FacebookClient");
         assertEquals(ID, fbClient.getKey());
         assertEquals(SECRET, fbClient.getSecret());
@@ -65,5 +69,8 @@ public final class PropertiesConfigFactoryTests implements TestsConstants {
         final OidcClient oidcClient = (OidcClient) clients.findClient("OidcClient");
         assertNotNull(oidcClient);
         assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_POST.toString(), oidcClient.getClientAuthenticationMethod().toString().toLowerCase());
+
+        final CasClient casClient1 = (CasClient) clients.findClient("CasClient.1");
+        assertEquals(CasClient.CasProtocol.CAS30, casClient1.getCasProtocol());
     }
 }


### PR DESCRIPTION
Closes #522 

OIDC, CAS and SAML2 clients can now be added via enumerated properties. Each category supports the old setting, and is now able to look up properties based on a `PROP_NAME.X` convention where `X` is the index of the property. Client names are handled the same way.

By default, Pac4J shall support upto 10 client configurations enumerated in this fashion. 

Facebook and Twitter clients are left alone. 