### PR TITLE
LinkedIn Profile URL pattern change

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedIn2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedIn2Client.java
@@ -72,7 +72,7 @@ public class LinkedIn2Client extends BaseOAuth20StateClient<LinkedIn2Profile> {
     
     @Override
     protected String getProfileUrl(final OAuth2AccessToken accessToken) {
-        return "https://api.linkedin.com/v1/people/~?:(" + this.fields + ")&format=json";
+        return "https://api.linkedin.com/v1/people/~:(" + this.fields + ")?format=json";
     }
     
     @Override


### PR DESCRIPTION
According to https://developer.linkedin.com/docs/signin-with-linkedin the profile URL pattern should be
"https://api.linkedin.com/v1/people/~:(" + this.fields + ")?format=json"
instead of
"https://api.linkedin.com/v1/people/~?:(" + this.fields + ")&format=json"

Otherwise the profile fields requested are not taken into account and only very few fields are obtained.