### PR TITLE
Improve integration with Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ overlays
 pac4j-test-cas/overlays/
 .DS_Store
 documentation/_site/
+.fbExcludeFilterFile
+.pmd
+.pmdruleset.xml

--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
 					<effort>Low</effort> <!-- Max -->
 					<threshold>Max</threshold> <!-- Medium Low -->
 					<failOnError>true</failOnError>
-					<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
+					<excludeFilterFile>${basedir}/../findbugs-exclude.xml</excludeFilterFile>
 					<includeTests>true</includeTests>
 				</configuration>
 				<executions>


### PR DESCRIPTION
- ignore more eclipse-originated files
- use a non parent-pom-relative findbugs exclusion file