### PR TITLE
More generic getPath(), fixes #613

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/J2EContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/J2EContext.java
@@ -213,8 +213,25 @@ public class J2EContext implements WebContext {
         this.response.addCookie(c);
     }
 
+    /**
+     * This is not implemented using {@link HttpServletRequest#getServletPath()} or
+     * {@link HttpServletRequest#getPathInfo()} because they both have strange behaviours
+     * in different contexts (inside servlets, inside filters, various container implementation, etc)
+     */
     @Override
     public String getPath() {
-        return request.getServletPath();
+        String fullPath = request.getRequestURI();
+        // it shouldn't be null, but in case it is, it's better to return empty string
+        if (fullPath == null) {
+            return "";
+        } else {
+            String context = request.getContextPath();
+            // this one shouldn't be null either, but in case it is, then let's consider it is empty
+            if (context != null) {
+                return fullPath.substring(context.length());
+            } else {
+                return fullPath;
+            }
+        }
     }
 }


### PR DESCRIPTION
Here is a fix for #613.

The ilea is to prefer to compute the request path based on the URI and the context instead of relying on the overly complex servlet's API.