### PR TITLE
ensured UTF-8 as Velocity engines input encoding (fixes #642)

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/VelocityEngineFactory.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/VelocityEngineFactory.java
@@ -23,7 +23,7 @@ public class VelocityEngineFactory {
 
             final Properties props =
                     new Properties(net.shibboleth.utilities.java.support.velocity.VelocityEngine.getDefaultProperties());
-            props.setProperty(RuntimeConstants.ENCODING_DEFAULT, "UTF-8");
+            props.setProperty(RuntimeConstants.INPUT_ENCODING, "UTF-8");
             props.setProperty(RuntimeConstants.OUTPUT_ENCODING, "UTF-8");
             props.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
             props.setProperty(RuntimeConstants.RUNTIME_LOG_LOGSYSTEM_CLASS, SLF4JLogChute.class.getName());


### PR DESCRIPTION
…arset

The velocity engine enforced the ISO-8859-1 input encoding (i.e. Velocity defaults) instead of the designed UTF-8.