### PR TITLE
Upgrade oauth-oidc-sdk to 5.8

### DIFF
--- a/pac4j-oidc/pom.xml
+++ b/pac4j-oidc/pom.xml
@@ -13,7 +13,7 @@
 	<name>pac4j for OpenID Connect protocol</name>
 
 	<properties>
-		<oauth-oidc-sdk.version>5.5</oauth-oidc-sdk.version>
+		<oauth-oidc-sdk.version>5.8</oauth-oidc-sdk.version>
 	</properties>
 
 	<dependencies>

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/AzureAdClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/AzureAdClient.java
@@ -1,7 +1,7 @@
 package org.pac4j.oidc.client;
 
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.oauth2.sdk.http.ResourceRetriever;
+import com.nimbusds.jose.util.ResourceRetriever;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
 import org.pac4j.oidc.client.azuread.AzureAdIdTokenValidator;
@@ -14,9 +14,9 @@ import org.pac4j.oidc.profile.AzureAdProfile;
  * authentication, the speciall common-tenant. For a specific tenant, the following discovery URI
  * must be used:
  * {@code https://login.microsoftonline.com/tenantid/.well-known/openid-configuration} or
- * {@code https://login.microsoftonline.com/tenantid/v2.0/.well-known/openid-configuration} for the
- * Azure AD v2.0 preview. Replace {@code tenantid} with the ID of the tenant to authenticate
- * against. To find this ID, fill in your tenant's domain name. Your tenant ID is the UUID in
+ * {@code https://login.microsoftonline.com/tenantid/v2.0/.well-known/openid-configuration} for
+ * Azure AD v2.0. Replace {@code tenantid} with the ID of the tenant to authenticate against. To
+ * find this ID, fill in your tenant's domain name. Your tenant ID is the UUID in
  * {@code authorization_endpoint}.
  * 
  * For authentication against an unknown (or dynamic tenant), use {@code common} as ID.

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.proc.BadJOSEException;
 import org.apache.commons.lang3.StringUtils;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.client.RedirectAction;
@@ -22,7 +20,11 @@ import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.credentials.OidcCredentials;
 import org.pac4j.oidc.profile.OidcProfile;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.ResourceRetriever;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -34,10 +36,8 @@ import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
 import com.nimbusds.oauth2.sdk.auth.ClientSecretPost;
 import com.nimbusds.oauth2.sdk.auth.Secret;
-import com.nimbusds.oauth2.sdk.http.DefaultResourceRetriever;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.http.HTTPResponse;
-import com.nimbusds.oauth2.sdk.http.ResourceRetriever;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -306,7 +306,8 @@ public class OidcClient<U extends OidcProfile> extends IndirectClient<OidcCreden
 
 	protected IDTokenValidator createRSATokenValidator(
 			final JWSAlgorithm jwsAlgorithm, ClientID clientID) throws MalformedURLException {
-		return new IDTokenValidator(getProviderMetadata().getIssuer(), clientID, jwsAlgorithm, getProviderMetadata().getJWKSetURI().toURL());
+		return new IDTokenValidator(getProviderMetadata().getIssuer(), clientID, jwsAlgorithm,
+				getProviderMetadata().getJWKSetURI().toURL(), createResourceRetriever());
 	}
 
 	protected IDTokenValidator createHMACTokenValidator(

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/azuread/AzureAdResourceRetriever.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/azuread/AzureAdResourceRetriever.java
@@ -3,9 +3,9 @@ package org.pac4j.oidc.client.azuread;
 import java.io.IOException;
 import java.net.URL;
 
-import com.nimbusds.oauth2.sdk.http.DefaultResourceRetriever;
-import com.nimbusds.oauth2.sdk.http.Resource;
-import com.nimbusds.oauth2.sdk.http.ResourceRetriever;
+import com.nimbusds.jose.util.DefaultResourceRetriever;
+import com.nimbusds.jose.util.Resource;
+import com.nimbusds.jose.util.ResourceRetriever;
 
 /**
  * Specialized ResourceRetriever which escapes a possibly invalid issuer URI.


### PR DESCRIPTION
This pull request upgrades com.nimbusds:oauth2-oidc-sdk to version 5.8.

In this version, the old ResourceRetriever is deprecated and replaced by a new one. Also, IDTokenValidator can now take a ResourceRetriever in its constructor, allowing it to follow the timeouts set in the client.

I've also updated the AzureADClient's javadoc to reflect the fact that v2 is no longer in preview.