### PR TITLE
Generic OAuth2.0 Clients

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
@@ -5,9 +5,9 @@ import com.github.scribejava.core.builder.api.BaseApi;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.oauth.OAuth20Service;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.AttributesDefinition;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.profile.JsonHelper;
-import org.pac4j.oauth.profile.generic.GenericAttributesDefinition;
 import org.pac4j.oauth.profile.generic.GenericOAuth20Profile;
 import org.pac4j.scribe.builder.api.GenericApi20;
 
@@ -20,11 +20,10 @@ import org.pac4j.scribe.builder.api.GenericApi20;
  */
 public class GenericOAuth20Client extends BaseOAuth20Client<GenericOAuth20Profile> {
 
-    protected String baseUrl = null;
-    protected String authEndpoint = null;
-    protected String tokenEndpoint = null;
-    protected String profileEndpoint = null;
-    protected GenericAttributesDefinition attributesDefinition = null;
+    protected String authUrl = null;
+    protected String tokenUrl = null;
+    protected String profileUrl = null;
+    protected AttributesDefinition attributesDefinition = null;
 
     protected String scope = null;
 
@@ -32,78 +31,58 @@ public class GenericOAuth20Client extends BaseOAuth20Client<GenericOAuth20Profil
     }
 
     /**
-     * Convenience constructor. Uses {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     * Convenience constructor. Uses {@link org.pac4j.oauth.profile.generic.DefaultGenericAttributesDefinition}
      * for the attributes definition
      */
     public GenericOAuth20Client(final String key,
                                 final String secret,
-                                final String baseUrl,
-                                final String authEndpoint,
-                                final String tokenEndpoint,
-                                final String profileEndpoint,
+                                final String authUrl,
+                                final String tokenUrl,
+                                final String profileUrl,
                                 final String scope) {
         setKey(key);
         setSecret(secret);
-        this.baseUrl = baseUrl;
-        this.authEndpoint = authEndpoint;
-        this.tokenEndpoint = tokenEndpoint;
-        this.profileEndpoint = profileEndpoint;
+        this.authUrl = authUrl;
+        this.tokenUrl = tokenUrl;
+        this.profileUrl = profileUrl;
         this.scope = scope;
     }
 
     /**
-     * Convenience constructor. Allows for a user-defined GenericAttributesDefinition to be passed in.
-     * See {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     * Convenience constructor. Allows for a user-defined AttributesDefinition to be passed in.
      */
     public GenericOAuth20Client(final String key,
                                 final String secret,
-                                final String baseUrl,
-                                final String authEndpoint,
-                                final String tokenEndpoint,
-                                final String profileEndpoint,
+                                final String authUrl,
+                                final String tokenUrl,
+                                final String profileUrl,
                                 final String scope,
-                                final GenericAttributesDefinition attributes) {
+                                final AttributesDefinition attributes) {
         setKey(key);
         setSecret(secret);
-        this.baseUrl = baseUrl;
-        this.authEndpoint = authEndpoint;
-        this.tokenEndpoint = tokenEndpoint;
-        this.profileEndpoint = profileEndpoint;
+        this.authUrl = authUrl;
+        this.tokenUrl = tokenUrl;
+        this.profileUrl = profileUrl;
         this.scope = scope;
         this.attributesDefinition = attributes;
     }
 
     @Override
     protected void internalInit(final WebContext context) {
-        CommonHelper.assertNotNull("baseUrl", this.baseUrl);
-        CommonHelper.assertNotBlank("authEndpoint", this.authEndpoint);
-        CommonHelper.assertNotBlank("tokenEndpoint", this.tokenEndpoint);
-        CommonHelper.assertNotBlank("profileEndpoint", this.profileEndpoint);
-        CommonHelper.assertNotNull("scope", this.scope);
+        CommonHelper.assertNotBlank("authEndpoint", this.authUrl);
+        CommonHelper.assertNotBlank("tokenEndpoint", this.tokenUrl);
+        CommonHelper.assertNotBlank("profileEndpoint", this.profileUrl);
         super.internalInit(context);
     }
 
     @Override
     protected BaseApi<OAuth20Service> getApi() {
-        return new GenericApi20(baseUrl, authEndpoint, tokenEndpoint);
-    }
-
-    @Override
-    protected String getOAuthScope() {
-        return this.scope;
-    }
-
-    public String getScope() {
-        return this.scope;
-    }
-
-    public void setScope(final String scope) {
-        this.scope = scope;
+        return new GenericApi20(authUrl, tokenUrl);
     }
 
     @Override
     protected String getProfileUrl(final OAuth2AccessToken accessToken) {
-        return baseUrl + profileEndpoint;
+        return profileUrl;
     }
 
     @Override
@@ -120,5 +99,45 @@ public class GenericOAuth20Client extends BaseOAuth20Client<GenericOAuth20Profil
             }
         }
         return profile;
