### PR TITLE
Do not put 'client_secret' in authentication request

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -246,7 +246,6 @@ public class OidcClient<U extends OidcProfile> extends IndirectClient<OidcCreden
         this.authParams.putAll(getCustomParams());
         // Override with required values
         this.authParams.put("client_id", getClientID());
-        this.authParams.put("client_secret", getSecret());
 
         this._clientID = new ClientID(getClientID());
         this._secret = new Secret(getSecret());


### PR DESCRIPTION
As discussed in #575, the 'client_secret' must not be rendered in the authentication request.