### PR TITLE
Remove final on client method in order to proxify it

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
@@ -46,7 +46,7 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
     protected abstract C retrieveCredentials(final WebContext context) throws HttpAction;
 
     @Override
-    public final U getUserProfile(final C credentials, final WebContext context) throws HttpAction {
+    public U getUserProfile(final C credentials, final WebContext context) throws HttpAction {
         init(context);
         logger.debug("credentials : {}", credentials);
         if (credentials == null) {

--- a/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
@@ -40,7 +40,7 @@ public abstract class IndirectClient<C extends Credentials, U extends CommonProf
     }
 
     @Override
-    public final HttpAction redirect(final WebContext context) throws HttpAction {
+    public HttpAction redirect(final WebContext context) throws HttpAction {
         final RedirectAction action = getRedirectAction(context);
         if (action.getType() == RedirectType.REDIRECT) {
             return HttpAction.redirect("redirection via 302", context, action.getLocation());
@@ -59,7 +59,7 @@ public abstract class IndirectClient<C extends Credentials, U extends CommonProf
      * @return the redirection action
      * @throws HttpAction requires an additional HTTP action
      */
-    public final RedirectAction getRedirectAction(final WebContext context) throws HttpAction {
+    public RedirectAction getRedirectAction(final WebContext context) throws HttpAction {
         init(context);
 
         // it's an AJAX request -> unauthorized (instead of a redirection)
@@ -101,7 +101,7 @@ public abstract class IndirectClient<C extends Credentials, U extends CommonProf
      * @throws HttpAction whether an additional HTTP action is required
      */
     @Override
-    public final C getCredentials(final WebContext context) throws HttpAction {
+    public C getCredentials(final WebContext context) throws HttpAction {
         init(context);
         final C credentials = retrieveCredentials(context);
         // no credentials -> save this authentication has already been tried and failed


### PR DESCRIPTION
To manage multi-tenant authentication I removed final on client method to be able to proxify client classes with CGLib.