### PR TITLE
Remove a possibly unnecessary/unneeded spring dependency

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -16,7 +16,6 @@
         <opensaml.version>3.2.0</opensaml.version>
         <joda-time.version>2.9.2</joda-time.version>
         <velocity.version>1.7</velocity.version>
-        <spring.extensions.version>5.1.1</spring.extensions.version>
         <cryptacular.version>1.1.0</cryptacular.version>
         <xalan.version>2.7.2</xalan.version>
         <java-support.version>7.1.1</java-support.version>
@@ -128,25 +127,8 @@
             <version>${velocity.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>${spring.version}</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>net.shibboleth.ext</groupId>
-            <artifactId>spring-extensions</artifactId>
-            <version>${spring.extensions.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -44,13 +44,14 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
     private final String callbackUrl;
     private final boolean forceSpMetadataGeneration;
     private boolean authnRequestSigned;
+    private boolean wantsAssertionsSigned;
 
     public SAML2ServiceProviderMetadataResolver(final String spMetadataPath,
                                                 final String callbackUrl,
                                                 @Nullable final String spEntityId,
                                                 final boolean forceSpMetadataGeneration,
                                                 final CredentialProvider credentialProvider) {
-        this(spMetadataPath, null, callbackUrl, spEntityId, forceSpMetadataGeneration, credentialProvider, true);
+        this(spMetadataPath, null, callbackUrl, spEntityId, forceSpMetadataGeneration, credentialProvider, true, true);
     }
 
     public SAML2ServiceProviderMetadataResolver(final SAML2ClientConfiguration configuration,
@@ -58,7 +59,7 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
                                                 final CredentialProvider credentialProvider) {
         this(configuration.getServiceProviderMetadataPath(), configuration.getServiceProviderMetadataResource(), callbackUrl,
                 configuration.getServiceProviderEntityId(), configuration.isForceServiceProviderMetadataGeneration(), credentialProvider,
-                configuration.isAuthnRequestSigned());
+                configuration.isAuthnRequestSigned(), configuration.getWantsAssertionsSigned());
     }
 
     private SAML2ServiceProviderMetadataResolver(final String spMetadataPath,
@@ -67,8 +68,9 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
                                                  @Nullable final String spEntityId,
                                                  final boolean forceSpMetadataGeneration,
                                                  final CredentialProvider credentialProvider,
-                                                 boolean authnRequestSigned) {
+                                                 boolean authnRequestSigned, boolean wantsAssertionsSigned) {
         this.authnRequestSigned = authnRequestSigned;
+        this.wantsAssertionsSigned = wantsAssertionsSigned;
 
         if (spMetadataResource != null) {
             this.spMetadataResource = spMetadataResource;
@@ -105,6 +107,7 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
 
         try {
             final SAML2MetadataGenerator metadataGenerator = new SAML2MetadataGenerator();
+            metadataGenerator.setWantAssertionSigned(this.wantsAssertionsSigned);
             metadataGenerator.setAuthnRequestSigned(this.authnRequestSigned);
 
             if (this.authnRequestSigned) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/storage/HttpSessionStorage.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/storage/HttpSessionStorage.java
@@ -2,9 +2,9 @@ package org.pac4j.saml.storage;
 
 import org.opensaml.core.xml.XMLObject;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.util.Assert;
 
 import java.util.Collections;
 import java.util.Hashtable;
@@ -51,7 +51,7 @@ public class HttpSessionStorage implements SAMLMessageStorage {
      * @param request request to load/store internalMessages from
      */
     public HttpSessionStorage(final WebContext request) {
-        Assert.notNull(request, "Request must be set");
+    	CommonHelper.assertNotNull("request", request);
         this.session = request;
     }
 


### PR DESCRIPTION
This pull request aims at removing spring dependencies on the saml pac4j implementation.
Spring-core seems only to be in use for an Assert that can be implemented using the utils class CommonHelper
Of course test dependencies which relies deeply on spring are unchanged.

This is also a sanity change to me as shiro in the first place targets java EE application as a clear alternative to Spring Security. 