### PR TITLE
Check if UserInfo was in a JWT

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.Secret;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
@@ -151,10 +152,13 @@ public class OidcProfileCreator<U extends OidcProfile> extends AbstractProfileCr
                             ((UserInfoErrorResponse) userInfoResponse).getErrorObject());
                 } else {
                     final UserInfoSuccessResponse userInfoSuccessResponse = (UserInfoSuccessResponse) userInfoResponse;
-                    final UserInfo userInfo = userInfoSuccessResponse.getUserInfo();
-                    if (userInfo != null) {
-                        profile.addAttributes(userInfo.toJWTClaimsSet().getClaims());
+                    final JWTClaimsSet claimsSet;
+                    if (userInfoSuccessResponse.claimsSet != null) {
+                        claimsSet = userInfoSuccessResponse.getUserInfo().toJWTClaimsSet();
+                    } else {
+                        claimsSet = userInfoSuccessResponse.getUserInfoJWT().getJWTClaimsSet();
                     }
+                    profile.addAttributes(claimsSet.getClaims());
                 }
             }
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -152,7 +152,7 @@ public class OidcProfileCreator<U extends OidcProfile> extends AbstractProfileCr
                 } else {
                     final UserInfoSuccessResponse userInfoSuccessResponse = (UserInfoSuccessResponse) userInfoResponse;
                     final JWTClaimsSet userInfoClaimsSet;
-                    if (userInfoSuccessResponse.claimsSet != null) {
+                    if (userInfoSuccessResponse.getUserInfo() != null) {
                         userInfoClaimsSet = userInfoSuccessResponse.getUserInfo().toJWTClaimsSet();
                     } else {
                         userInfoClaimsSet = userInfoSuccessResponse.getUserInfoJWT().getJWTClaimsSet();

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -15,7 +15,6 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.*;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.HttpAction;

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -151,13 +151,13 @@ public class OidcProfileCreator<U extends OidcProfile> extends AbstractProfileCr
                             ((UserInfoErrorResponse) userInfoResponse).getErrorObject());
                 } else {
                     final UserInfoSuccessResponse userInfoSuccessResponse = (UserInfoSuccessResponse) userInfoResponse;
-                    final JWTClaimsSet claimsSet;
+                    final JWTClaimsSet userInfoClaimsSet;
                     if (userInfoSuccessResponse.claimsSet != null) {
-                        claimsSet = userInfoSuccessResponse.getUserInfo().toJWTClaimsSet();
+                        userInfoClaimsSet = userInfoSuccessResponse.getUserInfo().toJWTClaimsSet();
                     } else {
-                        claimsSet = userInfoSuccessResponse.getUserInfoJWT().getJWTClaimsSet();
+                        userInfoClaimsSet = userInfoSuccessResponse.getUserInfoJWT().getJWTClaimsSet();
                     }
-                    profile.addAttributes(claimsSet.getClaims());
+                    profile.addAttributes(userInfoClaimsSet.getClaims());
                 }
             }
 


### PR DESCRIPTION
Fix for issue #747 

Previously, the UserInfo response was only checking the `getUserInfo` method. However, if the response was a JWT, the content would only be set on the `getUserInfoJWT` method, which was not checked.