### PR TITLE
Let PMD Maven Plugin output to console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,7 @@
 				<version>3.6</version>
 				<configuration>
 					<includeTests>true</includeTests>
+					<printFailingErrors>true</printFailingErrors>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Closes #658 

With this change, the ouput:

```
[INFO] --- maven-pmd-plugin:3.6:check (run-pmd) @ pac4j-core ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
```

becomes (for example):

```
[INFO] --- maven-pmd-plugin:3.6:check (run-pmd) @ pac4j-core ---
[INFO] PMD Failure: org/pac4j/core/authorization/authorizer/AbstractCheckAuthenticationAuthorizer.java:7 Rule:UnusedImports Priority:4 Avoid unused imports such as 'java.util.List'.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
```
