### PR TITLE
Issue #871 UserProfile::setLinkedId should allow null value

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -312,10 +312,6 @@ public abstract class UserProfile implements Serializable, Externalizable {
     }
 
     public void setLinkedId(final String linkedId) {
-        if (this.linkedId != null) {
-            // Don't allow unsetting of already set linked id
-            CommonHelper.assertNotNull("linkedId", linkedId);
-        }
         this.linkedId = linkedId;
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -1,15 +1,11 @@
 package org.pac4j.core.profile;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.io.Serializable;
-import java.util.*;
-
 import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.*;
 
 /**
  * This class is the user profile retrieved from a provider after successful authentication: it's an identifier (string) and attributes
@@ -316,7 +312,10 @@ public abstract class UserProfile implements Serializable, Externalizable {
     }
 
     public void setLinkedId(final String linkedId) {
-        CommonHelper.assertNotNull("linkedId", linkedId);
+        if (this.linkedId != null) {
+            // Don't allow unsetting of already set linked id
+            CommonHelper.assertNotNull("linkedId", linkedId);
+        }
         this.linkedId = linkedId;
     }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
@@ -142,11 +142,12 @@ public final class CommonProfileTests implements TestsConstants {
         assertNotNull(profile2);
     }
 
-    @Test(expected = TechnicalException.class)
+    @Test
     public void testSetNullLinkedIdWhenAlreadySet() {
         final CommonProfile profile = new CommonProfile();
         profile.setLinkedId("dummyLinkecId");
         profile.setLinkedId(null);
+        assertNull(profile.getLinkedId());
     }
 
     @Test

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
@@ -1,14 +1,14 @@
 package org.pac4j.core.profile;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import org.junit.Test;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.util.JavaSerializationHelper;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -140,6 +140,20 @@ public final class CommonProfileTests implements TestsConstants {
         final String s = helper.serializeToBase64(profile);
         final CommonProfile profile2 = (CommonProfile) helper.unserializeFromBase64(s);
         assertNotNull(profile2);
+    }
+
+    @Test(expected = TechnicalException.class)
+    public void testSetNullLinkedIdWhenAlreadySet() {
+        final CommonProfile profile = new CommonProfile();
+        profile.setLinkedId("dummyLinkecId");
+        profile.setLinkedId(null);
+    }
+
+    @Test
+    public void testSetNullLinkedIdWhenNotAlreadySet() {
+        final CommonProfile profile = new CommonProfile();
+        profile.setLinkedId(null);
+        assertNull(profile.getLinkedId());
     }
 
     @Test


### PR DESCRIPTION
It should be permissible (for Json deserialization) to set the linked id to null if it's already null, since this is a no-op.

Assuming the null check is in place to prevent un-settiing of a linked id, then it should only be enforced if the existing linked id as non-null.

Also added tests which validate this behaviour.