### PR TITLE
Allow to pass parameters to build a ConfigFactory

### DIFF
--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConfigFactory.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConfigFactory.java
@@ -116,7 +116,7 @@ public class PropertiesConfigFactory implements ConfigFactory {
         return properties.get(name);
     }
 
-    public Config build() {
+    public Config build(final Object... parameters) {
         final List<Client> clients = new ArrayList<>();
         tryCreateFacebookClient(clients);
         tryCreateTwitterClient(clients);

--- a/pac4j-core/src/main/java/org/pac4j/core/config/ConfigFactory.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/config/ConfigFactory.java
@@ -11,7 +11,8 @@ public interface ConfigFactory {
     /**
      * Build a configuration.
      *
+     * @param parameters the parameters to build the configuration
      * @return the built configuration
      */
-    Config build();
+    Config build(Object... parameters);
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/config/DefaultConfigFactory.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/config/DefaultConfigFactory.java
@@ -15,7 +15,7 @@ public class DefaultConfigFactory implements ConfigFactory {
     }
 
     @Override
-    public Config build() {
+    public Config build(final Object... parameters) {
         return config;
     }
 }


### PR DESCRIPTION
Closes #868 

@victornoel : this one is especially for Dropwizard to allow the `Pac4jFactory1` to pass properties when building the configuration (so that we can get rid of the `DropwizardConfigFactory` interface).