### PR TITLE
Enable customisation of profile manager creation without inheriting security logic class

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.function.Function;
 
 import static org.pac4j.core.util.CommonHelper.*;
 
@@ -54,6 +55,8 @@ public class DefaultSecurityLogic<R, C extends WebContext> implements SecurityLo
     private AuthorizationChecker authorizationChecker = new DefaultAuthorizationChecker();
 
     private MatchingChecker matchingChecker = new DefaultMatchingChecker();
+
+    private Function<C, ProfileManager> profileManagerFactory = context -> new ProfileManager(context);
 
     private boolean saveProfileInSession;
 
@@ -174,7 +177,7 @@ public class DefaultSecurityLogic<R, C extends WebContext> implements SecurityLo
      * @return profile manager implementation built from the context
      */
     protected ProfileManager getProfileManager(final C context) {
-        return new ProfileManager(context);
+        return profileManagerFactory.apply(context);
     }
 
     /**
@@ -293,5 +296,13 @@ public class DefaultSecurityLogic<R, C extends WebContext> implements SecurityLo
 
     public void setSaveProfileInSession(final boolean saveProfileInSession) {
         this.saveProfileInSession = saveProfileInSession;
+    }
+
+    public Function<C, ProfileManager> getProfileManagerFactory() {
+        return profileManagerFactory;
+    }
+
+    public void setProfileManagerFactory(final Function<C, ProfileManager> factory) {
+        this.profileManagerFactory = factory;
     }
 }


### PR DESCRIPTION
This is a PR to show how to enable customization of the profile manager creation without having to extend this class, by offering injection of a function for creating a profile manager for a given WebContext.

If this is accepted I'll submit analogous PRs for other components which need the same behaviour (e.g. callback logic).

The advantage of this approach is that (assuming Java 8) it enables customization of ProfileManager creation without having to extend thse classes, permitting particular implementations of Pac4j on different platforms to customize their profile management without hacking the webcontext behaviour or having to inherit classes just to extend one method.