### PR TITLE
Make method public so client outside pac4j can instantiate classes of their own

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -110,7 +110,7 @@ public final class ProfileHelper {
     }
 
     @SuppressWarnings("unchecked")
-	private static UserProfile buildUserProfileByClassCompleteName(final String typedId, final Map<String, Object> attributes,
+	public static UserProfile buildUserProfileByClassCompleteName(final String typedId, final Map<String, Object> attributes,
                                                                    final String completeName)
             throws Exception {
     	ClassLoader tccl = Thread.currentThread().getContextClassLoader();

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/TestCaseProfileHelper.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/TestCaseProfileHelper.java
@@ -60,6 +60,10 @@ public abstract class TestCaseProfileHelper extends TestCase implements TestsCon
         assertNotNull(ProfileHelper.buildProfile(getProfileType() + "#" + STRING_ID, EMPTY_MAP));
     }
     
+    public void testBuildUserProfileByClassCompleteName() throws Exception {
+        assertNotNull(ProfileHelper.buildUserProfileByClassCompleteName(getProfileType() + "#" + STRING_ID, EMPTY_MAP, getProfileClass().getName()));
+    }
+    
     protected abstract String getAttributeName();
     
     public void testBuildProfileOK() {

--- a/pac4j-http/src/test/java/org/pac4j/http/profile/CustomProfileClass.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/profile/CustomProfileClass.java
@@ -1,0 +1,6 @@
+package org.pac4j.http.profile;
+import org.pac4j.http.profile.HttpProfile;
+
+public class CustomProfileClass extends HttpProfile {
+
+}

--- a/pac4j-http/src/test/java/org/pac4j/http/profile/TestCustomProfileHelper.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/profile/TestCustomProfileHelper.java
@@ -1,0 +1,74 @@
+/*
+  Copyright 2012 - 2015 pac4j organization
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package org.pac4j.http.profile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.ProfileHelper;
+import org.pac4j.core.profile.TestCaseProfileHelper;
+import org.pac4j.core.profile.UserProfile;
+
+/**
+ * This class tests the {@link ProfileHelper} class for the {@link HttpProfile}.
+ * 
+ * @author Jerome Leleu
+ * @since 1.4.0
+ */
+public final class TestCustomProfileHelper extends TestCaseProfileHelper {
+    
+    @Override
+    protected Class<? extends CommonProfile> getProfileClass() {
+        return CustomProfileClass.class;
+    }
+    
+    @Override
+    protected String getProfileType() {
+        return "CustomProfileClass";
+    }
+    
+    @Override
+    protected String getAttributeName() {
+        return "whatever";
+    }
+    
+    @Override
+    public void testBuildProfileOK() {
+    	try {
+	        final Map<String, Object> attributes = new HashMap<String, Object>();
+	        attributes.put(getAttributeName(), VALUE);
+	        final UserProfile userProfile = ProfileHelper.buildUserProfileByClassCompleteName(getProfileType() + "#" + STRING_ID, attributes, getProfileClass().getName());
+	        assertNotNull(userProfile);
+	        assertEquals(STRING_ID, userProfile.getId());
+	        assertEquals(getProfileType() + "#" + STRING_ID, userProfile.getTypedId());
+	        final Map<String, Object> attributesProfile = userProfile.getAttributes();
+	        assertEquals(1, attributesProfile.size());
+	        assertEquals(VALUE, attributesProfile.get(getAttributeName()));
+    	} catch (Exception e) {
+    		throw new RuntimeException(e);
+    	}
+    }
+    
+    @Override
+    public void testBuildProfileNoAttribute() {
+    	try {
+    		assertNotNull(ProfileHelper.buildUserProfileByClassCompleteName(getProfileType() + "#" + STRING_ID, EMPTY_MAP, getProfileClass().getName()));
+    	} catch (Exception e) {
+    		throw new RuntimeException(e);
+    	}
+    }
+}

--- a/pac4j-http/src/test/java/org/pac4j/http/profile/TestCustomProfileHelper.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/profile/TestCustomProfileHelper.java
@@ -24,10 +24,10 @@ import org.pac4j.core.profile.TestCaseProfileHelper;
 import org.pac4j.core.profile.UserProfile;
 
 /**
- * This class tests the {@link ProfileHelper} class for the {@link HttpProfile}.
+ * This class tests the {@link ProfileHelper} class for a custom {@link CustomProfileClass}.
  * 
  * @author Jerome Leleu
- * @since 1.4.0
+ * @since 1.8.9
  */
 public final class TestCustomProfileHelper extends TestCaseProfileHelper {
     

--- a/pac4j-http/src/test/java/org/pac4j/http/profile/TestCustomProfileHelper.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/profile/TestCustomProfileHelper.java
@@ -26,7 +26,7 @@ import org.pac4j.core.profile.UserProfile;
 /**
  * This class tests the {@link ProfileHelper} class for a custom {@link CustomProfileClass}.
  * 
- * @author Jerome Leleu
+ * @author Garry Boyce
  * @since 1.8.9
  */
 public final class TestCustomProfileHelper extends TestCaseProfileHelper {


### PR DESCRIPTION
Make method public so client outside pac4j can instantiate classes of their own