### PR TITLE
Add a mechanism to handle attributes serialization into strings

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/InternalAttributeHandler.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/InternalAttributeHandler.java
@@ -25,13 +25,13 @@ public class InternalAttributeHandler implements Serializable {
 
     protected transient final Logger logger = LoggerFactory.getLogger(getClass());
 
-    public transient final static String PREFIX = "{#";
-    public transient final static String PREFIX_BOOLEAN = PREFIX + "bool}";
-    public transient final static String PREFIX_INT = PREFIX + "int}";
-    public transient final static String PREFIX_LONG = PREFIX + "long}";
-    public transient final static String PREFIX_DATE = PREFIX + "date}";
-    public transient final static String PREFIX_URI = PREFIX + "uri}";
-    public transient final static String PREFIX_SB64 = PREFIX + "sb64}";
+    public transient static final String PREFIX = "{#";
+    public transient static final String PREFIX_BOOLEAN = PREFIX + "bool}";
+    public transient static final String PREFIX_INT = PREFIX + "int}";
+    public transient static final String PREFIX_LONG = PREFIX + "long}";
+    public transient static final String PREFIX_DATE = PREFIX + "date}";
+    public transient static final String PREFIX_URI = PREFIX + "uri}";
+    public transient static final String PREFIX_SB64 = PREFIX + "sb64}";
 
     private JavaSerializationHelper serializationHelper = new JavaSerializationHelper();
 
@@ -48,17 +48,17 @@ public class InternalAttributeHandler implements Serializable {
             return value;
         } else {
             if (value instanceof Boolean) {
-                return PREFIX_BOOLEAN + value;
+                return PREFIX_BOOLEAN.concat(value.toString());
             } else if (value instanceof Integer) {
-                return PREFIX_INT + value;
+                return PREFIX_INT.concat(value.toString());
             } else if (value instanceof Long) {
-                return PREFIX_LONG + value;
+                return PREFIX_LONG.concat(value.toString());
             } else if (value instanceof Date) {
-                return PREFIX_DATE + newSdf().format((Date) value);
+                return PREFIX_DATE.concat(newSdf().format((Date) value));
             } else if (value instanceof URI) {
-                return PREFIX_URI + value.toString();
+                return PREFIX_URI.concat(value.toString());
             } else {
-                return PREFIX_SB64 + serializationHelper.serializeToBase64((Serializable) value);
+                return PREFIX_SB64.concat(serializationHelper.serializeToBase64((Serializable) value));
             }
         }
     }
@@ -117,6 +117,12 @@ public class InternalAttributeHandler implements Serializable {
         return stringify;
     }
 
