### PR TITLE
Fixed wrong implementation of GenericOauth2Client

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
@@ -18,13 +18,13 @@ import org.pac4j.scribe.builder.api.GenericApi20;
  *   <li>authUrl : Server auth url</li>
  *   <li>tokeUrl : Server token url</li>
  *   <li>profileUrl : Server profile url</li>
- * <ul>
-* <p>These additiona custom parameters may be used:</p>
+ * </ul>
+ * <p>These additiona custom parameters may be used:</p>
  * <ul>
  *   <li>profilePath : Path to find profile in json response</li>
  *   <li>profileVerb : Http method used to request profile</li>
  *   <li>profileAttrs : Map of attribute name/json path for each profile attribute </li>
- * <ul>
+ * </ul>
  *
  * @author Julio Arrebola
  */

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
@@ -1,10 +1,10 @@
 package org.pac4j.oauth.client;
 
 import java.util.Map;
-import java.util.logging.Logger;
 
 import com.github.scribejava.core.model.Verb;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.profile.OAuth20Profile;
 import org.pac4j.oauth.profile.generic.GenericOAuth20ProfileDefinition;
 import org.pac4j.scribe.builder.api.GenericApi20;
@@ -13,77 +13,69 @@ import org.pac4j.scribe.builder.api.GenericApi20;
  * <p>This class is a generic OAuth2 client to authenticate users in a standard OAuth2 server.</p>
  * <p>All configuration parameters can be specified setting the corresponding attribute.</p>
  * <p>It returns a {@link org.pac4j.oauth.profile.OAuth20Profile}.</p>
