### PR TITLE
Enable use of custom ProfileManager implementations in DefaultSecurityLogic

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
@@ -93,7 +93,7 @@ public class DefaultSecurityLogic<R, C extends WebContext> implements SecurityLo
 
                 final boolean loadProfilesFromSession = loadProfilesFromSession(context, currentClients);
                 logger.debug("loadProfilesFromSession: {}", loadProfilesFromSession);
-                final ProfileManager manager = new ProfileManager(context);
+                final ProfileManager manager = getProfileManager(context);
                 List<CommonProfile> profiles = manager.getAll(loadProfilesFromSession);
                 logger.debug("profiles: {}", profiles);
 
@@ -163,6 +163,16 @@ public class DefaultSecurityLogic<R, C extends WebContext> implements SecurityLo
         }
 
         return httpActionAdapter.adapt(action.getCode(), context);
+    }
+
+    /**
+     * Given a webcontext generate a profileManager for it.
+     * Can be overridden for custom profile manager implementations
+     * @param context the web context
+     * @return profile manager implementation built from the context
+     */
+    protected ProfileManager getProfileManager(final C context) {
+        return new ProfileManager(context);
     }
 
     /**


### PR DESCRIPTION
Enable use of custom ProfileManager implementations in DefaultSecurityLogic

Some pac4j platform implementations (for example vertx-pac4j) use custom implementations of ProfileManager. However, the DefaultSecurityLogic appears to provide the implementation they would want to use, if they could inject their own ProfileManagers.

Therefore this change is proposed to use an overridable factory method for a ProfileManager (or subclass) rather than have an inline construction of a ProfileManager. Overriding this method thus enables use of a custom ProfileManager implementation such as that required for vert.x.