### PR TITLE
Changes to allow IDC's PAC4J Extensions build against PAC4J

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/Clients.java
@@ -89,25 +89,7 @@ public class Clients extends InitializableObject {
             }
             names.add(lowerName);
             if (client instanceof IndirectClient) {
-                final IndirectClient indirectClient = (IndirectClient) client;
-                String indirectClientCallbackUrl = indirectClient.getCallbackUrl();
-                // no callback url defined for the client but a group callback one -> set it with the group callback url
-                if (CommonHelper.isNotBlank(this.callbackUrl) && indirectClientCallbackUrl == null) {
-                    indirectClient.setCallbackUrl(this.callbackUrl);
-                    indirectClientCallbackUrl = this.callbackUrl;
-                }
-                // if the "client_name" parameter is not already part of the client callback url, add it unless the client has indicated to not include it.
-                if (indirectClient.isIncludeClientNameInCallbackUrl() && indirectClientCallbackUrl != null && !indirectClientCallbackUrl.contains(this.clientNameParameter + "=")) {
-                    indirectClient.setCallbackUrl(CommonHelper.addParameter(indirectClientCallbackUrl, this.clientNameParameter, name));
-                }
-                final AjaxRequestResolver clientAjaxRequestResolver = indirectClient.getAjaxRequestResolver();
-                if (ajaxRequestResolver != null && (clientAjaxRequestResolver == null || clientAjaxRequestResolver instanceof DefaultAjaxRequestResolver)) {
-                    indirectClient.setAjaxRequestResolver(ajaxRequestResolver);
-                }
-                final CallbackUrlResolver clientCallbackUrlResolver = indirectClient.getCallbackUrlResolver();
-                if (callbackUrlResolver != null && (clientCallbackUrlResolver == null || clientCallbackUrlResolver instanceof DefaultCallbackUrlResolver)) {
-                    indirectClient.setCallbackUrlResolver(this.callbackUrlResolver);
-                }
+                updateCallbackUrlOfIndirectClient((IndirectClient) client);
             }
             final BaseClient baseClient = (BaseClient) client;
             if (!authorizationGenerators.isEmpty()) {
@@ -116,6 +98,34 @@ public class Clients extends InitializableObject {
         }
     }
 
+    
+    /**
+     * Sets a client's Callback URL, if not already set. If requested, the "client_name" parameter will also be a part of the URL.
+     * 
+     * @param indirectClient A client.
+     */
+    protected void updateCallbackUrlOfIndirectClient(final IndirectClient indirectClient) {
+        String indirectClientCallbackUrl = indirectClient.getCallbackUrl();
+        // no callback url defined for the client but a group callback one -> set it with the group callback url
+        if (CommonHelper.isNotBlank(this.callbackUrl) && indirectClientCallbackUrl == null) {
+            indirectClient.setCallbackUrl(this.callbackUrl);
+            indirectClientCallbackUrl = this.callbackUrl;
+        }
+        // if the "client_name" parameter is not already part of the client callback url, add it unless the client has indicated to not include it.
+        if (indirectClient.isIncludeClientNameInCallbackUrl() && indirectClientCallbackUrl != null && !indirectClientCallbackUrl.contains(this.clientNameParameter + "=")) {
+            indirectClient.setCallbackUrl(CommonHelper.addParameter(indirectClientCallbackUrl, this.clientNameParameter, indirectClient.getName()));
+        }
+        final AjaxRequestResolver clientAjaxRequestResolver = indirectClient.getAjaxRequestResolver();
+        if (ajaxRequestResolver != null && (clientAjaxRequestResolver == null || clientAjaxRequestResolver instanceof DefaultAjaxRequestResolver)) {
+            indirectClient.setAjaxRequestResolver(ajaxRequestResolver);
+        }
+        final CallbackUrlResolver clientCallbackUrlResolver = indirectClient.getCallbackUrlResolver();
+        if (callbackUrlResolver != null && (clientCallbackUrlResolver == null || clientCallbackUrlResolver instanceof DefaultCallbackUrlResolver)) {
+            indirectClient.setCallbackUrlResolver(this.callbackUrlResolver);
+        }
+    }
+
+    
     /**
      * Return the right client according to the web context.
      * 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -103,7 +103,11 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
     @Override
     protected void internalInit(final WebContext context) {
         CommonHelper.assertNotBlank("callbackUrl", this.callbackUrl);
-
+        CommonHelper.assertNotNull("configuration", this.configuration); 
+        
+        // First of all, initialize the configuration. It may dynamically load some properties, if it is not a static one.
+        this.configuration.init(getName(), context); 
+        
         initCredentialProvider();
         initDecrypter();
         initSignatureSigningParametersProvider();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -6,6 +6,7 @@ import org.bouncycastle.x509.X509V3CertificateGenerator;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.io.Resource;
 import org.pac4j.core.io.WritableResource;
 import org.pac4j.core.util.CommonHelper;
@@ -38,7 +39,7 @@ import java.util.List;
  * @author Misagh Moayyed
  * @since 1.7
  */
-public final class SAML2ClientConfiguration implements Cloneable {
+public class SAML2ClientConfiguration implements Cloneable {
     private static final Logger LOGGER = LoggerFactory.getLogger(SAML2ClientConfiguration.class);
 
     private KeyStore keyStore;
@@ -419,7 +420,21 @@ public final class SAML2ClientConfiguration implements Cloneable {
     public boolean isAuthnRequestSigned() {
         return authnRequestSigned;
     }
-
+    
+    
+	/**
+	 * Initializes the configuration for a particular client.
+	 * 
+	 * @param clientName
+	 *            Name of the client. The configuration can use the value or not.
+	 * @param context
+	 *            Web context to transport additional information to the configuration.
+	 */
+    protected void init(final String clientName, final WebContext context) {
+    	// Intentionally left empty
+    }
+    
+    
     private void createKeystore() {
         try {
             Security.addProvider(new BouncyCastleProvider());


### PR DESCRIPTION
SAML2ClientConfiguration has been made non-final to allow for sub-classes. A new init() method has been introduced. It does nothing in SAML2ClientConfiguration but can be overridden in sub-classes.

SAML2Client now calls the new init() method on its configuration.

A piece of code in Clients has been extracted into a separate method. It allows for reuse in sub-classes of Clients.