### PR TITLE
CredentialException handling improvements

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/authenticator/Authenticator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/authenticator/Authenticator.java
@@ -20,6 +20,7 @@ public interface Authenticator<C extends Credentials> {
      * @param credentials the given credentials
      * @param context the web context
      * @throws HttpAction requires a specific HTTP action if necessary
+     * @throws CredentialsException the credentials are invalid
      */
-    void validate(C credentials, WebContext context) throws HttpAction;
+    void validate(C credentials, WebContext context) throws HttpAction, CredentialsException;
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/authenticator/LocalCachingAuthenticator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/authenticator/LocalCachingAuthenticator.java
@@ -45,7 +45,7 @@ public class LocalCachingAuthenticator<T extends Credentials> extends Initializa
     }
 
     @Override
-    public void validate(final T credentials, final WebContext context) throws HttpAction {
+    public void validate(final T credentials, final WebContext context) throws HttpAction, CredentialsException {
         init(context);
 
         try {

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
@@ -32,7 +32,7 @@ public class BasicAuthExtractor implements CredentialsExtractor<UsernamePassword
     }
 
     @Override
-    public UsernamePasswordCredentials extract(WebContext context) throws HttpAction {
+    public UsernamePasswordCredentials extract(WebContext context) throws HttpAction, CredentialsException {
         final TokenCredentials credentials = this.extractor.extract(context);
         if (credentials == null) {
             return null;

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/CredentialsExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/CredentialsExtractor.java
@@ -20,6 +20,7 @@ public interface CredentialsExtractor<C extends Credentials> {
      * @param context the current web context
      * @return the credentials
      * @throws HttpAction requires a specific HTTP action if necessary
+     * @throws CredentialsException the credentials are invalid
      */
-    C extract(WebContext context) throws HttpAction;
+    C extract(WebContext context) throws HttpAction, CredentialsException;
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/HeaderExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/HeaderExtractor.java
@@ -26,7 +26,7 @@ public class HeaderExtractor implements CredentialsExtractor<TokenCredentials> {
     }
 
     @Override
-    public TokenCredentials extract(WebContext context) throws HttpAction {
+    public TokenCredentials extract(WebContext context) throws HttpAction, CredentialsException {
         final String header = context.getRequestHeader(this.headerName);
         if (header == null) {
             return null;

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/ParameterExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/ParameterExtractor.java
@@ -35,7 +35,7 @@ public class ParameterExtractor implements CredentialsExtractor<TokenCredentials
     }
 
     @Override
-    public TokenCredentials extract(WebContext context) throws HttpAction {
+    public TokenCredentials extract(WebContext context) throws HttpAction, CredentialsException {
         final String method = context.getRequestMethod();
         if ("GET".equals(method) && !supportGetRequest) {
             throw new CredentialsException("GET requests not supported");

--- a/pac4j-core/src/main/java/org/pac4j/core/exception/CredentialsException.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/exception/CredentialsException.java
@@ -1,15 +1,15 @@
 package org.pac4j.core.exception;
 
 /**
- * This class represents an exception occuring during credentials retrieval.
+ * This class represents an expected exception occurring during credentials retrieval.
  * 
  * @author Jerome Leleu
  * @since 1.4.0
  */
-public class CredentialsException extends TechnicalException {
-    
-    private static final long serialVersionUID = 8188990220217650629L;
-    
+public class CredentialsException extends Exception {
+
+    private static final long serialVersionUID = 6013115966613706463L;
+
     public CredentialsException(final String message) {
         super(message);
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/exception/MultipleAccountsFoundException.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/exception/MultipleAccountsFoundException.java
@@ -6,7 +6,7 @@ package org.pac4j.core.exception;
  * @author Jerome Leleu
  * @since 1.8.0
  */
-public class MultipleAccountsFoundException extends CredentialsException {
+public class MultipleAccountsFoundException extends TechnicalException {
 
     private static final long serialVersionUID = 1430582289490541876L;
 

--- a/pac4j-core/src/test/java/org/pac4j/core/credentials/authenticator/LocalCachingAuthenticatorTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/credentials/authenticator/LocalCachingAuthenticatorTests.java
@@ -52,7 +52,7 @@ public class LocalCachingAuthenticatorTests {
             new UsernamePasswordCredentials("a", "a", this.getClass().getName());
 
     @Test
-    public void testDoubleCalls() throws HttpAction {
+    public void testDoubleCalls() throws HttpAction, CredentialsException {
         final OnlyOneCallAuthenticator authenticator = new OnlyOneCallAuthenticator();
         final LocalCachingAuthenticator localCachingAuthenticator = new LocalCachingAuthenticator(authenticator, 10, 10, TimeUnit.SECONDS);
         localCachingAuthenticator.init(null);
@@ -72,7 +72,7 @@ public class LocalCachingAuthenticatorTests {
     }
 
     @Test
-    public void testValidateAndCache() throws HttpAction {
+    public void testValidateAndCache() throws HttpAction, CredentialsException {
         final LocalCachingAuthenticator authenticator = new
                 LocalCachingAuthenticator(this.delegate, 10, 2, TimeUnit.SECONDS);
         authenticator.init(null);
@@ -82,7 +82,7 @@ public class LocalCachingAuthenticatorTests {
     }
 
     @Test
-    public void testValidateAndCacheSwitchDelegate() throws HttpAction {
+    public void testValidateAndCacheSwitchDelegate() throws HttpAction, CredentialsException {
         final LocalCachingAuthenticator<UsernamePasswordCredentials> authenticator = new
                 LocalCachingAuthenticator<>(this.delegate, 10, 2, TimeUnit.SECONDS);
         authenticator.init(null);
@@ -107,7 +107,7 @@ public class LocalCachingAuthenticatorTests {
     }
 
     @Test
-    public void testValidateAndCacheAndRemove() throws HttpAction {
+    public void testValidateAndCacheAndRemove() throws HttpAction, CredentialsException {
         final LocalCachingAuthenticator authenticator = new
                 LocalCachingAuthenticator(this.delegate, 10, 2, TimeUnit.SECONDS);
         authenticator.init(null);
@@ -119,7 +119,7 @@ public class LocalCachingAuthenticatorTests {
     }
 
     @Test
-    public void testValidateAndCacheAndClean() throws HttpAction {
+    public void testValidateAndCacheAndClean() throws HttpAction, CredentialsException {
         final LocalCachingAuthenticator authenticator = new
                 LocalCachingAuthenticator(this.delegate, 10, 2, TimeUnit.SECONDS);
         authenticator.init(null);
@@ -145,7 +145,7 @@ public class LocalCachingAuthenticatorTests {
     private static class ThrowingAuthenticator implements Authenticator<UsernamePasswordCredentials> {
 
         @Override
-        public void validate(final UsernamePasswordCredentials credentials, final WebContext context) {
+        public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws CredentialsException {
             throw new CredentialsException("fail");
         }
     }

--- a/pac4j-core/src/test/java/org/pac4j/core/credentials/extractor/HeaderExtractorTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/credentials/extractor/HeaderExtractorTests.java
@@ -27,21 +27,21 @@ public final class HeaderExtractorTests implements TestsConstants {
     private final static HeaderExtractor extractor = new HeaderExtractor(GOOD_HEADER, GOOD_PREFIX, CLIENT_NAME);
 
     @Test
-    public void testRetrieveHeaderOk() throws HttpAction {
+    public void testRetrieveHeaderOk() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create().addRequestHeader(GOOD_HEADER, GOOD_PREFIX + VALUE);
         final TokenCredentials credentials = extractor.extract(context);
         assertEquals(VALUE, credentials.getToken());
     }
 
     @Test
-    public void testBadHeader() throws HttpAction {
+    public void testBadHeader() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create().addRequestHeader(BAD_HEADER, GOOD_PREFIX + VALUE);
         final TokenCredentials credentials = extractor.extract(context);
         assertNull(credentials);
     }
 
     @Test
-    public void testBadPrefix() throws HttpAction {
+    public void testBadPrefix() {
         final MockWebContext context = MockWebContext.create().addRequestHeader(GOOD_HEADER, BAD_PREFIX + VALUE);
         TestsHelper.expectException(() -> extractor.extract(context), CredentialsException.class, "Wrong prefix for header: " + GOOD_HEADER);
     }

--- a/pac4j-http/src/main/java/org/pac4j/http/client/indirect/FormClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/indirect/FormClient.java
@@ -7,7 +7,6 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
-import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.core.util.CommonHelper;
@@ -114,7 +113,7 @@ public class FormClient extends IndirectClientV2<UsernamePasswordCredentials, Co
      * @param e the technical exception
      * @return the error message
      */
-    protected String computeErrorMessage(final TechnicalException e) {
+    protected String computeErrorMessage(final Exception e) {
         return e.getClass().getSimpleName();
     }
 

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/IpRegexpAuthenticator.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/IpRegexpAuthenticator.java
@@ -33,7 +33,7 @@ public class IpRegexpAuthenticator implements Authenticator<TokenCredentials> {
     }
 
     @Override
-    public void validate(final TokenCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final TokenCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
         CommonHelper.assertNotNull("pattern", pattern);
 
         final String ip = credentials.getToken();

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/test/SimpleTestDigestAuthenticator.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/test/SimpleTestDigestAuthenticator.java
@@ -18,7 +18,7 @@ import org.pac4j.http.credentials.DigestCredentials;
 public class SimpleTestDigestAuthenticator implements Authenticator<TokenCredentials> {
 
     @Override
-    public void validate(final TokenCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final TokenCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
         if (credentials == null) {
             throw new CredentialsException("No credential");
         }

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/test/SimpleTestTokenAuthenticator.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/test/SimpleTestTokenAuthenticator.java
@@ -17,7 +17,7 @@ import org.pac4j.core.credentials.TokenCredentials;
 public class SimpleTestTokenAuthenticator implements Authenticator<TokenCredentials> {
 
     @Override
-    public void validate(final TokenCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final TokenCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
         if (credentials == null) {
             throw new CredentialsException("credentials must not be null");
         }

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/test/SimpleTestUsernamePasswordAuthenticator.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/authenticator/test/SimpleTestUsernamePasswordAuthenticator.java
@@ -22,7 +22,7 @@ public class SimpleTestUsernamePasswordAuthenticator implements Authenticator<Us
     protected static final Logger logger = LoggerFactory.getLogger(SimpleTestUsernamePasswordAuthenticator.class);
 
     @Override
-    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
         if (credentials == null) {
             throwsException("No credential");
         }
@@ -43,7 +43,7 @@ public class SimpleTestUsernamePasswordAuthenticator implements Authenticator<Us
         credentials.setUserProfile(profile);
     }
 
-    protected void throwsException(final String message) {
+    protected void throwsException(final String message) throws CredentialsException {
         throw new CredentialsException(message);
     }
 }

--- a/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/DigestAuthExtractor.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/credentials/extractor/DigestAuthExtractor.java
@@ -53,7 +53,7 @@ public class DigestAuthExtractor implements CredentialsExtractor<DigestCredentia
      * @return the Digest credentials
      */
     @Override
-    public DigestCredentials extract(WebContext context) throws HttpAction {
+    public DigestCredentials extract(WebContext context) throws HttpAction, CredentialsException {
         final TokenCredentials credentials = this.extractor.extract(context);
 
         if (credentials == null) {

--- a/pac4j-http/src/test/java/org/pac4j/http/credentials/authenticator/IpRegexpAuthenticatorTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/credentials/authenticator/IpRegexpAuthenticatorTests.java
@@ -25,13 +25,13 @@ public final class IpRegexpAuthenticatorTests implements TestsConstants {
     private final static IpRegexpAuthenticator authenticator = new IpRegexpAuthenticator(GOOD_IP);
 
     @Test(expected = TechnicalException.class)
-    public void testNoPattern() throws HttpAction {
+    public void testNoPattern() throws HttpAction, CredentialsException {
         IpRegexpAuthenticator authenticator = new IpRegexpAuthenticator();
         authenticator.validate(null, null);
     }
 
     @Test
-    public void testValidateGoodIP() throws HttpAction {
+    public void testValidateGoodIP() throws HttpAction, CredentialsException {
         final TokenCredentials credentials = new TokenCredentials(GOOD_IP, CLIENT_NAME);
         authenticator.validate(credentials, null);
         final IpProfile profile = (IpProfile) credentials.getUserProfile();
@@ -39,7 +39,7 @@ public final class IpRegexpAuthenticatorTests implements TestsConstants {
     }
 
     @Test
-    public void testValidateBadIP() throws HttpAction {
+    public void testValidateBadIP() {
         final TokenCredentials credentials = new TokenCredentials(BAD_IP, CLIENT_NAME);
         TestsHelper.expectException(() -> authenticator.validate(credentials, null), CredentialsException.class, "Unauthorized IP address: " + BAD_IP);
     }

--- a/pac4j-http/src/test/java/org/pac4j/http/credentials/extractor/DigestExtractorTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/credentials/extractor/DigestExtractorTests.java
@@ -3,6 +3,7 @@ package org.pac4j.http.credentials.extractor;
 import org.junit.Test;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.http.credentials.DigestCredentials;
@@ -20,7 +21,7 @@ public class DigestExtractorTests implements TestsConstants {
     private final static DigestAuthExtractor digestExtractor = new DigestAuthExtractor(CLIENT_NAME);
 
     @Test
-    public void testRetrieveDigestHeaderComponents() throws HttpAction {
+    public void testRetrieveDigestHeaderComponents() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create();
         context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER, DIGEST_AUTHORIZATION_HEADER_VALUE);
         final DigestCredentials credentials = digestExtractor.extract(context);
@@ -29,7 +30,7 @@ public class DigestExtractorTests implements TestsConstants {
     }
 
     @Test
-    public void testNotDigest() throws HttpAction {
+    public void testNotDigest() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create();
         final DigestCredentials credentials = digestExtractor.extract(context);
         assertNull(credentials);

--- a/pac4j-http/src/test/java/org/pac4j/http/credentials/extractor/ParameterExtractorTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/credentials/extractor/ParameterExtractorTests.java
@@ -25,40 +25,40 @@ public final class ParameterExtractorTests implements TestsConstants {
     private final static ParameterExtractor postExtractor = new ParameterExtractor(GOOD_PARAMETER, false, true, CLIENT_NAME);
 
     @Test
-    public void testRetrieveGetParameterOk() throws HttpAction {
+    public void testRetrieveGetParameterOk() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create().setRequestMethod("GET").addRequestParameter(GOOD_PARAMETER, VALUE);
         final TokenCredentials credentials = getExtractor.extract(context);
         assertEquals(VALUE, credentials.getToken());
     }
 
     @Test
-    public void testRetrievePostParameterOk() throws HttpAction {
+    public void testRetrievePostParameterOk() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create().setRequestMethod("POST").addRequestParameter(GOOD_PARAMETER, VALUE);
         final TokenCredentials credentials = postExtractor.extract(context);
         assertEquals(VALUE, credentials.getToken());
     }
 
     @Test
-    public void testRetrievePostParameterNotSupported() throws HttpAction {
+    public void testRetrievePostParameterNotSupported() {
         final MockWebContext context = MockWebContext.create().setRequestMethod("POST").addRequestParameter(GOOD_PARAMETER, VALUE);
         TestsHelper.expectException(() -> getExtractor.extract(context), CredentialsException.class, "POST requests not supported");
     }
 
     @Test
-    public void testRetrieveGetParameterNotSupported() throws HttpAction {
+    public void testRetrieveGetParameterNotSupported() {
         final MockWebContext context = MockWebContext.create().setRequestMethod("GET").addRequestParameter(GOOD_PARAMETER, VALUE);
         TestsHelper.expectException(() -> postExtractor.extract(context), CredentialsException.class, "GET requests not supported");
     }
 
     @Test
-    public void testRetrieveNoGetParameter() throws HttpAction {
+    public void testRetrieveNoGetParameter() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create().setRequestMethod("GET");
         final TokenCredentials credentials = getExtractor.extract(context);
         assertNull(credentials);
     }
 
     @Test
-    public void testRetrieveNoPostParameter() throws HttpAction {
+    public void testRetrieveNoPostParameter() throws HttpAction, CredentialsException {
         final MockWebContext context = MockWebContext.create().setRequestMethod("POST");
         final TokenCredentials credentials = postExtractor.extract(context);
         assertNull(credentials);

--- a/pac4j-jwt/src/test/java/org/pac4j/jwt/JwtTests.java
+++ b/pac4j-jwt/src/test/java/org/pac4j/jwt/JwtTests.java
@@ -2,9 +2,9 @@ package org.pac4j.jwt;
 
 import com.nimbusds.jose.EncryptionMethod;
 import org.junit.Test;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.exception.TechnicalException;
-
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.credentials.TokenCredentials;
@@ -43,7 +43,7 @@ public final class JwtTests implements TestsConstants {
     private static final Set<String> PERMISSIONS = new HashSet<>(Arrays.asList(new String[] { "perm1"}));
 
     @Test
-    public void testGenericJwt() throws HttpAction {
+    public void testGenericJwt() throws HttpAction, CredentialsException {
         final String token =
                 "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJDdXN0b20gSldUIEJ1aWxkZXIiLCJpYXQiOjE0NTAxNjQ0NTUsImV4cCI6MTQ4MTcwMDQ1NSwiYXVkIjoiaHR0cHM6Ly9naXRodWIuY29tL3BhYzRqIiwic3ViIjoidXNlckBwYWM0ai5vcmciLCJlbWFpbCI6InVzZXJAcGFjNGoub3JnIn0.zOPb7rbI3IY7iLXTK126Ggu2Q3pNCZsUzzgzgsqR7xU";
 
@@ -54,7 +54,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test(expected = TechnicalException.class)
-    public void testGenerateAuthenticateSub() throws HttpAction {
+    public void testGenerateAuthenticateSub() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(MAC_SECRET));
         final FacebookProfile profile = createProfile();
         profile.addAttribute(JwtClaims.SUBJECT, VALUE);
@@ -63,7 +63,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test(expected = TechnicalException.class)
-    public void testGenerateAuthenticateIat() throws HttpAction {
+    public void testGenerateAuthenticateIat() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(MAC_SECRET));
         final FacebookProfile profile = createProfile();
         profile.addAttribute(JwtClaims.ISSUED_AT, VALUE);
@@ -72,7 +72,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testPlainJwt() throws HttpAction {
+    public void testPlainJwt() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>();
         final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
@@ -80,7 +80,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testPlainJwtNotExpired() throws HttpAction {
+    public void testPlainJwtNotExpired() {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>();
         Map<String, Object> claims = new HashMap<>();
         claims.put(JwtClaims.SUBJECT, ID);
@@ -91,7 +91,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testPlainJwtExpired() throws HttpAction {
+    public void testPlainJwtExpired() {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>();
         Map<String, Object> claims = new HashMap<>();
         claims.put(JwtClaims.SUBJECT, ID);
@@ -102,7 +102,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testPlainJwtNoSubject() throws HttpAction {
+    public void testPlainJwtNoSubject() {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>();
         final String token = generator.generate(new HashMap<>());
         JwtAuthenticator authenticator = new JwtAuthenticator();
@@ -121,7 +121,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticate() throws HttpAction {
+    public void testGenerateAuthenticate() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(MAC_SECRET), new SecretEncryptionConfiguration(MAC_SECRET));
         final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
@@ -129,7 +129,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateClaims() throws HttpAction {
+    public void testGenerateAuthenticateClaims() {
         final JwtGenerator<JwtProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(MAC_SECRET), new SecretEncryptionConfiguration(MAC_SECRET));
         final Map<String, Object> claims = new HashMap<>();
         claims.put(JwtClaims.SUBJECT, VALUE);
@@ -158,7 +158,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateDifferentSecrets() throws HttpAction {
+    public void testGenerateAuthenticateDifferentSecrets() throws HttpAction, CredentialsException {
         final SignatureConfiguration signatureConfiguration = new SecretSignatureConfiguration(MAC_SECRET);
         final EncryptionConfiguration encryptionConfiguration = new SecretEncryptionConfiguration(KEY2);
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(signatureConfiguration, encryptionConfiguration);
@@ -168,7 +168,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateUselessSignatureConfiguration() throws HttpAction {
+    public void testGenerateAuthenticateUselessSignatureConfiguration() throws HttpAction, CredentialsException {
         final SignatureConfiguration signatureConfiguration = new SecretSignatureConfiguration(KEY2);
         final SignatureConfiguration signatureConfiguration2 = new SecretSignatureConfiguration(MAC_SECRET);
         final EncryptionConfiguration encryptionConfiguration = new SecretEncryptionConfiguration(MAC_SECRET);
@@ -183,7 +183,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateSlightlyDifferentSignatureConfiguration() throws HttpAction {
+    public void testGenerateAuthenticateSlightlyDifferentSignatureConfiguration() {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(KEY2));
         final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
@@ -205,7 +205,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateDifferentEncryptionConfiguration() throws HttpAction {
+    public void testGenerateAuthenticateDifferentEncryptionConfiguration() {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>();
         generator.setEncryptionConfiguration(new SecretEncryptionConfiguration(KEY2));
         final FacebookProfile profile = createProfile();
@@ -217,7 +217,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateNotEncrypted() throws HttpAction {
+    public void testGenerateAuthenticateNotEncrypted() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(MAC_SECRET));
         final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
@@ -225,7 +225,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateNotSigned() throws HttpAction {
+    public void testGenerateAuthenticateNotSigned() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>();
         generator.setEncryptionConfiguration(new SecretEncryptionConfiguration(MAC_SECRET));
         final FacebookProfile profile = createProfile();
@@ -235,7 +235,7 @@ public final class JwtTests implements TestsConstants {
 
     @Deprecated
     @Test
-    public void testGenerateAuthenticateAndEncrypted() throws HttpAction {
+    public void testGenerateAuthenticateAndEncrypted() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(MAC_SECRET, MAC_SECRET);
         final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
@@ -243,7 +243,7 @@ public final class JwtTests implements TestsConstants {
     }
 
     @Test
-    public void testGenerateAuthenticateAndEncryptedWithRolesPermissions() throws HttpAction {
+    public void testGenerateAuthenticateAndEncryptedWithRolesPermissions() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(new SecretSignatureConfiguration(MAC_SECRET));
         final FacebookProfile profile = createProfile();
         profile.addRoles(ROLES);
@@ -256,18 +256,19 @@ public final class JwtTests implements TestsConstants {
 
     @Deprecated
     @Test
-    public void testGenerateAuthenticateAndEncryptedDifferentKeys() throws HttpAction {
+    public void testGenerateAuthenticateAndEncryptedDifferentKeys() throws HttpAction, CredentialsException {
         final JwtGenerator<FacebookProfile> generator = new JwtGenerator<>(MAC_SECRET, KEY2);
         final FacebookProfile profile = createProfile();
         final String token = generator.generate(profile);
         assertToken(profile, token, new JwtAuthenticator(MAC_SECRET, KEY2));
     }
 
-    private CommonProfile assertToken(FacebookProfile profile, String token) throws HttpAction {
+    private CommonProfile assertToken(FacebookProfile profile, String token) throws HttpAction, CredentialsException {
         return assertToken(profile, token, new JwtAuthenticator(new SecretSignatureConfiguration(MAC_SECRET), new SecretEncryptionConfiguration(MAC_SECRET)));
     }
 
-    private CommonProfile assertToken(FacebookProfile profile, String token, JwtAuthenticator authenticator) throws HttpAction {
+    private CommonProfile assertToken(FacebookProfile profile, String token, JwtAuthenticator authenticator)
+            throws HttpAction, CredentialsException {
         final TokenCredentials credentials = new TokenCredentials(token, CLIENT_NAME);
         authenticator.validate(credentials, null);
         final CommonProfile profile2 = credentials.getUserProfile();
@@ -289,8 +290,8 @@ public final class JwtTests implements TestsConstants {
         return profile;
     }
 
-    @Test(expected = TechnicalException.class)
-    public void testAuthenticateFailed() throws HttpAction {
+    @Test(expected = CredentialsException.class)
+    public void testAuthenticateFailed() throws HttpAction, CredentialsException {
         final JwtAuthenticator authenticator = new JwtAuthenticator(new SecretSignatureConfiguration(MAC_SECRET), new SecretEncryptionConfiguration(MAC_SECRET));
         final TokenCredentials credentials = new TokenCredentials("fakeToken", CLIENT_NAME);
         authenticator.validate(credentials, null);

--- a/pac4j-ldap/src/main/java/org/pac4j/ldap/credentials/authenticator/LdapAuthenticator.java
+++ b/pac4j-ldap/src/main/java/org/pac4j/ldap/credentials/authenticator/LdapAuthenticator.java
@@ -10,6 +10,7 @@ import org.ldaptive.auth.Authenticator;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.AccountNotFoundException;
 import org.pac4j.core.exception.BadCredentialsException;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.creator.AuthenticatorProfileCreator;
@@ -53,7 +54,7 @@ public class LdapAuthenticator extends InitializableWebObject implements org.pac
     }
 
     @Override
-    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
         init(context);
 
         final String username = credentials.getUsername();

--- a/pac4j-ldap/src/test/java/org/pac4j/ldap/credentials/authenticator/LdapAuthenticatorTests.java
+++ b/pac4j-ldap/src/test/java/org/pac4j/ldap/credentials/authenticator/LdapAuthenticatorTests.java
@@ -3,6 +3,7 @@ package org.pac4j.ldap.credentials.authenticator;
 import org.junit.*;
 import org.ldaptive.auth.Authenticator;
 import org.pac4j.core.exception.BadCredentialsException;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
@@ -42,26 +43,26 @@ public final class LdapAuthenticatorTests implements TestsConstants {
     }
 
     @Test
-    public void testNullAuthenticator() throws HttpAction {
+    public void testNullAuthenticator() {
         final LdapAuthenticator ldapAuthenticator = new LdapAuthenticator();
         TestsHelper.expectException(() -> ldapAuthenticator.init(null), TechnicalException.class, "ldapAuthenticator cannot be null");
     }
 
     @Test
-    public void testNullAttributes() throws HttpAction {
+    public void testNullAttributes() {
         final LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(authenticator, null);
         TestsHelper.expectException(() -> ldapAuthenticator.init(null), TechnicalException.class, "attributes cannot be null");
     }
 
     @Test(expected = BadCredentialsException.class)
-    public void authentFailed() throws HttpAction {
+    public void authentFailed() throws HttpAction, CredentialsException {
         final LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(authenticator);
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
         ldapAuthenticator.validate(credentials, null);
     }
 
     @Test
-    public void authentSuccessNoAttribute() throws HttpAction {
+    public void authentSuccessNoAttribute() throws HttpAction, CredentialsException {
         final LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(authenticator);
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
         ldapAuthenticator.validate(credentials, null);
@@ -75,7 +76,7 @@ public final class LdapAuthenticatorTests implements TestsConstants {
     }
 
     @Test
-    public void authentSuccessSingleAttribute() throws HttpAction {
+    public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
         final LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(authenticator, LdapServer.CN + "," + LdapServer.SN);
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
         ldapAuthenticator.validate(credentials, null);
@@ -91,7 +92,7 @@ public final class LdapAuthenticatorTests implements TestsConstants {
     }
 
     @Test
-    public void authentSuccessMultiAttribute() throws HttpAction {
+    public void authentSuccessMultiAttribute() throws HttpAction, CredentialsException {
         final LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(authenticator, LdapServer.CN + "," + LdapServer.SN + "," + LdapServer.ROLE);
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME2, PASSWORD, CLIENT_NAME);
         ldapAuthenticator.validate(credentials, null);

--- a/pac4j-mongo/src/main/java/org/pac4j/mongo/credentials/authenticator/MongoAuthenticator.java
+++ b/pac4j-mongo/src/main/java/org/pac4j/mongo/credentials/authenticator/MongoAuthenticator.java
@@ -9,6 +9,7 @@ import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.AccountNotFoundException;
 import org.pac4j.core.exception.BadCredentialsException;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.exception.MultipleAccountsFoundException;
 import org.pac4j.core.profile.creator.AuthenticatorProfileCreator;
@@ -78,7 +79,7 @@ public class MongoAuthenticator extends AbstractUsernamePasswordAuthenticator {
     }
 
     @Override
-    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
 
         init(context);
 

--- a/pac4j-mongo/src/test/java/org/pac4j/mongo/credentials/authenticator/MongoAuthenticatorIT.java
+++ b/pac4j-mongo/src/test/java/org/pac4j/mongo/credentials/authenticator/MongoAuthenticatorIT.java
@@ -38,47 +38,47 @@ public class MongoAuthenticatorIT implements TestsConstants {
 
 
     @Test
-    public void testNullPasswordEncoder() throws HttpAction {
+    public void testNullPasswordEncoder() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), FIRSTNAME);
         authenticator.setPasswordEncoder(null);
         TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "passwordEncoder cannot be null");
     }
 
     @Test
-    public void testNullAttribute() throws HttpAction {
+    public void testNullAttribute() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), null, new NopPasswordEncoder());
         TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "attributes cannot be null");
     }
 
     @Test
-    public void testNullMongoClient() throws HttpAction {
+    public void testNullMongoClient() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(null, FIRSTNAME, new NopPasswordEncoder());
         TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "mongoClient cannot be null");
     }
 
     @Test
-    public void testNullDatabase() throws HttpAction {
+    public void testNullDatabase() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), FIRSTNAME, new NopPasswordEncoder());
         authenticator.setUsersDatabase(null);
         TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "usersDatabase cannot be null");
     }
 
     @Test
-    public void testNullCollection() throws HttpAction {
+    public void testNullCollection() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), FIRSTNAME, new NopPasswordEncoder());
         authenticator.setUsersCollection(null);
         TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "usersCollection cannot be null");
     }
 
     @Test
-    public void testNullUsername() throws HttpAction {
+    public void testNullUsername() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), FIRSTNAME, new NopPasswordEncoder());
         authenticator.setUsernameAttribute(null);
         TestsHelper.expectException(() -> authenticator.init(null), TechnicalException.class, "usernameAttribute cannot be null");
     }
 
     @Test
-    public void testNullPassword() throws HttpAction {
+    public void testNullPassword() {
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), FIRSTNAME, new NopPasswordEncoder());
         authenticator.setPasswordAttribute(null);
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
@@ -89,7 +89,7 @@ public class MongoAuthenticatorIT implements TestsConstants {
         return new MongoClient("localhost", PORT);
     }
 
-    private UsernamePasswordCredentials login(final String username, final String password, final String attribute) throws HttpAction {
+    private UsernamePasswordCredentials login(final String username, final String password, final String attribute) throws HttpAction, CredentialsException{
         final MongoAuthenticator authenticator = new MongoAuthenticator(getClient(), attribute);
         authenticator.setPasswordEncoder(new BasicSaltedSha512PasswordEncoder(SALT));
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(username, password, CLIENT_NAME);
@@ -99,7 +99,7 @@ public class MongoAuthenticatorIT implements TestsConstants {
     }
 
     @Test
-    public void testGoodUsernameAttribute() throws HttpAction {
+    public void testGoodUsernameAttribute() throws HttpAction, CredentialsException {
         final UsernamePasswordCredentials credentials =  login(GOOD_USERNAME, PASSWORD, FIRSTNAME);
 
         final CommonProfile profile = credentials.getUserProfile();
@@ -111,7 +111,7 @@ public class MongoAuthenticatorIT implements TestsConstants {
     }
 
     @Test
-    public void testGoodUsernameNoAttribute() throws HttpAction {
+    public void testGoodUsernameNoAttribute() throws HttpAction, CredentialsException {
         final UsernamePasswordCredentials credentials =  login(GOOD_USERNAME, PASSWORD, "");
 
         final CommonProfile profile = credentials.getUserProfile();
@@ -123,17 +123,17 @@ public class MongoAuthenticatorIT implements TestsConstants {
     }
 
     @Test(expected = MultipleAccountsFoundException.class)
-    public void testMultipleUsername() throws HttpAction {
+    public void testMultipleUsername() throws HttpAction, CredentialsException {
         login(MULTIPLE_USERNAME, PASSWORD, "");
     }
 
     @Test(expected = AccountNotFoundException.class)
-    public void testBadUsername() throws HttpAction {
+    public void testBadUsername() throws HttpAction, CredentialsException {
         login(BAD_USERNAME, PASSWORD, "");
     }
 
     @Test(expected = BadCredentialsException.class)
-    public void testBadPassword() throws HttpAction {
+    public void testBadPassword() throws HttpAction, CredentialsException {
         login(GOOD_USERNAME, PASSWORD + "bad", "");
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/exception/OAuthCredentialsException.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/exception/OAuthCredentialsException.java
@@ -2,7 +2,7 @@ package org.pac4j.oauth.exception;
 
 import java.util.*;
 
-import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.exception.TechnicalException;
 
 /**
  * This class represents an exception occurring during OAuth credentials retrieval.
@@ -10,7 +10,7 @@ import org.pac4j.core.exception.CredentialsException;
  * @author Jerome Leleu
  * @since 1.3.0
  */
-public class OAuthCredentialsException extends CredentialsException {
+public class OAuthCredentialsException extends TechnicalException {
     
     private static final long serialVersionUID = -3540979749535811079L;
     

--- a/pac4j-sql/src/main/java/org/pac4j/sql/credentials/authenticator/DbAuthenticator.java
+++ b/pac4j-sql/src/main/java/org/pac4j/sql/credentials/authenticator/DbAuthenticator.java
@@ -68,7 +68,8 @@ public class DbAuthenticator extends AbstractUsernamePasswordAuthenticator {
     }
 
     @Override
-    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final UsernamePasswordCredentials credentials, final WebContext context)
+            throws HttpAction, CredentialsException {
 
         init(context);
 

--- a/pac4j-sql/src/test/java/org/pac4j/sql/credentials/authenticator/DbAuthenticatorTests.java
+++ b/pac4j-sql/src/test/java/org/pac4j/sql/credentials/authenticator/DbAuthenticatorTests.java
@@ -25,26 +25,26 @@ public final class DbAuthenticatorTests implements TestsConstants {
     private DataSource ds = DbServer.getInstance();
 
     @Test(expected = TechnicalException.class)
-    public void testNullPasswordEncoder() throws HttpAction {
+    public void testNullPasswordEncoder() throws HttpAction, CredentialsException {
         final DbAuthenticator authenticator = new DbAuthenticator(ds, FIRSTNAME);
         authenticator.validate(null, null);
     }
 
     @Test(expected = TechnicalException.class)
-    public void testNullAttribute() throws HttpAction {
+    public void testNullAttribute() throws HttpAction, CredentialsException {
         final DbAuthenticator authenticator = new DbAuthenticator(ds, null);
         authenticator.setPasswordEncoder(new NopPasswordEncoder());
         authenticator.validate(null, null);
     }
 
     @Test(expected = TechnicalException.class)
-    public void testNullDataSource() throws HttpAction {
+    public void testNullDataSource() throws HttpAction, CredentialsException {
         final DbAuthenticator authenticator = new DbAuthenticator(null, FIRSTNAME);
         authenticator.setPasswordEncoder(new NopPasswordEncoder());
         authenticator.validate(null, null);
     }
 
-    private UsernamePasswordCredentials login(final String username, final String password, final String attribute) throws HttpAction {
+    private UsernamePasswordCredentials login(final String username, final String password, final String attribute) throws HttpAction, CredentialsException {
         final DbAuthenticator authenticator = new DbAuthenticator(ds, attribute);
         authenticator.setPasswordEncoder(new BasicSaltedSha512PasswordEncoder(SALT));
 
@@ -55,7 +55,7 @@ public final class DbAuthenticatorTests implements TestsConstants {
     }
 
     @Test
-    public void testGoodUsernameAttribute() throws HttpAction {
+    public void testGoodUsernameAttribute() throws HttpAction, CredentialsException {
         final UsernamePasswordCredentials credentials =  login(GOOD_USERNAME, PASSWORD, FIRSTNAME);
 
         final CommonProfile profile = credentials.getUserProfile();
@@ -67,7 +67,7 @@ public final class DbAuthenticatorTests implements TestsConstants {
     }
 
     @Test
-    public void testGoodUsernameNoAttribute() throws HttpAction {
+    public void testGoodUsernameNoAttribute() throws HttpAction, CredentialsException {
         final UsernamePasswordCredentials credentials =  login(GOOD_USERNAME, PASSWORD, "");
 
         final CommonProfile profile = credentials.getUserProfile();
@@ -79,17 +79,17 @@ public final class DbAuthenticatorTests implements TestsConstants {
     }
 
     @Test(expected = MultipleAccountsFoundException.class)
-    public void testMultipleUsername() throws HttpAction {
+    public void testMultipleUsername() throws HttpAction, CredentialsException {
         login(MULTIPLE_USERNAME, PASSWORD, "");
     }
 
     @Test(expected = AccountNotFoundException.class)
-    public void testBadUsername() throws HttpAction {
+    public void testBadUsername() throws HttpAction, CredentialsException {
         login(BAD_USERNAME, PASSWORD, "");
     }
 
     @Test(expected = BadCredentialsException.class)
-    public void testBadPassword() throws HttpAction {
+    public void testBadPassword() throws HttpAction, CredentialsException {
         login(GOOD_USERNAME, PASSWORD + "bad", "");
     }
 }

--- a/pac4j-stormpath/src/main/java/org/pac4j/stormpath/credentials/authenticator/StormpathAuthenticator.java
+++ b/pac4j-stormpath/src/main/java/org/pac4j/stormpath/credentials/authenticator/StormpathAuthenticator.java
@@ -10,7 +10,9 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.BadCredentialsException;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.authenticator.Authenticator;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
+import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.InitializableWebObject;
 import org.pac4j.stormpath.profile.StormpathProfile;
@@ -66,14 +68,14 @@ public class StormpathAuthenticator extends InitializableWebObject
             this.application = client.getDataStore().getResource(
                     String.format("/applications/%s", applicationId), Application.class);
         } catch (final Exception e) {
-            throw new BadCredentialsException("An exception is caught trying to access Stormpath cloud. " +
+            throw new TechnicalException("An exception is caught trying to access Stormpath cloud. " +
                     "Please verify that your provided Stormpath <accessId>, " +
-                    "<secretKey>, and <applicationId> are correct. Original Stormpath error: " + e.getMessage());
+                    "<secretKey>, and <applicationId> are correct.", e);
         }
     }
 
     @Override
-    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction {
+    public void validate(final UsernamePasswordCredentials credentials, final WebContext context) throws HttpAction, CredentialsException {
 
         init(context);
 

--- a/pac4j-stormpath/src/test/java/org/pac4j/stormpath/credentials/authenticator/StormpathAuthenticatorIT.java
+++ b/pac4j-stormpath/src/test/java/org/pac4j/stormpath/credentials/authenticator/StormpathAuthenticatorIT.java
@@ -4,6 +4,7 @@ import com.stormpath.sdk.group.GroupList;
 import com.stormpath.sdk.group.GroupMembershipList;
 import org.junit.Test;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
@@ -26,7 +27,7 @@ public final class StormpathAuthenticatorIT implements TestsConstants {
     }
 
     @Test
-    public void testFullAuthentication() throws HttpAction {
+    public void testFullAuthentication() throws HttpAction, CredentialsException {
         // luminous-smoke1
         final StormpathAuthenticator authenticator = new StormpathAuthenticator("77NW47MHGJV5DA8R5UA5YORE0",
                 "nPCDRYPPxhBNpq1HT9Gr85hB7fCACQXSHx0aCuG6D/Q", "2MahZGmC0Rcl7gYkVIea94");


### PR DESCRIPTION
EDIT: see comments below, this has been rebased on top of #697 

A fix for #695

It became MUCH bigger than what I expected at first.

The thing is that I found myself needing to differentiate between expect exception (such as bad formatted client request, invalid credentials, missing information, unexisting accounts) and unexpected exception (such as multiple accounts in the db, problem connecting to the remote authenticator provider, etc).

So I made `CredentialsException` extends Exception instead of `TechnicalException`, I made `MultipleAccountsFoundException` extends `TechnicalException`, and then I had to make `OAuthCredentialsException` extends `TechnicalException` too because the OAuth client is not a `IndirectClientV2` and does not use the `Authenticator` abstractions.

Then because `CredentialsException` became a checked exception, I had to change a lot of things in many places, mostly tests.

I took this opportunity to add a few improvements in the `LocalCachingAuthenticator` so that it rethrow the original exception and not the cache's `ExecutionException`.
I also improved (but please check it is correct) the `JwtAuthenticator` to throw a `CredentialsException` instead of a `TechnicalException` when the JWT token can't be parsed, because it is expected that client could send wrong data. The opposite happened with the `StormpathAuthenticator` that was throwing a `BadCredentialsException` when it had a problem connecting to Stormpath.

This changes the API of `Authenticator` because now it can throw 2 checked exception in validate. The same for `CredentialsExtractor` (maybe in its case, an exception for bad format could be introduced instead of using the generic `CredentialsException` by the way...).