### PR TITLE
Use getter/setter in OidcConfiguration

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -90,21 +90,20 @@ public class OidcConfiguration extends InitializableWebObject {
         // checks
         CommonHelper.assertNotBlank("clientId", clientId);
         CommonHelper.assertNotBlank("secret", secret);
-        if (this.discoveryURI == null && this.providerMetadata == null) {
+        if (this.getDiscoveryURI() == null && this.getProviderMetadata() == null) {
             throw new TechnicalException("You must define either the discovery URL or directly the provider metadata");
         }
 
         // default value
-        if (resourceRetriever == null) {
-            resourceRetriever = new DefaultResourceRetriever(connectTimeout, readTimeout);
+        if (getResourceRetriever() == null) {
+            setResourceRetriever(new DefaultResourceRetriever(connectTimeout, readTimeout));
         }
-        if (this.providerMetadata == null) {
+        if (this.getProviderMetadata() == null) {
             CommonHelper.assertNotBlank("discoveryURI", discoveryURI);
             try {
                 // Download OIDC metadata
-                this.providerMetadata = OIDCProviderMetadata.parse(resourceRetriever.retrieveResource(
-                        new URL(this.discoveryURI)).getContent());
-
+                this.setProviderMetadata(OIDCProviderMetadata.parse(resourceRetriever.retrieveResource(
+                        new URL(this.discoveryURI)).getContent()));
             } catch (final IOException | ParseException e) {
                 throw new TechnicalException(e);
             }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -88,22 +88,22 @@ public class OidcConfiguration extends InitializableWebObject {
     @Override
     protected void internalInit(final WebContext context) {
         // checks
-        CommonHelper.assertNotBlank("clientId", clientId);
-        CommonHelper.assertNotBlank("secret", secret);
+        CommonHelper.assertNotBlank("clientId", getClientId());
+        CommonHelper.assertNotBlank("secret", getSecret());
         if (this.getDiscoveryURI() == null && this.getProviderMetadata() == null) {
             throw new TechnicalException("You must define either the discovery URL or directly the provider metadata");
         }
 
         // default value
         if (getResourceRetriever() == null) {
-            setResourceRetriever(new DefaultResourceRetriever(connectTimeout, readTimeout));
+            setResourceRetriever(new DefaultResourceRetriever(getConnectTimeout(),getReadTimeout()));
         }
         if (this.getProviderMetadata() == null) {
-            CommonHelper.assertNotBlank("discoveryURI", discoveryURI);
+            CommonHelper.assertNotBlank("discoveryURI", getDiscoveryURI());
             try {
                 // Download OIDC metadata
-                this.setProviderMetadata(OIDCProviderMetadata.parse(resourceRetriever.retrieveResource(
-                        new URL(this.discoveryURI)).getContent()));
+                this.setProviderMetadata(OIDCProviderMetadata.parse(getResourceRetriever().retrieveResource(
+                        new URL(this.getDiscoveryURI())).getContent()));
             } catch (final IOException | ParseException e) {
                 throw new TechnicalException(e);
             }


### PR DESCRIPTION
Hi,
I have an small fix for OidcConfiguration that makes proper use of properties using its getter/setter methods instead of access directly to the variables .