### PR TITLE
Fixes NPE in OidcClient when token endpoint auth methods are undefined.

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -283,7 +283,7 @@ public class OidcClient<U extends OidcProfile> extends IndirectClient<OidcCreden
         final List<ClientAuthenticationMethod> methods = getProviderMetadata().getTokenEndpointAuthMethods();
         final ClientAuthenticationMethod method;
 
-        if (!methods.isEmpty()) {
+        if (methods != null && !methods.isEmpty()) {
             if (methods.contains(getClientAuthenticationMethod())) {
                 method = getClientAuthenticationMethod();
             } else {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -283,7 +283,7 @@ public class OidcClient<U extends OidcProfile> extends IndirectClient<OidcCreden
         final List<ClientAuthenticationMethod> methods = getProviderMetadata().getTokenEndpointAuthMethods();
         final ClientAuthenticationMethod method;
 
-        if (methods != null && !methods.isEmpty()) {
+        if (isNotEmpty(methods)) {
             if (methods.contains(getClientAuthenticationMethod())) {
                 method = getClientAuthenticationMethod();
             } else {


### PR DESCRIPTION
The OIDCProviderMetadata class from nimbus/oauth-oidc returns null, rather than an empty list when these are not specified.

	/*
	 * @return The supported token endpoint authentication methods,
	 *         {@code null} if not specified.
	 */
	public List<ClientAuthenticationMethod> getTokenEndpointAuthMethods() {