+    /**
+     * Define if we need to turn all attributes into strings, to properly work with CAS
+     * (regarding Kryo serialization or service ticket validation).
+     *
+     * @param stringify whether we need to turn all attributes into strings
+     */
     public void setStringify(final boolean stringify) {
         this.stringify = stringify;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/InternalAttributeHandler.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/InternalAttributeHandler.java
@@ -1,0 +1,128 @@
+package org.pac4j.core.profile;
+
+import org.pac4j.core.profile.converter.Converters;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.core.util.JavaSerializationHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Internally handles attributes (set / get).
+ *
+ * @author Jerome Leleu
+ * @since 2.0.0
+ */
+public class InternalAttributeHandler implements Serializable {
+
+    private static final long serialVersionUID = 3391226300882369266L;
+
+    protected transient final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public transient final static String PREFIX = "{#";
+    public transient final static String PREFIX_BOOLEAN = PREFIX + "bool}";
+    public transient final static String PREFIX_INT = PREFIX + "int}";
+    public transient final static String PREFIX_LONG = PREFIX + "long}";
+    public transient final static String PREFIX_DATE = PREFIX + "date}";
+    public transient final static String PREFIX_URI = PREFIX + "uri}";
+    public transient final static String PREFIX_SB64 = PREFIX + "sb64}";
+
+    private JavaSerializationHelper serializationHelper = new JavaSerializationHelper();
+
+    private boolean stringify = false;
+
+    /**
+     * Before saving the attribute into the attributes map.
+     *
+     * @param value the original value
+     * @return the prepared value
+     */
+    public Object prepare(final Object value) {
+        if (value == null || value instanceof String || !stringify) {
+            return value;
+        } else {
+            if (value instanceof Boolean) {
+                return PREFIX_BOOLEAN + value;
+            } else if (value instanceof Integer) {
+                return PREFIX_INT + value;
+            } else if (value instanceof Long) {
+                return PREFIX_LONG + value;
+            } else if (value instanceof Date) {
+                return PREFIX_DATE + newSdf().format((Date) value);
+            } else if (value instanceof URI) {
+                return PREFIX_URI + value.toString();
+            } else {
+                return PREFIX_SB64 + serializationHelper.serializeToBase64((Serializable) value);
+            }
+        }
+    }
+
+    /**
+     * After retrieving the attribute from the attributes map.
+     *
+     * @param value the retrieved value
+     * @return the restored value
+     */
+    public Object restore(final Object value) {
+        if (value != null && value instanceof String) {
+            final String sValue = (String) value;
+            if (sValue.startsWith(PREFIX)) {
+                if (sValue.startsWith(PREFIX_BOOLEAN)) {
+                    return Boolean.parseBoolean(sValue.substring(PREFIX_BOOLEAN.length()));
+                } else if (sValue.startsWith(PREFIX_INT)) {
+                    return Integer.parseInt(sValue.substring(PREFIX_INT.length()));
+                } else if (sValue.startsWith(PREFIX_LONG)) {
+                    return Long.parseLong(sValue.substring(PREFIX_LONG.length()));
+                } else if (sValue.startsWith(PREFIX_DATE)) {
+                    final String d = sValue.substring(PREFIX_DATE.length());
+                    try {
+                        return newSdf().parse(d);
+                    } catch (final ParseException e) {
+                        logger.warn("Unable to parse stringified date: {}", d, e);
+                    }
+                } else if (sValue.startsWith(PREFIX_URI)) {
+                    final String uri = sValue.substring(PREFIX_URI.length());
+                    try {
+                        return new URI(uri);
+                    } catch (final URISyntaxException e) {
+                        logger.warn("Unable to parse stringified URI: {}", uri, e);
+                    }
+                } else if (sValue.startsWith(PREFIX_SB64)) {
+                    return serializationHelper.unserializeFromBase64(sValue.substring(PREFIX_SB64.length()));
+                }
+            }
+        }
+        return value;
+    }
+
+    protected SimpleDateFormat newSdf() {
+        return new SimpleDateFormat(Converters.DATE_TZ_GENERAL_FORMAT);
+    }
+
+    public JavaSerializationHelper getSerializationHelper() {
+        return serializationHelper;
+    }
+
+    public void setSerializationHelper(final JavaSerializationHelper serializationHelper) {
+        this.serializationHelper = serializationHelper;
+    }
+
+    public boolean isStringify() {
+        return stringify;
+    }
+
+    public void setStringify(final boolean stringify) {
+        this.stringify = stringify;
+    }
+
+    @Override
+    public String toString() {
+        return CommonHelper.toString(this.getClass(), "serializationHelper", serializationHelper, "stringify", stringify);
+    }
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/InternalAttributeHandler.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/InternalAttributeHandler.java
@@ -19,9 +19,7 @@ import java.util.Date;
  * @author Jerome Leleu
  * @since 2.0.0
  */
-public class InternalAttributeHandler implements Serializable {
-
-    private static final long serialVersionUID = 3391226300882369266L;
+public class InternalAttributeHandler {
 
     protected transient final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -22,6 +22,8 @@ public final class ProfileHelper {
 
     private static final Map<String, Constructor<? extends CommonProfile>> constructorsCache = new ConcurrentHashMap<>();
 
+    private static InternalAttributeHandler internalAttributeHandler = new InternalAttributeHandler();
+
     /**
      * Indicate if the user identifier matches this kind of profile.
      * 
@@ -148,5 +150,13 @@ public final class ProfileHelper {
             listProfiles.add(entry.getValue());
         }
         return Collections.unmodifiableList(listProfiles);
+    }
+
+    public static InternalAttributeHandler getInternalAttributeHandler() {
+        return internalAttributeHandler;
+    }
+
+    public static void setInternalAttributeHandler(final InternalAttributeHandler internalAttributeHandler) {
+        ProfileHelper.internalAttributeHandler = internalAttributeHandler;
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -39,8 +39,6 @@ public abstract class UserProfile implements Serializable, Externalizable {
 
     private String clientName;
 
-    private static InternalAttributeHandler internalAttributeHandler = new InternalAttributeHandler();
-
     /**
      * Build a profile from user identifier and attributes.
      * 
@@ -74,7 +72,7 @@ public abstract class UserProfile implements Serializable, Externalizable {
             if (definition == null) {
                 logger.debug("no conversion => key: {} / value: {} / {}",
                         new Object[] { key, value, value.getClass() });
-                this.attributes.put(key, internalAttributeHandler.prepare(value));
+                this.attributes.put(key, ProfileHelper.getInternalAttributeHandler().prepare(value));
             } else {
                 value = definition.convert(key, value);
                 if (value != null) {
@@ -87,7 +85,7 @@ public abstract class UserProfile implements Serializable, Externalizable {
                     }
                     logger.debug("converted to => key: {} / value: {} / {}",
                             new Object[] { key, value2, value2.getClass() });
-                    this.attributes.put(key, internalAttributeHandler.prepare(value2));
+                    this.attributes.put(key, ProfileHelper.getInternalAttributeHandler().prepare(value2));
                 }
             }
         }
@@ -177,7 +175,7 @@ public abstract class UserProfile implements Serializable, Externalizable {
      * @return the attribute with name
      */
     public Object getAttribute(final String name) {
-        return internalAttributeHandler.restore(this.attributes.get(name));
+        return ProfileHelper.getInternalAttributeHandler().restore(this.attributes.get(name));
     }
 
     /**
@@ -346,13 +344,5 @@ public abstract class UserProfile implements Serializable, Externalizable {
     public void setClientName(String clientName) {
         CommonHelper.assertNotNull("clientName", clientName);
         this.clientName = clientName;
-    }
-
-    public static InternalAttributeHandler getInternalAttributeHandler() {
-        return internalAttributeHandler;
-    }
-
-    public static void setInternalAttributeHandler(final InternalAttributeHandler internalAttributeHandler) {
-        UserProfile.internalAttributeHandler = internalAttributeHandler;
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
@@ -14,9 +14,7 @@ import java.util.List;
  * @author Jerome Leleu
  * @since 1.8.1
  */
-public class JavaSerializationHelper implements Serializable {
-
-    private static final long serialVersionUID = -752260329685838265L;
+public class JavaSerializationHelper {
 
     private transient static final Logger logger = LoggerFactory.getLogger(JavaSerializationHelper.class);
 

--- a/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
@@ -14,9 +14,11 @@ import java.util.List;
  * @author Jerome Leleu
  * @since 1.8.1
  */
-public class JavaSerializationHelper {
+public class JavaSerializationHelper implements Serializable {
 
-    private static final Logger logger = LoggerFactory.getLogger(JavaSerializationHelper.class);
+    private static final long serialVersionUID = -752260329685838265L;
+
+    private transient static final Logger logger = LoggerFactory.getLogger(JavaSerializationHelper.class);
 
     private List<String> trustedPackages = Arrays.asList("java.", "javax.", "org.pac4j.", "com.github.scribejava.", "org.opensaml.", "com.nimbusds.", "org.joda.");
 

--- a/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public class JavaSerializationHelper {
 
-    private transient static final Logger logger = LoggerFactory.getLogger(JavaSerializationHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(JavaSerializationHelper.class);
 
     private List<String> trustedPackages = Arrays.asList("java.", "javax.", "org.pac4j.", "com.github.scribejava.", "org.opensaml.", "com.nimbusds.", "org.joda.");
 

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
@@ -6,6 +6,7 @@ import java.util.Set;
 
 import org.junit.Test;
 import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.util.JavaSerializationHelper;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
 
@@ -130,5 +131,29 @@ public final class CommonProfileTests implements TestsConstants {
     public void testNullPermissions() {
         final CommonProfile profile = new CommonProfile();
         TestsHelper.expectException(() -> profile.addPermissions((Set<String>) null), TechnicalException.class, "permissions cannot be null");
+    }
+
+    @Test
+    public void serializeProfile() {
+        final JavaSerializationHelper helper = new JavaSerializationHelper();
+        final CommonProfile profile = new CommonProfile();
+        final String s = helper.serializeToBase64(profile);
+        final CommonProfile profile2 = (CommonProfile) helper.unserializeFromBase64(s);
+        assertNotNull(profile2);
+    }
+
+    @Test
+    public void stringifyProfile() {
+        try {
+            UserProfile.getInternalAttributeHandler().setStringify(true);
+            final CommonProfile profile = new CommonProfile();
+            profile.setId(ID);
+            profile.addAttribute(KEY, true);
+            profile.addAttribute(NAME, 1);
+            assertEquals(true, profile.getAttribute(KEY));
+            assertEquals(1, profile.getAttributes().get(NAME));
+        } finally {
+            UserProfile.getInternalAttributeHandler().setStringify(false);
+        }
     }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
@@ -145,7 +145,7 @@ public final class CommonProfileTests implements TestsConstants {
     @Test
     public void stringifyProfile() {
         try {
-            UserProfile.getInternalAttributeHandler().setStringify(true);
+            ProfileHelper.getInternalAttributeHandler().setStringify(true);
             final CommonProfile profile = new CommonProfile();
             profile.setId(ID);
             profile.addAttribute(KEY, true);
@@ -153,7 +153,7 @@ public final class CommonProfileTests implements TestsConstants {
             assertEquals(true, profile.getAttribute(KEY));
             assertEquals(1, profile.getAttributes().get(NAME));
         } finally {
-            UserProfile.getInternalAttributeHandler().setStringify(false);
+            ProfileHelper.getInternalAttributeHandler().setStringify(false);
         }
     }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/InternalAttributeHandlerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/InternalAttributeHandlerTests.java
@@ -19,12 +19,12 @@ import static org.junit.Assert.*;
  */
 public final class InternalAttributeHandlerTests implements TestsConstants {
 
-    private final static boolean BOOL = true;
-    private final static int INT = 1;
-    private final static long LONG = 2L;
-    private final static Date DATE = new Date();
-    private final static URI URL;
-    private final static Color COLOR = new Color(1,1,1);
+    private static final boolean BOOL = true;
+    private static final int INT = 1;
+    private static final long LONG = 2L;
+    private static final Date DATE = new Date();
+    private static final URI URL;
+    private static final Color COLOR = new Color(1,1,1);
 
     static {
         try {

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/InternalAttributeHandlerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/InternalAttributeHandlerTests.java
@@ -1,0 +1,72 @@
+package org.pac4j.core.profile;
+
+import org.junit.Test;
+import org.pac4j.core.profile.converter.Converters;
+import org.pac4j.core.util.TestsConstants;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link InternalAttributeHandler}.
+ *
+ * @author Jerome Leleu
+ * @since 2.0.0
+ */
+public final class InternalAttributeHandlerTests implements TestsConstants {
+
+    private final static boolean BOOL = true;
+    private final static int INT = 1;
+    private final static long LONG = 2L;
+    private final static Date DATE = new Date();
+    private final static URI URL;
+    private final static Color COLOR = new Color(1,1,1);
+
+    static {
+        try {
+            URL = new URI("http://www.google.com");
+        } catch (final URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void noStringify() {
+        final InternalAttributeHandler handler = new InternalAttributeHandler();
+        assertAttribute(handler, null, null);
+        assertAttribute(handler, VALUE, VALUE);
+        assertAttribute(handler, BOOL, BOOL);
+        assertAttribute(handler, INT, INT);
+        assertAttribute(handler, LONG, LONG);
+        assertAttribute(handler, DATE, DATE);
+        assertAttribute(handler, URL, URL);
+        assertAttribute(handler, COLOR, COLOR);
+    }
+
+    @Test
+    public void stringify() {
+        final InternalAttributeHandler handler = new InternalAttributeHandler();
+        handler.setStringify(true);
+        assertAttribute(handler, null, null);
+        assertAttribute(handler, VALUE, VALUE);
+        assertAttribute(handler, BOOL, InternalAttributeHandler.PREFIX_BOOLEAN + BOOL);
+        assertAttribute(handler, INT, InternalAttributeHandler.PREFIX_INT + INT);
+        assertAttribute(handler, LONG, InternalAttributeHandler.PREFIX_LONG + LONG);
+        assertAttribute(handler, DATE, InternalAttributeHandler.PREFIX_DATE + new SimpleDateFormat(Converters.DATE_TZ_GENERAL_FORMAT).format(DATE));
+        assertAttribute(handler, URL, InternalAttributeHandler.PREFIX_URI + URL.toString());
+        assertAttribute(handler, COLOR, InternalAttributeHandler.PREFIX_SB64 + "rO0ABXNyABxvcmcucGFjNGouY29yZS5wcm9maWxlLkNvbG9y/5w8lvR27osCAANJAARibHVlSQAFZ3JlZW5JAANyZWR4cAAAAAEAAAABAAAAAQ==");
+    }
+
+    private void assertAttribute(final InternalAttributeHandler handler, final Object given, final Object transformed) {
+        assertEquals(transformed, handler.prepare(given));
+        if (given instanceof Date || given instanceof Color) {
+            assertEquals(given.toString(), handler.restore(transformed).toString());
+        } else {
+            assertEquals(given, handler.restore(transformed));
+        }
+    }
+}


### PR DESCRIPTION
@mmoayyed :

There is now an `InternalAttributeHandler`, global to all profiles which handle attributes before saving them in the map or after restoring them from the map.

In CAS, we will do: `ProfileHelper.getInternalAttributeHandler().setStringify(true);` to force attributes to be turned into strings (otherwise, nothing is required).

In that case:
A string stays a string.
A boolean becomes a "{#bool} + boolean value" String.
An integer becomes a "{#int} + integer value" String.
A long becomes a "{#long} + long value" String.
A date becomes a "{#date} + date value" String.
An URI becomes a "{#uri} + uri value" String.
Otherwise, it becomes a "{#sb64} + serialized and base64 value" String.