+ * <p>This client requires next custom parameters in configuration:</p>
+ * <ul>
+ *   <li>authUrl : Server auth url</li>
+ *   <li>tokeUrl : Server token url</li>
+ *   <li>profileUrl : Server profile url</li>
+ * <ul>
+* <p>These additiona custom parameters may be used:</p>
+ * <ul>
+ *   <li>profilePath : Path to find profile in json response</li>
+ *   <li>profileVerb : Http method used to request profile</li>
+ *   <li>profileAttrs : Map of attribute name/json path for each profile attribute </li>
+ * <ul>
  *
  * @author Julio Arrebola
  */
 public class GenericOAuth20Client extends OAuth20Client<OAuth20Profile> {
 
-    private static final Logger LOG = Logger.getLogger(GenericOAuth20Client.class.getName());
-
-    private String authUrl;
-    private String tokenUrl;
-    private String profileUrl;
-    private String profilePath;
-    private Verb profileVerb;
-    private Map<String, String> profileAttrs;
-    private Map<String, String> customParams;
-
     public GenericOAuth20Client() {
     }
 
     @Override
-    protected void internalInit(final WebContext context) {
-
-        LOG.info("InternalInit");
-
-        GenericApi20 genApi = new GenericApi20(authUrl, tokenUrl);
+    protected void internalInit(final WebContext context) {       
+        
+        CommonHelper.assertNotNull("configuration", configuration);
+        
+        Object authUrl = configuration.getCustomParam("authUrl");
+        CommonHelper.assertNotNull("authUrl", authUrl);
+        
+        Object tokenUrl = configuration.getCustomParam("tokenUrl");
+        CommonHelper.assertNotNull("tokenUrl", tokenUrl);
+        
+        Object profileUrl = configuration.getCustomParam("profileUrl");
+        CommonHelper.assertNotNull("profileUrl", profileUrl);
+        
+        GenericApi20 genApi = new GenericApi20(authUrl.toString(), tokenUrl.toString());
         configuration.setApi(genApi);
-
-        configuration.setCustomParams(customParams);
-
-        setConfiguration(configuration);
+        
+        Object profileVerb = configuration.getCustomParam("profileVerb");
+        Object profilePath = configuration.getCustomParam("profilePath");
+        Object profileAttrs = configuration.getCustomParam("profileAttrs");
 
         GenericOAuth20ProfileDefinition profileDefinition = new GenericOAuth20ProfileDefinition();
-        profileDefinition.setFirstNodePath(profilePath);
-        profileDefinition.setProfileVerb(profileVerb);
-        profileDefinition.setProfileUrl(profileUrl);
+        profileDefinition.setProfileUrl(profileUrl.toString());
+      
+        if (profileVerb != null) {
+            Verb auxVerb = profileVerb instanceof Verb?(Verb)profileVerb:
+                    "POST".equalsIgnoreCase(profileVerb.toString())?Verb.POST:Verb.GET;
+            profileDefinition.setProfileVerb(auxVerb);
+        }
 
-        if (profileAttrs != null) {
-            for (Map.Entry<String,String> entry : profileAttrs.entrySet()) {
+        if (profilePath != null) {
+            profileDefinition.setFirstNodePath(profilePath.toString());
+        }
+        
+        if (profileAttrs != null && profileAttrs instanceof Map) {
+            for (Map.Entry<String,String> entry : ((Map<String,String>)profileAttrs).entrySet()) {
                 profileDefinition.profileAttribute(entry.getKey(), entry.getValue(), null);
             }
         }
 
         configuration.setProfileDefinition(profileDefinition);
-
+        setConfiguration(configuration);
+        
         super.internalInit(context);
-    }
-
-    public void setAuthUrl(final String authUrl) {
-        this.authUrl = authUrl;
-    }
-
-    public void setTokenUrl(final String tokenUrl) {
-        this.tokenUrl = tokenUrl;
-    }
-
-    public void setProfileUrl(final String profileUrl) {
-        this.profileUrl = profileUrl;
-    }
-
-    public void setProfileNodePath(final String profilePath) {
-        this.profilePath = profilePath;
-    }
-
-    public void setProfileVerb(final Verb profileVerb) {
-        this.profileVerb = profileVerb;
-    }
-
-    public void setProfileAttrs(final Map<String, String> profileAttrsMap) {
-        this.profileAttrs = profileAttrsMap;
-    }
-
-    public void setCustomParams(final Map<String, String> customParamsMap) {
-        this.customParams = customParamsMap;
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuth20Configuration.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuth20Configuration.java
@@ -22,7 +22,7 @@ public class OAuth20Configuration extends OAuthConfiguration<OAuth20Client, OAut
     private static final String STATE_SESSION_PARAMETER = "#oauth20StateParameter";
 
     /* Map containing user defined parameters */
-    private Map<String, String> customParams = new HashMap<>();
+    private Map<String, Object> customParams = new HashMap<>();
 
     private boolean withState;
 
@@ -32,14 +32,22 @@ public class OAuth20Configuration extends OAuthConfiguration<OAuth20Client, OAut
         return getClient().getName() + STATE_SESSION_PARAMETER;
     }
 
-    public Map<String, String> getCustomParams() {
+    public Map<String, Object> getCustomParams() {
         return customParams;
     }
 
-    public void setCustomParams(final Map<String, String> customParams) {
+    public Object getCustomParam(String name) {
+        return (customParams!=null)?customParams.get(name):null;
+    }
+
+    public void setCustomParams(final Map<String, Object> customParams) {
         this.customParams = customParams;
     }
 
+    public void addCustomParam(String name, Object value) {
+        this.customParams.put(name, value);
+    }    
+    
     public boolean isWithState() {
         return withState;
     }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuth20Configuration.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuth20Configuration.java
@@ -6,6 +6,7 @@ import org.pac4j.oauth.client.OAuth20Client;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.pac4j.core.util.CommonHelper;
 
 /**
  * The OAuh 2.0 configuration.
@@ -37,17 +38,18 @@ public class OAuth20Configuration extends OAuthConfiguration<OAuth20Client, OAut
     }
 
     public Object getCustomParam(String name) {
-        return (customParams!=null)?customParams.get(name):null;
+        return customParams.get(name);
     }
 
     public void setCustomParams(final Map<String, Object> customParams) {
+        CommonHelper.assertNotNull("customParams", customParams);
         this.customParams = customParams;
     }
 
     public void addCustomParam(String name, Object value) {
         this.customParams.put(name, value);
-    }    
-    
+    }
+
     public boolean isWithState() {
         return withState;
     }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/redirect/OAuth20RedirectActionBuilder.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/redirect/OAuth20RedirectActionBuilder.java
@@ -53,7 +53,7 @@ public class OAuth20RedirectActionBuilder extends InitializableWebObject impleme
 
                 service = this.configuration.getService();
             }
-            final String authorizationUrl = service.getAuthorizationUrl(this.configuration.getCustomParams());
+            final String authorizationUrl = service.getAuthorizationUrl();
             logger.debug("authorizationUrl: {}", authorizationUrl);
             return RedirectAction.redirect(authorizationUrl);
 

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/GenericApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/GenericApi20.java
@@ -2,10 +2,9 @@ package org.pac4j.scribe.builder.api;
 
 import com.github.scribejava.core.builder.api.DefaultApi20;
 import com.github.scribejava.core.model.Verb;
-import com.github.scribejava.core.utils.OAuthEncoder;
 import com.github.scribejava.core.model.OAuthConfig;
+import com.github.scribejava.core.model.ParameterList;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * OAuth API class for the GenericOAuth20Client
@@ -14,8 +13,6 @@ import java.util.Map.Entry;
  * @since 1.9.2
  */
 public class GenericApi20 extends DefaultApi20 {
-
-    private final static String AUTHORIZATION_URL = "%s?response_type=code&client_id=%s&redirect_uri=%s";
 
     protected final String authUrl;
     protected final String tokenUrl;
@@ -30,7 +27,7 @@ public class GenericApi20 extends DefaultApi20 {
     public Verb getAccessTokenVerb() {
         return accessTokenVerb;
     }
-    
+
     public void setAccessTokenVerb(Verb verb) {
         accessTokenVerb = verb;
     }
@@ -42,30 +39,24 @@ public class GenericApi20 extends DefaultApi20 {
 
     @Override
     public String getAuthorizationUrl(final OAuthConfig config, Map<String, String> additionalParams) {
-        
-        StringBuilder url = new StringBuilder(String.format(AUTHORIZATION_URL, authUrl, config.getApiKey(), OAuthEncoder.encode(config.getCallback())));
-                
+        final ParameterList parameters = new ParameterList(additionalParams);
+        parameters.add("response_type", "code");
+        parameters.add("client_id", config.getApiKey());
+        parameters.add("redirect_uri", config.getCallback());
+
         if (config.getScope() != null) {
-            url.append("&scope=").append(OAuthEncoder.encode(config.getScope()));            
+            parameters.add("scope", config.getScope());
         }
-        
+
         if (config.getState() != null) {
-            url.append("&state=").append(OAuthEncoder.encode(config.getState()));
+            parameters.add("state", config.getState());
         }
-        
-        if (additionalParams != null && !additionalParams.isEmpty()) {
-            for (Entry entry: additionalParams.entrySet()) {
-                if (entry.getValue() != null) {
-                    url.append("&").append(entry.getKey()).append("=").append(OAuthEncoder.encode(entry.getValue().toString()));
-                }
-            }
-        }
-        
-        return url.toString();
+
+        return parameters.appendTo(authUrl);
     }
-    
+
     @Override
     protected String getAuthorizationBaseUrl() {
         return authUrl;
-    }      
+    }
 }


### PR DESCRIPTION
I've found that previous implementation of GenericOAuth2Client I sent was adding additional attributes to the class instead of using the configuration object.

I've also made customParameters more flexible for different client implementations.