### PR TITLE
Extend profile manager factory injection to DefaultApplicationLogoutLogic and DefaultCallbackLogic

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultApplicationLogoutLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultApplicationLogoutLogic.java
@@ -9,6 +9,7 @@ import org.pac4j.core.profile.ProfileManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.Function;
 import java.util.regex.Pattern;
 
 import static org.pac4j.core.util.CommonHelper.*;
@@ -25,6 +26,7 @@ public class DefaultApplicationLogoutLogic<R, C extends WebContext> implements A
 
     protected Logger logger = LoggerFactory.getLogger(getClass());
 
+    private Function<C, ProfileManager> profileManagerFactory = context -> new ProfileManager(context);
     private boolean killSession;
 
     @Override
@@ -48,7 +50,7 @@ public class DefaultApplicationLogoutLogic<R, C extends WebContext> implements A
         assertNotBlank(Pac4jConstants.LOGOUT_URL_PATTERN, logoutUrlPattern);
 
         // logic
-        final ProfileManager manager = new ProfileManager(context);
+        final ProfileManager manager = getProfileManager(context);
         manager.logout();
         postLogout(context);
 
@@ -79,6 +81,16 @@ public class DefaultApplicationLogoutLogic<R, C extends WebContext> implements A
         }
     }
 
+    /**
+     * Given a webcontext generate a profileManager for it.
+     * Can be overridden for custom profile manager implementations
+     * @param context the web context
+     * @return profile manager implementation built from the context
+     */
+    protected ProfileManager getProfileManager(final C context) {
+        return profileManagerFactory.apply(context);
+    }
+
     public boolean isKillSession() {
         return killSession;
     }
@@ -86,4 +98,13 @@ public class DefaultApplicationLogoutLogic<R, C extends WebContext> implements A
     public void setKillSession(boolean killSession) {
         this.killSession = killSession;
     }
+
+    public Function<C, ProfileManager> getProfileManagerFactory() {
+        return profileManagerFactory;
+    }
+
+    public void setProfileManagerFactory(final Function<C, ProfileManager> factory) {
+        this.profileManagerFactory = factory;
+    }
+
 }


### PR DESCRIPTION
This is a PR to extend profile manager factory injection, as carried out for DefaultSecurityLogic, to DefaultApplicationLogoutLogic and DefaultCallbackLogic. The approach offers injection of a function for creating a profile manager for a given WebContext.

The advantage of this approach is that (assuming Java 8) it enables customization of ProfileManager creation without having to extend thse classes, permitting particular implementations of Pac4j on different platforms to customize their profile management without hacking the webcontext behaviour or having to inherit classes just to extend one method, both of which are less desirable. The default behaviour is to create new ProfileManager (as was previously occurring) but it is now much easier to customise these behaviours. I would also suggest that it wouldn't be unreasonable to make the getProfileManager private as overriding the getProfileManager offers nothing that injection of a factory does not. However, this PR does not take that step.