### PR TITLE
Session index added to SAML2Credentials

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -223,6 +223,7 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
     protected SAML2Profile retrieveUserProfile(final SAML2Credentials credentials, final WebContext context) throws RequiresHttpAction {
         final SAML2Profile profile = new SAML2Profile();
         profile.setId(credentials.getNameId().getValue());
+        profile.addAttribute("sessionindex", credentials.getSessionIndex());
         for (final Attribute attribute : credentials.getAttributes()) {
             logger.debug("Processing profile attribute {}", attribute);
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -19,13 +19,16 @@ public class SAML2Credentials extends Credentials {
 
     private NameID nameId;
 
+    private String sessionIndex;
+
     private List<Attribute> attributes;
     
     private Conditions conditions;
 
     public SAML2Credentials(final NameID nameId, final List<Attribute> attributes, final Conditions conditions,
-                            final String clientName) {
+                            final String clientName, final String sessionIndex) {
         this.nameId = nameId;
+        this.sessionIndex = sessionIndex;
         this.attributes = attributes;
         this.conditions = conditions;
         setClientName(clientName);
@@ -33,6 +36,10 @@ public class SAML2Credentials extends Credentials {
 
     public final NameID getNameId() {
         return this.nameId;
+    }
+
+    public final String getSessionIndex() {
+    	return this.sessionIndex;
     }
 
     public final List<Attribute> getAttributes() {
@@ -52,6 +59,7 @@ public class SAML2Credentials extends Credentials {
 
         if (nameId != null ? !nameId.equals(that.nameId) : that.nameId != null) return false;
         if (attributes != null ? !attributes.equals(that.attributes) : that.attributes != null) return false;
+        if (sessionIndex != null ? sessionIndex.equals(that.sessionIndex) : that.sessionIndex != null) return false;
         return !(conditions != null ? !conditions.equals(that.conditions) : that.conditions != null);
 
     }
@@ -60,12 +68,13 @@ public class SAML2Credentials extends Credentials {
     public int hashCode() {
         int result = nameId != null ? nameId.hashCode() : 0;
         result = 31 * result + (attributes != null ? attributes.hashCode() : 0);
+        result = 31 * result + (sessionIndex != null ? sessionIndex.hashCode() : 0);
         result = 31 * result + (conditions != null ? conditions.hashCode() : 0);
         return result;
     }
 
     @Override
     public final String toString() {
-        return "SAMLCredential [nameId=" + this.nameId + ", attributes=" + this.attributes + "]";
+        return "SAMLCredential [nameId=" + this.nameId + ", attributes=" + this.attributes + ", sessionIndex=" + this.sessionIndex + "]";
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -179,7 +179,9 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         List<AuthnStatement> authnStatements = subjectAssertion.getAuthnStatements();
         if(authnStatements != null && authnStatements.size() > 0) {
         	AuthnStatement statement = authnStatements.get(0);
-        	return statement.getSessionIndex();
+        	if(statement != null) {
+        		return statement.getSessionIndex();
+        	}
         }
         return null;
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -144,6 +144,8 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         final NameID nameId = context.getSAMLSubjectNameIdentifierContext().getSAML2SubjectNameID();
         final Assertion subjectAssertion = context.getSubjectAssertion();
 
+        final String sessionIndex = getSessionIndex(subjectAssertion);
+
         final List<Attribute> attributes = new ArrayList<Attribute>();
         for (final AttributeStatement attributeStatement : subjectAssertion.getAttributeStatements()) {
             for (final Attribute attribute : attributeStatement.getAttributes()) {
@@ -164,7 +166,22 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             }
         }
         return new SAML2Credentials(nameId, attributes, subjectAssertion.getConditions(),
-                SAML2Client.class.getSimpleName());
+                SAML2Client.class.getSimpleName(), sessionIndex);
+    }
+
+    /**
+     * Searches the sessionIndex in the assertion
+     * 
+     * @param subjectAssertion assertion from the response
+     * @return the sessionIndex if found in the assertion
+     */
+    private final String getSessionIndex(Assertion subjectAssertion) {
+        List<AuthnStatement> authnStatements = subjectAssertion.getAuthnStatements();
+        if(authnStatements != null && authnStatements.size() > 0) {
+        	AuthnStatement statement = authnStatements.get(0);
+        	return statement.getSessionIndex();
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Session index is taken from SAML2 response. It is added to SAML2Credentials and then to the SAML2Profile as an attribute (however not sure it is a good choice)