### PR TITLE
Bugfix for State parameter check in OidcExtractor

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
@@ -76,7 +76,7 @@ public class OidcExtractor extends InitializableWebObject implements Credentials
         if (state == null) {
             throw new TechnicalException("Missing state parameter");
         }
-        if (!state.equals(new State(context.getSessionAttribute(OidcConfiguration.STATE_SESSION_ATTRIBUTE)))) {
+        if (!state.equals(new State((String)context.getSessionAttribute(OidcConfiguration.STATE_SESSION_ATTRIBUTE)))) {
             throw new TechnicalException("State parameter is different from the one sent in authentication request. "
                     + "Session expired or possible threat of cross-site request forgery");
         }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
@@ -76,7 +76,7 @@ public class OidcExtractor extends InitializableWebObject implements Credentials
         if (state == null) {
             throw new TechnicalException("Missing state parameter");
         }
-        if (!state.equals(context.getSessionAttribute(OidcConfiguration.STATE_SESSION_ATTRIBUTE))) {
+        if (!state.equals(new State(context.getSessionAttribute(OidcConfiguration.STATE_SESSION_ATTRIBUTE)))) {
             throw new TechnicalException("State parameter is different from the one sent in authentication request. "
                     + "Session expired or possible threat of cross-site request forgery");
         }


### PR DESCRIPTION
I noticed that the OidcExtractor has been failing the state parameter check even when the state value strings match. 
This is because the redirect action builder saves the state as a String, but the comparison check here (on line 79) relies on the com.nimbusds.oauth2.sdk.id.State.equals() method, which checks first if the other object is an instanceof State (before checking to see if the value strings match). Since the retrieved object is a raw String, it fails the check.