+    }
+
+    public String getAuthUrl() {
+        return authUrl;
+    }
+
+    public void setAuthUrl(String authUrl) {
+        this.authUrl = authUrl;
+    }
+
+    public String getTokenUrl() {
+        return tokenUrl;
+    }
+
+    public void setTokenUrl(String tokenUrl) {
+        this.tokenUrl = tokenUrl;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public AttributesDefinition getAttributesDefinition() {
+        return attributesDefinition;
+    }
+
+    public void setAttributesDefinition(AttributesDefinition attributesDefinition) {
+        this.attributesDefinition = attributesDefinition;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
@@ -1,0 +1,124 @@
+package org.pac4j.oauth.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.scribejava.core.builder.api.BaseApi;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oauth.profile.JsonHelper;
+import org.pac4j.oauth.profile.generic.GenericAttributesDefinition;
+import org.pac4j.oauth.profile.generic.GenericOAuth20Profile;
+import org.pac4j.scribe.builder.api.GenericApi20;
+
+/**
+ * <p>This class is the OAuth client to authenticate users using OAuth protocol version 2.0.</p>
+ * <p>It returns a {@link org.pac4j.oauth.profile.generic.GenericOAuth20Profile}.</p>
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class GenericOAuth20Client extends BaseOAuth20Client<GenericOAuth20Profile> {
+
+    protected String baseUrl = null;
+    protected String authEndpoint = null;
+    protected String tokenEndpoint = null;
+    protected String profileEndpoint = null;
+    protected GenericAttributesDefinition attributesDefinition = null;
+
+    protected String scope = null;
+
+    public GenericOAuth20Client() {
+    }
+
+    /**
+     * Convenience constructor. Uses {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     * for the attributes definition
+     */
+    public GenericOAuth20Client(final String key,
+                                final String secret,
+                                final String baseUrl,
+                                final String authEndpoint,
+                                final String tokenEndpoint,
+                                final String profileEndpoint,
+                                final String scope) {
+        setKey(key);
+        setSecret(secret);
+        this.baseUrl = baseUrl;
+        this.authEndpoint = authEndpoint;
+        this.tokenEndpoint = tokenEndpoint;
+        this.profileEndpoint = profileEndpoint;
+        this.scope = scope;
+    }
+
+    /**
+     * Convenience constructor. Allows for a user-defined GenericAttributesDefinition to be passed in.
+     * See {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     */
+    public GenericOAuth20Client(final String key,
+                                final String secret,
+                                final String baseUrl,
+                                final String authEndpoint,
+                                final String tokenEndpoint,
+                                final String profileEndpoint,
+                                final String scope,
+                                final GenericAttributesDefinition attributes) {
+        setKey(key);
+        setSecret(secret);
+        this.baseUrl = baseUrl;
+        this.authEndpoint = authEndpoint;
+        this.tokenEndpoint = tokenEndpoint;
+        this.profileEndpoint = profileEndpoint;
+        this.scope = scope;
+        this.attributesDefinition = attributes;
+    }
+
+    @Override
+    protected void internalInit(final WebContext context) {
+        CommonHelper.assertNotNull("baseUrl", this.baseUrl);
+        CommonHelper.assertNotBlank("authEndpoint", this.authEndpoint);
+        CommonHelper.assertNotBlank("tokenEndpoint", this.tokenEndpoint);
+        CommonHelper.assertNotBlank("profileEndpoint", this.profileEndpoint);
+        CommonHelper.assertNotNull("scope", this.scope);
+        super.internalInit(context);
+    }
+
+    @Override
+    protected BaseApi<OAuth20Service> getApi() {
+        return new GenericApi20(baseUrl, authEndpoint, tokenEndpoint);
+    }
+
+    @Override
+    protected String getOAuthScope() {
+        return this.scope;
+    }
+
+    public String getScope() {
+        return this.scope;
+    }
+
+    public void setScope(final String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    protected String getProfileUrl(final OAuth2AccessToken accessToken) {
+        return baseUrl + profileEndpoint;
+    }
+
+    @Override
+    protected GenericOAuth20Profile extractUserProfile(String body) {
+        final GenericOAuth20Profile profile = new GenericOAuth20Profile();
+        if (attributesDefinition != null) {
+            profile.setAttributesDefinition(attributesDefinition);
+        }
+        final JsonNode json = JsonHelper.getFirstNode(body);
+        if (json != null) {
+            profile.setId(JsonHelper.getElement(json, "id"));
+            for (final String attribute : profile.getAttributesDefinition().getPrimaryAttributes()) {
+                profile.addAttribute(attribute, JsonHelper.getElement(json, attribute));
+            }
+        }
+        return profile;
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20StateClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20StateClient.java
@@ -1,0 +1,118 @@
+package org.pac4j.oauth.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.scribejava.core.builder.api.BaseApi;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oauth.profile.JsonHelper;
+import org.pac4j.oauth.profile.generic.GenericAttributesDefinition;
+import org.pac4j.oauth.profile.generic.GenericOAuth20Profile;
+import org.pac4j.scribe.builder.api.GenericApi20;
+
+/**
+ * <p>This class is the OAuth state client to authenticate users using OAuth protocol version 2.0.</p>
+ * <p>It returns a {@link org.pac4j.oauth.profile.generic.GenericOAuth20Profile}.</p>
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class GenericOAuth20StateClient extends BaseOAuth20StateClient<GenericOAuth20Profile> {
+
+    protected String baseUrl = null;
+    protected String authEndpoint = null;
+    protected String tokenEndpoint = null;
+    protected String profileEndpoint = null;
+    protected GenericAttributesDefinition attributesDefinition = null;
+
+    protected String scope = null;
+
+    public GenericOAuth20StateClient() {
+    }
+
+    /**
+     * Convenience constructor. Uses {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     * for the attributes definition
+     */
+    public GenericOAuth20StateClient(final String key,
+                                final String secret,
+                                final String baseUrl,
+                                final String authEndpoint,
+                                final String tokenEndpoint,
+                                final String profileEndpoint,
+                                final String scope) {
+        setKey(key);
+        setSecret(secret);
+        this.baseUrl = baseUrl;
+        this.authEndpoint = authEndpoint;
+        this.tokenEndpoint = tokenEndpoint;
+        this.profileEndpoint = profileEndpoint;
+        this.scope = scope;
+    }
+
+    /**
+     * Convenience constructor. Allows for a user-defined GenericAttributesDefinition to be passed in.
+     * See {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     */
+    public GenericOAuth20StateClient(final String key,
+                                final String secret,
+                                final String baseUrl,
+                                final String authEndpoint,
+                                final String tokenEndpoint,
+                                final String profileEndpoint,
+                                final String scope,
+                                final GenericAttributesDefinition attributes) {
+        setKey(key);
+        setSecret(secret);
+        this.baseUrl = baseUrl;
+        this.authEndpoint = authEndpoint;
+        this.tokenEndpoint = tokenEndpoint;
+        this.profileEndpoint = profileEndpoint;
+        this.scope = scope;
+        this.attributesDefinition = attributes;
+    }
+
+    @Override
+    protected void internalInit(final WebContext context) {
+        CommonHelper.assertNotNull("baseUrl", this.baseUrl);
+        CommonHelper.assertNotBlank("authEndpoint", this.authEndpoint);
+        CommonHelper.assertNotBlank("tokenEndpoint", this.tokenEndpoint);
+        CommonHelper.assertNotBlank("profileEndpoint", this.profileEndpoint);
+        super.internalInit(context);
+    }
+
+    @Override
+    protected BaseApi<OAuth20Service> getApi() {
+        return new GenericApi20(baseUrl, authEndpoint, tokenEndpoint);
+    }
+
+    public String getScope() {
+        return this.scope;
+    }
+
+    public void setScope(final String scope) {
+        this.scope = scope;
+    }
+
+    @Override
+    protected String getProfileUrl(final OAuth2AccessToken accessToken) {
+        return baseUrl + profileEndpoint;
+    }
+
+    @Override
+    protected GenericOAuth20Profile extractUserProfile(String body) {
+        final GenericOAuth20Profile profile = new GenericOAuth20Profile();
+        if (attributesDefinition != null) {
+            profile.setAttributesDefinition(attributesDefinition);
+        }
+        final JsonNode json = JsonHelper.getFirstNode(body);
+        if (json != null) {
+            profile.setId(JsonHelper.getElement(json, "id"));
+            for (final String attribute : profile.getAttributesDefinition().getPrimaryAttributes()) {
+                profile.addAttribute(attribute, JsonHelper.getElement(json, attribute));
+            }
+        }
+        return profile;
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20StateClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20StateClient.java
@@ -5,9 +5,9 @@ import com.github.scribejava.core.builder.api.BaseApi;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.oauth.OAuth20Service;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.AttributesDefinition;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.profile.JsonHelper;
-import org.pac4j.oauth.profile.generic.GenericAttributesDefinition;
 import org.pac4j.oauth.profile.generic.GenericOAuth20Profile;
 import org.pac4j.scribe.builder.api.GenericApi20;
 
@@ -20,11 +20,10 @@ import org.pac4j.scribe.builder.api.GenericApi20;
  */
 public class GenericOAuth20StateClient extends BaseOAuth20StateClient<GenericOAuth20Profile> {
 
-    protected String baseUrl = null;
-    protected String authEndpoint = null;
-    protected String tokenEndpoint = null;
-    protected String profileEndpoint = null;
-    protected GenericAttributesDefinition attributesDefinition = null;
+    protected String authUrl = null;
+    protected String tokenUrl = null;
+    protected String profileUrl = null;
+    protected AttributesDefinition attributesDefinition = null;
 
     protected String scope = null;
 
@@ -32,72 +31,58 @@ public class GenericOAuth20StateClient extends BaseOAuth20StateClient<GenericOAu
     }
 
     /**
-     * Convenience constructor. Uses {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     * Convenience constructor. Uses {@link org.pac4j.oauth.profile.generic.DefaultGenericAttributesDefinition}
      * for the attributes definition
      */
     public GenericOAuth20StateClient(final String key,
                                 final String secret,
-                                final String baseUrl,
-                                final String authEndpoint,
-                                final String tokenEndpoint,
-                                final String profileEndpoint,
+                                final String authUrl,
+                                final String tokenUrl,
+                                final String profileUrl,
                                 final String scope) {
         setKey(key);
         setSecret(secret);
-        this.baseUrl = baseUrl;
-        this.authEndpoint = authEndpoint;
-        this.tokenEndpoint = tokenEndpoint;
-        this.profileEndpoint = profileEndpoint;
+        this.authUrl = authUrl;
+        this.tokenUrl = tokenUrl;
+        this.profileUrl = profileUrl;
         this.scope = scope;
     }
 
     /**
-     * Convenience constructor. Allows for a user-defined GenericAttributesDefinition to be passed in.
-     * See {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     * Convenience constructor. Allows for a user-defined AttributesDefinition to be passed in.
      */
     public GenericOAuth20StateClient(final String key,
                                 final String secret,
-                                final String baseUrl,
-                                final String authEndpoint,
-                                final String tokenEndpoint,
-                                final String profileEndpoint,
+                                final String authUrl,
+                                final String tokenUrl,
+                                final String profileUrl,
                                 final String scope,
-                                final GenericAttributesDefinition attributes) {
+                                final AttributesDefinition attributes) {
         setKey(key);
         setSecret(secret);
-        this.baseUrl = baseUrl;
-        this.authEndpoint = authEndpoint;
-        this.tokenEndpoint = tokenEndpoint;
-        this.profileEndpoint = profileEndpoint;
+        this.authUrl = authUrl;
+        this.tokenUrl = tokenUrl;
+        this.profileUrl = profileUrl;
         this.scope = scope;
         this.attributesDefinition = attributes;
     }
 
     @Override
     protected void internalInit(final WebContext context) {
-        CommonHelper.assertNotNull("baseUrl", this.baseUrl);
-        CommonHelper.assertNotBlank("authEndpoint", this.authEndpoint);
-        CommonHelper.assertNotBlank("tokenEndpoint", this.tokenEndpoint);
-        CommonHelper.assertNotBlank("profileEndpoint", this.profileEndpoint);
+        CommonHelper.assertNotBlank("authEndpoint", this.authUrl);
+        CommonHelper.assertNotBlank("tokenEndpoint", this.tokenUrl);
+        CommonHelper.assertNotBlank("profileEndpoint", this.profileUrl);
         super.internalInit(context);
     }
 
     @Override
     protected BaseApi<OAuth20Service> getApi() {
-        return new GenericApi20(baseUrl, authEndpoint, tokenEndpoint);
-    }
-
-    public String getScope() {
-        return this.scope;
-    }
-
-    public void setScope(final String scope) {
-        this.scope = scope;
+        return new GenericApi20(authUrl, tokenUrl);
     }
 
     @Override
     protected String getProfileUrl(final OAuth2AccessToken accessToken) {
-        return baseUrl + profileEndpoint;
+        return profileUrl;
     }
 
     @Override
@@ -114,5 +99,45 @@ public class GenericOAuth20StateClient extends BaseOAuth20StateClient<GenericOAu
             }
         }
         return profile;
+    }
+
+    public String getAuthUrl() {
+        return authUrl;
+    }
+
+    public void setAuthUrl(String authUrl) {
+        this.authUrl = authUrl;
+    }
+
+    public String getTokenUrl() {
+        return tokenUrl;
+    }
+
+    public void setTokenUrl(String tokenUrl) {
+        this.tokenUrl = tokenUrl;
+    }
+
+    public String getProfileUrl() {
+        return profileUrl;
+    }
+
+    public void setProfileUrl(String profileUrl) {
+        this.profileUrl = profileUrl;
+    }
+
+    public AttributesDefinition getAttributesDefinition() {
+        return attributesDefinition;
+    }
+
+    public void setAttributesDefinition(AttributesDefinition attributesDefinition) {
+        this.attributesDefinition = attributesDefinition;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/DefaultGenericAttributesDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/DefaultGenericAttributesDefinition.java
@@ -9,19 +9,19 @@ import org.pac4j.core.profile.converter.Converters;
  * @author aherrick
  * @since 1.9.2
  */
-public class GenericAttributesDefinition extends AttributesDefinition {
+public class DefaultGenericAttributesDefinition extends AttributesDefinition {
 
-    public final String EMAIL = "email";
-    public final String FIRST_NAME = "first_name";
-    public final String FAMILY_NAME = "family_name";
-    public final String DISPLAY_NAME = "display_name";
-    public final String GENDER = "gender";
-    public final String LOCALE = "locale";
-    public final String PICTURE_URL = "picture_url";
-    public final String PROFILE_URL = "profile_url";
-    public final String LOCATION = "location";
+    public static final String EMAIL = "email";
+    public static final String FIRST_NAME = "first_name";
+    public static final String FAMILY_NAME = "family_name";
+    public static final String DISPLAY_NAME = "display_name";
+    public static final String GENDER = "gender";
+    public static final String LOCALE = "locale";
+    public static final String PICTURE_URL = "picture_url";
+    public static final String PROFILE_URL = "profile_url";
+    public static final String LOCATION = "location";
 
-    public GenericAttributesDefinition() {
+    public DefaultGenericAttributesDefinition() {
         primary(EMAIL, Converters.STRING);
         primary(FIRST_NAME, Converters.STRING);
         primary(FAMILY_NAME, Converters.STRING);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericAttributesDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericAttributesDefinition.java
@@ -1,0 +1,35 @@
+package org.pac4j.oauth.profile.generic;
+
+import org.pac4j.core.profile.AttributesDefinition;
+import org.pac4j.core.profile.converter.Converters;
+
+/**
+ * Default attribute definition of the GenericOAuth20Profile
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class GenericAttributesDefinition extends AttributesDefinition {
+
+    public final String EMAIL = "email";
+    public final String FIRST_NAME = "first_name";
+    public final String FAMILY_NAME = "family_name";
+    public final String DISPLAY_NAME = "display_name";
+    public final String GENDER = "gender";
+    public final String LOCALE = "locale";
+    public final String PICTURE_URL = "picture_url";
+    public final String PROFILE_URL = "profile_url";
+    public final String LOCATION = "location";
+
+    public GenericAttributesDefinition() {
+        primary(EMAIL, Converters.STRING);
+        primary(FIRST_NAME, Converters.STRING);
+        primary(FAMILY_NAME, Converters.STRING);
+        primary(DISPLAY_NAME, Converters.STRING);
+        primary(GENDER, Converters.GENDER);
+        primary(LOCALE, Converters.LOCALE);
+        primary(PICTURE_URL, Converters.URL);
+        primary(PROFILE_URL, Converters.URL);
+        primary(EMAIL, Converters.STRING);
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericOAuth20Profile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericOAuth20Profile.java
@@ -1,10 +1,8 @@
 package org.pac4j.oauth.profile.generic;
 
-import org.pac4j.core.context.Pac4jConstants;
-import org.pac4j.core.profile.Gender;
-import org.pac4j.oauth.profile.OAuth20Profile;
+import org.pac4j.core.profile.AttributesDefinition;
 
-import java.util.Locale;
+import org.pac4j.oauth.profile.OAuth20Profile;
 
 /**
  * <p>This is the user profile for the generic OAuth 2.0 client.</p>
@@ -15,75 +13,19 @@ import java.util.Locale;
  */
 public class GenericOAuth20Profile extends OAuth20Profile {
 
-    private transient GenericAttributesDefinition attributes = new GenericAttributesDefinition();
+    private transient AttributesDefinition attributes = new DefaultGenericAttributesDefinition();
 
     @Override
-    public GenericAttributesDefinition getAttributesDefinition() {
+    public AttributesDefinition getAttributesDefinition() {
         return attributes;
     }
 
     /**
      * Used to set a custom AttributesDefinition.
-     * Custom definition must extend {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
      *
      * @param attributes
      */
-    public void setAttributesDefinition(GenericAttributesDefinition attributes) {
+    public void setAttributesDefinition(AttributesDefinition attributes) {
         this.attributes = attributes;
-    }
-
-    @Override
-    public String getEmail() {
-        return (String) getAttribute(attributes.EMAIL);
-    }
-
-    @Override
-    public String getFirstName() {
-        return (String) getAttribute(attributes.FIRST_NAME);
-    }
-
-    @Override
-    public String getFamilyName() {
-        return (String) getAttribute(attributes.FAMILY_NAME);
-    }
-
-    @Override
-    public String getDisplayName() {
-        return (String) getAttribute(attributes.DISPLAY_NAME);
-    }
-
-    @Override
-    public String getUsername() {
-        return (String) getAttribute(Pac4jConstants.USERNAME);
-    }
-
-    @Override
-    public Gender getGender() {
-        final Gender gender = (Gender) getAttribute(attributes.GENDER);
-        if (gender == null) {
-            return Gender.UNSPECIFIED;
-        } else {
-            return gender;
-        }
-    }
-
-    @Override
-    public Locale getLocale() {
-        return (Locale) getAttribute(attributes.GENDER);
-    }
-
-    @Override
-    public String getPictureUrl() {
-        return (String) getAttribute(attributes.PICTURE_URL);
-    }
-
-    @Override
-    public String getProfileUrl() {
-        return (String) getAttribute(attributes.PROFILE_URL);
-    }
-
-    @Override
-    public String getLocation() {
-        return (String) getAttribute(attributes.LOCATION);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericOAuth20Profile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericOAuth20Profile.java
@@ -1,0 +1,89 @@
+package org.pac4j.oauth.profile.generic;
+
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.profile.Gender;
+import org.pac4j.oauth.profile.OAuth20Profile;
+
+import java.util.Locale;
+
+/**
+ * <p>This is the user profile for the generic OAuth 2.0 client.</p>
+ * <p>It is returned by the {@link org.pac4j.oauth.client.GenericOAuth20Client}  </p>
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class GenericOAuth20Profile extends OAuth20Profile {
+
+    private transient GenericAttributesDefinition attributes = new GenericAttributesDefinition();
+
+    @Override
+    public GenericAttributesDefinition getAttributesDefinition() {
+        return attributes;
+    }
+
+    /**
+     * Used to set a custom AttributesDefinition.
+     * Custom definition must extend {@link org.pac4j.oauth.profile.generic.GenericAttributesDefinition}
+     *
+     * @param attributes
+     */
+    public void setAttributesDefinition(GenericAttributesDefinition attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) getAttribute(attributes.EMAIL);
+    }
+
+    @Override
+    public String getFirstName() {
+        return (String) getAttribute(attributes.FIRST_NAME);
+    }
+
+    @Override
+    public String getFamilyName() {
+        return (String) getAttribute(attributes.FAMILY_NAME);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return (String) getAttribute(attributes.DISPLAY_NAME);
+    }
+
+    @Override
+    public String getUsername() {
+        return (String) getAttribute(Pac4jConstants.USERNAME);
+    }
+
+    @Override
+    public Gender getGender() {
+        final Gender gender = (Gender) getAttribute(attributes.GENDER);
+        if (gender == null) {
+            return Gender.UNSPECIFIED;
+        } else {
+            return gender;
+        }
+    }
+
+    @Override
+    public Locale getLocale() {
+        return (Locale) getAttribute(attributes.GENDER);
+    }
+
+    @Override
+    public String getPictureUrl() {
+        return (String) getAttribute(attributes.PICTURE_URL);
+    }
+
+    @Override
+    public String getProfileUrl() {
+        return (String) getAttribute(attributes.PROFILE_URL);
+    }
+
+    @Override
+    public String getLocation() {
+        return (String) getAttribute(attributes.LOCATION);
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/GenericApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/GenericApi20.java
@@ -1,0 +1,46 @@
+package org.pac4j.scribe.builder.api;
+
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.utils.OAuthEncoder;
+import com.github.scribejava.core.model.OAuthConfig;
+
+/**
+ * OAuth API class for the GenericOAuth20Client
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class GenericApi20 extends DefaultApi20 {
+
+    private final static String AUTHORIZATION_URL = "%s%s?response_type=code&client_id=%s&redirect_uri=%s&scope=%s";
+
+    protected final String baseUrl;
+    protected final String authEndpoint;
+    protected final String tokenEndpoint;
+
+    public GenericApi20(String baseUrl, String authEndpoint, String tokenEndpoint) {
+        this.baseUrl = baseUrl;
+        this.authEndpoint = authEndpoint;
+        this.tokenEndpoint = tokenEndpoint;
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.POST;
+    }
+
+    public String getAccessTokenEndpoint() {
+        return baseUrl + tokenEndpoint;
+    }
+
+    @Override
+    public String getAuthorizationUrl(final OAuthConfig config) {
+        String url = String.format(AUTHORIZATION_URL, baseUrl, authEndpoint, config.getApiKey(), OAuthEncoder.encode(config.getCallback()),
+                                   OAuthEncoder.encode(config.getScope()));
+        if (config.getState() != null) {
+            url += "&state=" + OAuthEncoder.encode(config.getState());
+        }
+        return url;
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/GenericApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/GenericApi20.java
@@ -13,16 +13,14 @@ import com.github.scribejava.core.model.OAuthConfig;
  */
 public class GenericApi20 extends DefaultApi20 {
 
-    private final static String AUTHORIZATION_URL = "%s%s?response_type=code&client_id=%s&redirect_uri=%s&scope=%s";
+    private final static String AUTHORIZATION_URL = "%s?response_type=code&client_id=%s&redirect_uri=%s&scope=%s";
 
-    protected final String baseUrl;
-    protected final String authEndpoint;
-    protected final String tokenEndpoint;
+    protected final String authUrl;
+    protected final String tokenUrl;
 
-    public GenericApi20(String baseUrl, String authEndpoint, String tokenEndpoint) {
-        this.baseUrl = baseUrl;
-        this.authEndpoint = authEndpoint;
-        this.tokenEndpoint = tokenEndpoint;
+    public GenericApi20(String authUrl, String tokenUrl) {
+        this.authUrl = authUrl;
+        this.tokenUrl = tokenUrl;
     }
 
     @Override
@@ -31,12 +29,12 @@ public class GenericApi20 extends DefaultApi20 {
     }
 
     public String getAccessTokenEndpoint() {
-        return baseUrl + tokenEndpoint;
+        return tokenUrl;
     }
 
     @Override
     public String getAuthorizationUrl(final OAuthConfig config) {
-        String url = String.format(AUTHORIZATION_URL, baseUrl, authEndpoint, config.getApiKey(), OAuthEncoder.encode(config.getCallback()),
+        String url = String.format(AUTHORIZATION_URL, authUrl, config.getApiKey(), OAuthEncoder.encode(config.getCallback()),
                                    OAuthEncoder.encode(config.getScope()));
         if (config.getState() != null) {
             url += "&state=" + OAuthEncoder.encode(config.getState());

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGeneric20Client.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGeneric20Client.java
@@ -1,0 +1,102 @@
+package org.pac4j.oauth.run;
+
+import java.util.Date;
+
+import org.pac4j.oauth.profile.github.GitHubAttributesDefinition;
+import org.pac4j.oauth.profile.github.GitHubPlan;
+import org.pac4j.oauth.profile.github.GitHubProfile;
+import com.esotericsoftware.kryo.Kryo;
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.Gender;
+import org.pac4j.core.profile.ProfileHelper;
+import org.pac4j.core.run.RunClient;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oauth.client.GenericOAuth20Client;
+import org.pac4j.oauth.profile.generic.GenericOAuth20Profile;
+import static org.junit.Assert.*;
+
+/**
+ * Test class for {@link GenericOAuth20StateClient}
+ * Connects with Google for testing
+ * @see RunGoogle2Client
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class RunGeneric20Client extends RunClient {
+
+    public static void main(String[] args) throws Exception {
+        new RunGoogle2Client().run();
+    }
+
+    @Override
+    protected String getLogin() {
+        return "testscribeup@gmail.com";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "testpwdscribeup91";
+    }
+
+    @Override
+    protected IndirectClient getClient() {
+        final GenericOAuth20Client client = new GenericOAuth20Client();
+        client.setAttributesDefinition(new GitHubAttributesDefinition());
+        client.setAuthUrl("https://github.com/login/oauth/authorize");
+        client.setTokenUrl("https://github.com/login/oauth/access_token");
+        client.setProfileUrl("https://api.github.com/user");
+        client.setKey("62374f5573a89a8f9900");
+        client.setSecret("01dd26d60447677ceb7399fb4c744f545bb86359");
+        client.setCallbackUrl(PAC4J_BASE_URL);
+        client.setScope("user");
+        return client;
+    }
+
+    @Override
+    protected void registerForKryo(final Kryo kryo) {
+        kryo.register(GenericOAuth20Profile.class);
+    }
+
+    @Override
+    protected boolean canCancel() {
+        return true;
+    }
+
+    @Override
+    protected void verifyProfile(CommonProfile userProfile) {
+        final GenericOAuth20Profile profile = (GenericOAuth20Profile) userProfile;
+        profile.setAttributesDefinition(new GitHubAttributesDefinition());
+        assertEquals("1412558", profile.getId());
+        assertEquals(GitHubProfile.class.getName() + CommonProfile.SEPARATOR + "1412558", profile.getTypedId());
+        assertTrue(ProfileHelper.isTypedIdOf(profile.getTypedId(), GitHubProfile.class));
+        assertTrue(CommonHelper.isNotBlank(profile.getAccessToken()));
+        assertCommonProfile(userProfile, "testscribeup@gmail.com", null, null, "Test", "testscribeup",
+                Gender.UNSPECIFIED, null, "https://avatars.githubusercontent.com/u/1412558?",
+                "https://github.com/testscribeup", "Paris");
+        assertEquals("User", (String) profile.getAttribute("type"));
+        assertEquals("ScribeUp", (String) profile.getAttribute("blog"));
+        assertEquals("https://api.github.com/users/testscribeup", (String) profile.getAttribute("url"));
+        assertEquals(0, ((Integer) profile.getAttribute("public_gists")).intValue());
+        assertEquals(0, ((Integer) profile.getAttribute("following")).intValue());
+        assertEquals(0, ((Integer) profile.getAttribute("private_gists")).intValue());
+        assertEquals(0, ((Integer) profile.getAttribute("public_repos")).intValue());
+        assertEquals("", (String) profile.getAttribute("gravatar_id"));
+        assertEquals(0, ((Integer) profile.getAttribute("followers")).intValue());
+        assertEquals("Company", (String) profile.getAttribute("company"));
+        assertNull((Boolean) profile.getAttribute("hirable"));
+        assertEquals(0, ((Integer) profile.getAttribute("collaborators")).intValue());
+        assertNull((String) profile.getAttribute("bio"));
+        assertEquals(0, ((Integer) profile.getAttribute("total_private_repos")).intValue());
+        assertEquals("2012-02-06T13:05:21Z", ((Date) profile.getAttribute("created_at")).toString());
+        assertEquals(0, ((Integer) profile.getAttribute("disk_usage")).intValue());
+        assertEquals(0, ((Integer) profile.getAttribute("owned_private_repos")).intValue());
+        final GitHubPlan plan = (GitHubPlan) profile.getAttribute("plan");
+        assertEquals("free", plan.getName());
+        assertEquals(0, plan.getCollaborators().intValue());
+        assertEquals(976562499, plan.getSpace().intValue());
+        assertEquals(0, plan.getPrivateRepos().intValue());
+        assertEquals(24, profile.getAttributes().size());
+    }
+}

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGeneric20StateClient.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGeneric20StateClient.java
@@ -1,0 +1,88 @@
+package org.pac4j.oauth.run;
+
+import org.pac4j.oauth.profile.google2.Google2AttributesDefinition;
+import org.pac4j.oauth.profile.google2.Google2Email;
+import com.esotericsoftware.kryo.Kryo;
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.Gender;
+import org.pac4j.core.profile.ProfileHelper;
+import org.pac4j.core.run.RunClient;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oauth.client.GenericOAuth20StateClient;
+import org.pac4j.oauth.profile.generic.GenericOAuth20Profile;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test class for {@link GenericOAuth20StateClient}
+ * Connects with Google for testing
+ * @see RunGoogle2Client
+ *
+ * @author aherrick
+ * @since 1.9.2
+ */
+public class RunGeneric20StateClient extends RunClient {
+
+    public static void main(String[] args) throws Exception {
+        new RunGoogle2Client().run();
+    }
+
+    @Override
+    protected String getLogin() {
+        return "testscribeup@gmail.com";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "testpwdscribeup91";
+    }
+
+    @Override
+    protected IndirectClient getClient() {
+        final GenericOAuth20StateClient client = new GenericOAuth20StateClient();
+        client.setAttributesDefinition(new Google2AttributesDefinition());
+        client.setAuthUrl("https://accounts.google.com/o/oauth2/auth");
+        client.setTokenUrl("https://accounts.google.com/o/oauth2/token");
+        client.setProfileUrl("https://www.googleapis.com/plus/v1/people/me");
+        client.setKey("682158564078-ndcjc83kp5v7vudikqu1fudtkcs2odeb.apps.googleusercontent.com");
+        client.setSecret("gLB2U7LPYBFTxqYtyG81AhLH");
+        client.setCallbackUrl(PAC4J_BASE_URL);
+        client.setScope("profile email");
+        return client;
+    }
+
+    @Override
+    protected void registerForKryo(final Kryo kryo) {
+        kryo.register(GenericOAuth20Profile.class);
+    }
+
+    @Override
+    protected boolean canCancel() {
+        return true;
+    }
+
+    @Override
+    protected void verifyProfile(CommonProfile userProfile) {
+        final GenericOAuth20Profile profile = (GenericOAuth20Profile) userProfile;
+        profile.setAttributesDefinition(new Google2AttributesDefinition());
+        assertEquals("113675986756217860428", profile.getId());
+        assertEquals(GenericOAuth20StateClient.class.getName() + CommonProfile.SEPARATOR + "113675986756217860428",
+                profile.getTypedId());
+        assertTrue(ProfileHelper.isTypedIdOf(profile.getTypedId(), GenericOAuth20Profile.class));
+        assertTrue(CommonHelper.isNotBlank(profile.getAccessToken()));
+        assertCommonProfile(userProfile, "testscribeup@gmail.com", "Jérôme", "ScribeUP", "Jérôme ScribeUP", null,
+                Gender.MALE, Locale.ENGLISH,
+                "https://lh4.googleusercontent.com/-fFUNeYqT6bk/AAAAAAAAAAI/AAAAAAAAAAA/5gBL6csVWio/photo.jpg",
+                "https://plus.google.com/113675986756217860428", null);
+        assertNull(profile.getAttribute("birthday"));
+        List<Google2Email> emails = (List<Google2Email>) profile.getAttribute("emails");
+        assertTrue(emails != null && emails.size() == 1);
+        assertEquals(9, profile.getAttributes().size());
+    }
+
+
+}


### PR DESCRIPTION
What: An OAuth2.0 client that can be used with any OAuth 2.0 service (theoretically). It allows the user to define all of the URLs to make the relevant requests to. In addition, the user can define a custom AttributesDefinition (that extends the new GenericAttributesDefinition) to extract whatever profile details they expect.

Why: My organization uses pac4j for Google SSO in our apps, and we like how simple it makes the process. We also released our own internal OAuth provider and have migrated our Play applications to use that instead of each app having their own login screen to maintain. I created this because we would like to use pac4j with our internal OAuth provider, but needed more flexibility than a hardcoded Api. The purpose for this client is for use with internal OAuth2.0 services.

I also was looking into making BaseOAuth20Client and BaseOAuth20StateClient non-abstract with this functionality, but am limited on time. Perhaps that could be a future change.

Also, I'm not sure about tests for this. Perhaps I could create a test that configures this to authenticate with Google and run the same Google tests?