### PR TITLE
Check all JWT signing configurations before giving up

### DIFF
--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
@@ -163,7 +163,9 @@ public class JwtAuthenticator implements Authenticator<TokenCredentials> {
                             try {
                                 verified = config.verify(signedJWT);
                                 found = true;
-                                break;
+                                if (verified) {
+                                  break;
+                                }
                             } catch (final JOSEException e) {
                                 logger.debug("Verification fails with signature configuration: {}, passing to the next one", config);
                             }


### PR DESCRIPTION
There are cases where a service publishes several keys that are all valid signers of JWT Tokens, for example google publishes several associated with their android sign in tool. (See https://developers.google.com/identity/sign-in/android/start-integrating for an in depth description of the flow, https://www.googleapis.com/oauth2/v3/certs is a list of the keys that they provide.)

When adding multiple signature configurations to a jwtAuthenticator, only the first signature configuration is tried.

I think this change should cause the JWT Authenticator to correctly attempt each successive configuration. This would be my first patch into Pac4J, and I would appreciate any feedback on the patch. 