### PR TITLE
Improve Mongo support

### DIFF
--- a/pac4j-mongo/pom.xml
+++ b/pac4j-mongo/pom.xml
@@ -13,7 +13,7 @@
 	<name>pac4j for MongoDB</name>
 
 	<properties>
-		<mongo-driver.version>3.2.1</mongo-driver.version>
+		<mongo-driver.version>3.3.0</mongo-driver.version>
 		<mongo-allanbank.version>2.0.1</mongo-allanbank.version>
 		<flapdoodle.version>1.50.2</flapdoodle.version>
 	</properties>
@@ -25,7 +25,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.mongodb</groupId>
-			<artifactId>mongo-java-driver</artifactId>
+			<artifactId>mongodb-driver</artifactId>
 			<version>${mongo-driver.version}</version>
 			<optional>true</optional>
 		</dependency>

--- a/pac4j-mongo/pom.xml
+++ b/pac4j-mongo/pom.xml
@@ -14,6 +14,7 @@
 
 	<properties>
 		<mongo-driver.version>3.2.1</mongo-driver.version>
+		<mongo-allanbank.version>2.0.1</mongo-allanbank.version>
 		<flapdoodle.version>1.50.2</flapdoodle.version>
 	</properties>
 
@@ -26,6 +27,13 @@
 			<groupId>org.mongodb</groupId>
 			<artifactId>mongo-java-driver</artifactId>
 			<version>${mongo-driver.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.allanbank</groupId>
+			<artifactId>mongodb-async-driver</artifactId>
+			<version>${mongo-allanbank.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<!-- for testing -->
 		<dependency>

--- a/pac4j-mongo/src/main/java/org/pac4j/mongo/credentials/authenticator/AbstractMongoAuthenticator.java
+++ b/pac4j-mongo/src/main/java/org/pac4j/mongo/credentials/authenticator/AbstractMongoAuthenticator.java
@@ -1,0 +1,139 @@
+package org.pac4j.mongo.credentials.authenticator;
+
+import java.util.Iterator;
+
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.credentials.authenticator.AbstractUsernamePasswordAuthenticator;
+import org.pac4j.core.credentials.password.PasswordEncoder;
+import org.pac4j.core.exception.AccountNotFoundException;
+import org.pac4j.core.exception.BadCredentialsException;
+import org.pac4j.core.exception.HttpAction;
+import org.pac4j.core.exception.MultipleAccountsFoundException;
+import org.pac4j.core.profile.creator.AuthenticatorProfileCreator;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.mongo.profile.MongoProfile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Authenticator for users stored in a MongoDB database. It creates the user profile and stores it in the credentials
+ * for the {@link AuthenticatorProfileCreator}.
+ *
+ * @author Jerome Leleu
+ * @since 1.8.0
+ */
+public abstract class AbstractMongoAuthenticator<TDoc> extends AbstractUsernamePasswordAuthenticator {
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * This must a list of attribute names separated by commas.
+     */
+    protected String attributes = "";
+    protected String usernameAttribute = Pac4jConstants.USERNAME;
+    protected String passwordAttribute = Pac4jConstants.PASSWORD;
+    protected String usersDatabase = "users";
+    protected String usersCollection = "users";
+
+    public AbstractMongoAuthenticator() {}
+
+    public AbstractMongoAuthenticator(final String attributes) {
+        this.attributes = attributes;
+    }
+
+    public AbstractMongoAuthenticator(final String attributes, final PasswordEncoder passwordEncoder) {
+        this.attributes = attributes;
+        setPasswordEncoder(passwordEncoder);
+    }
+
+    @Override
+    protected void internalInit(final WebContext context) {
+        CommonHelper.assertNotNull("usernameAttribute", this.usernameAttribute);
+        CommonHelper.assertNotNull("passwordAttribute", this.passwordAttribute);
+        CommonHelper.assertNotNull("usersDatabase", this.usersDatabase);
+        CommonHelper.assertNotNull("usersCollection", this.usersCollection);
+        CommonHelper.assertNotNull("attributes", this.attributes);
+
+        super.internalInit(context);
+    }
+
+    @Override
+    public void validate(UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction {
+
+        final String username = credentials.getUsername();
+
+        final Iterator<TDoc> it = getUsersFor(credentials).iterator();
+
+        if (!it.hasNext()) {
+            throw new AccountNotFoundException("No account found for: " + username);
+        } else {
+            final TDoc user = it.next();
+            if (it.hasNext()) {
+                throw new MultipleAccountsFoundException("Too many accounts found for: " + username);
+            }
+            final String expectedPassword = getPasswordEncoder().encode(credentials.getPassword());
+            final String returnedPassword = getUserAttribute(user, passwordAttribute);
+            if (CommonHelper.areNotEquals(returnedPassword, expectedPassword)) {
+                throw new BadCredentialsException("Bad credentials for: " + username);
+            } else {
+                final MongoProfile profile = createProfile(username, attributes.split(","), user);
+                credentials.setUserProfile(profile);
+            }
+        }
+    }
+
+    protected abstract Iterable<TDoc> getUsersFor(UsernamePasswordCredentials credentials);
+
+    protected abstract String getUserAttribute(TDoc user, String attribute);
+
+    protected MongoProfile createProfile(final String username, final String[] attributes, final TDoc result) {
+        final MongoProfile profile = new MongoProfile();
+        profile.setId(username);
+        for (String attribute: attributes) {
+            profile.addAttribute(attribute, getUserAttribute(result, attribute));
+        }
+        return profile;
+    }
+
+    public String getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(String attributes) {
+        this.attributes = attributes;
+    }
+
+    public String getUsernameAttribute() {
+        return usernameAttribute;
+    }
+
+    public void setUsernameAttribute(String usernameAttribute) {
+        this.usernameAttribute = usernameAttribute;
+    }
+
+    public String getPasswordAttribute() {
+        return passwordAttribute;
+    }
+
+    public void setPasswordAttribute(String passwordAttribute) {
+        this.passwordAttribute = passwordAttribute;
+    }
+
+    public String getUsersDatabase() {
+        return usersDatabase;
+    }
+
+    public void setUsersDatabase(String usersDatabase) {
+        this.usersDatabase = usersDatabase;
+    }
+
+    public String getUsersCollection() {
+        return usersCollection;
+    }
+
+    public void setUsersCollection(String usersCollection) {
+        this.usersCollection = usersCollection;
+    }
+}

--- a/pac4j-mongo/src/main/java/org/pac4j/mongo/credentials/authenticator/MongoAllanbankAuthenticator.java
+++ b/pac4j-mongo/src/main/java/org/pac4j/mongo/credentials/authenticator/MongoAllanbankAuthenticator.java
@@ -1,43 +1,41 @@
 package org.pac4j.mongo.credentials.authenticator;
 
-import static com.mongodb.client.model.Filters.eq;
-
-import org.bson.Document;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.password.PasswordEncoder;
 import org.pac4j.core.util.CommonHelper;
 
-import com.mongodb.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
+import com.allanbank.mongodb.MongoClient;
+import com.allanbank.mongodb.MongoCollection;
+import com.allanbank.mongodb.MongoDatabase;
+import com.allanbank.mongodb.bson.Document;
+import com.allanbank.mongodb.bson.Element;
+import com.allanbank.mongodb.builder.QueryBuilder;
 
 /**
- * Authenticator for users stored in a MongoDB database, based on the {@link MongoClient} class from the Java Mongo
- * driver.
- *
- * Add the <code>spring-security-crypto</code> dependency to use this class.
+ * Authenticator for users stored in a MongoDB database, based on the {@link MongoClient} class from the Allanbank
+ * Async-based Mongo driver (the synchronous API is used).
  *
  * @author Victor Noël
  * @since 1.9.2
  */
-public class MongoAuthenticator extends AbstractMongoAuthenticator<Document> {
+public class MongoAllanbankAuthenticator extends AbstractMongoAuthenticator<Document> {
 
     protected MongoClient mongoClient;
 
-    public MongoAuthenticator() {
+    public MongoAllanbankAuthenticator() {
     }
 
-    public MongoAuthenticator(final MongoClient mongoClient) {
+    public MongoAllanbankAuthenticator(final MongoClient mongoClient) {
         this.mongoClient = mongoClient;
     }
 
-    public MongoAuthenticator(final MongoClient mongoClient, final String attributes) {
+    public MongoAllanbankAuthenticator(final MongoClient mongoClient, final String attributes) {
         super(attributes);
         this.mongoClient = mongoClient;
     }
 
-    public MongoAuthenticator(final MongoClient mongoClient, final String attributes,
+    public MongoAllanbankAuthenticator(final MongoClient mongoClient, final String attributes,
             final PasswordEncoder passwordEncoder) {
         super(attributes, passwordEncoder);
         this.mongoClient = mongoClient;
@@ -53,14 +51,15 @@ public class MongoAuthenticator extends AbstractMongoAuthenticator<Document> {
     @Override
     protected Iterable<Document> getUsersFor(UsernamePasswordCredentials credentials) {
         final MongoDatabase db = mongoClient.getDatabase(usersDatabase);
-        final MongoCollection<Document> collection = db.getCollection(usersCollection);
+        final MongoCollection collection = db.getCollection(usersCollection);
 
-        return collection.find(eq(usernameAttribute, credentials.getUsername()));
+        return collection.find(QueryBuilder.where(usernameAttribute).equals(credentials.getUsername()));
     }
 
     @Override
     protected String getUserAttribute(Document user, String attribute) {
-        return user.getString(attribute);
+        final Element element = user.get(attribute);
+        return element == null ? null : element.getValueAsString();
     }
 
     public MongoClient getMongoClient() {

--- a/pac4j-mongo/src/main/java/org/pac4j/mongo/profile/MongoProfile.java
+++ b/pac4j-mongo/src/main/java/org/pac4j/mongo/profile/MongoProfile.java
@@ -1,12 +1,12 @@
 package org.pac4j.mongo.profile;
 
 import org.pac4j.core.profile.CommonProfile;
-import org.pac4j.mongo.credentials.authenticator.MongoAuthenticator;
+import org.pac4j.mongo.credentials.authenticator.AbstractMongoAuthenticator;
 
 /**
  * <p>The user profile returned from a MongoDB.</p>
  *
- * @see MongoAuthenticator
+ * @see AbstractMongoAuthenticator
  * @author Jerome Leleu
  * @since 1.8.0
  */

--- a/pac4j-mongo/src/test/java/org/pac4j/mongo/credentials/authenticator/MongoAllanbankAuthenticatorIT.java
+++ b/pac4j-mongo/src/test/java/org/pac4j/mongo/credentials/authenticator/MongoAllanbankAuthenticatorIT.java
@@ -1,0 +1,157 @@
+package org.pac4j.mongo.credentials.authenticator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.credentials.password.BasicSaltedSha512PasswordEncoder;
+import org.pac4j.core.credentials.password.NopPasswordEncoder;
+import org.pac4j.core.exception.AccountNotFoundException;
+import org.pac4j.core.exception.BadCredentialsException;
+import org.pac4j.core.exception.HttpAction;
+import org.pac4j.core.exception.MultipleAccountsFoundException;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.core.util.TestsHelper;
+import org.pac4j.mongo.profile.MongoProfile;
+import org.pac4j.mongo.test.tools.MongoServer;
+
+import com.allanbank.mongodb.MongoClient;
+import com.allanbank.mongodb.MongoFactory;
+
+/**
+ * Tests the {@link MongoAllanbankAuthenticator}.
+ *
+ * @author Victor Noël
+ * @since 1.9.2
+ */
+public class MongoAllanbankAuthenticatorIT implements TestsConstants {
+
+    private final static int PORT = 37017;
+
+    private final MongoServer mongoServer = new MongoServer();
+
+    @Before
+    public void setUp() {
+        mongoServer.start(PORT);
+    }
+
+    @After
+    public void tearDown() {
+        mongoServer.stop();
+    }
+
+
+    @Test
+    public void testNullPasswordEncoder() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), FIRSTNAME);
+        authenticator.setPasswordEncoder(null);
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "passwordEncoder cannot be null");
+    }
+
+    @Test
+    public void testNullAttribute() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), null,
+                new NopPasswordEncoder());
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "attributes cannot be null");
+    }
+
+    @Test
+    public void testNullMongoClient() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(null, FIRSTNAME,
+                new NopPasswordEncoder());
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "mongoClient cannot be null");
+    }
+
+    @Test
+    public void testNullDatabase() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), FIRSTNAME,
+                new NopPasswordEncoder());
+        authenticator.setUsersDatabase(null);
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "usersDatabase cannot be null");
+    }
+
+    @Test
+    public void testNullCollection() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), FIRSTNAME,
+                new NopPasswordEncoder());
+        authenticator.setUsersCollection(null);
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "usersCollection cannot be null");
+    }
+
+    @Test
+    public void testNullUsername() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), FIRSTNAME,
+                new NopPasswordEncoder());
+        authenticator.setUsernameAttribute(null);
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "usernameAttribute cannot be null");
+    }
+
+    @Test
+    public void testNullPassword() throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), FIRSTNAME,
+                new NopPasswordEncoder());
+        authenticator.setPasswordAttribute(null);
+        TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "passwordAttribute cannot be null");
+    }
+
+    private MongoClient getClient() {
+        return MongoFactory.createClient("mongodb://localhost:" + PORT);
+    }
+
+    private UsernamePasswordCredentials login(final String username, final String password, final String attribute) throws HttpAction {
+        final MongoAllanbankAuthenticator authenticator = new MongoAllanbankAuthenticator(getClient(), attribute);
+        authenticator.setPasswordEncoder(new BasicSaltedSha512PasswordEncoder(SALT));
+        authenticator.init(null);
+
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password, CLIENT_NAME);
+        authenticator.validate(credentials, null);
+
+        return credentials;
+    }
+
+    @Test
+    public void testGoodUsernameAttribute() throws HttpAction {
+        final UsernamePasswordCredentials credentials =  login(GOOD_USERNAME, PASSWORD, FIRSTNAME);
+
+        final CommonProfile profile = credentials.getUserProfile();
+        assertNotNull(profile);
+        assertTrue(profile instanceof MongoProfile);
+        final MongoProfile dbProfile = (MongoProfile) profile;
+        assertEquals(GOOD_USERNAME, dbProfile.getId());
+        assertEquals(FIRSTNAME_VALUE, dbProfile.getAttribute(FIRSTNAME));
+    }
+
+    @Test
+    public void testGoodUsernameNoAttribute() throws HttpAction {
+        final UsernamePasswordCredentials credentials =  login(GOOD_USERNAME, PASSWORD, "");
+
+        final CommonProfile profile = credentials.getUserProfile();
+        assertNotNull(profile);
+        assertTrue(profile instanceof MongoProfile);
+        final MongoProfile dbProfile = (MongoProfile) profile;
+        assertEquals(GOOD_USERNAME, dbProfile.getId());
+        assertNull(dbProfile.getAttribute(FIRSTNAME));
+    }
+
+    @Test(expected = MultipleAccountsFoundException.class)
+    public void testMultipleUsername() throws HttpAction {
+        login(MULTIPLE_USERNAME, PASSWORD, "");
+    }
+
+    @Test(expected = AccountNotFoundException.class)
+    public void testBadUsername() throws HttpAction {
+        login(BAD_USERNAME, PASSWORD, "");
+    }
+
+    @Test(expected = BadCredentialsException.class)
+    public void testBadPassword() throws HttpAction {
+        login(GOOD_USERNAME, PASSWORD + "bad", "");
+    }
+}


### PR DESCRIPTION
Hi,

Here is a PR (to be discussed :) to improve the mongodb support.

It introduces support for another library to access mongo named mongo-async-driver from Allanbank. It a driver I use a lot (because it is supported by [Quasar](http://docs.paralleluniverse.co/quasar/) mainly and I needed such support).
I factored the common code in a class named `AbstractMongoAuthenticator`.

The old MongoAuthenticator is still usable exactly as before EXCEPT for the fact that the dependency is now optional (since we have 2 different libraries to access mongo in the dependencies now). Not sure how to handle that better…

Some thoughts I had when I made this PR: in a way the common code is very similar to the code present in pac4j-sql: maybe it would make sense to gather all these database-oriented authenticators in one package, or inversely have the common code in pac4j-core and have a package for each of the database supported. It's just an idea, maybe it's not worth the effort to do all of that :)

Thanks!