### PR TITLE
Missing initialisation of Clients in findClients

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
@@ -123,6 +123,7 @@ public class Clients extends InitializableObject {
      * @return the right client
      */
     public Client findClient(final WebContext context) {
+        init();
         final String name = context.getRequestParameter(this.clientNameParameter);
 		if (name == null && defaultClient != null) {
 			return defaultClient;


### PR DESCRIPTION
`findClient(WebContext)` is missing the initialisation of the clients BEFORE the default client is returned.

I think there is also undefined behaviour if the default client is NOT in the clients collection, but this PR does not cover this problem yet.
If you have an idea how to better handle that case, I can add some commits for it :)