### PR TITLE
Define constants for authorizers (#892)

### DIFF
--- a/documentation/docs/authorizers.md
+++ b/documentation/docs/authorizers.md
@@ -36,3 +36,5 @@ Most *pac4j* implementations use *pac4j* logics and authorizers and thus the [`D
 - `isFullyAuthenticated` for the `IsFullyAuthenticatedAuthorizer` authorizer
 - `isRemembered` for the `IsRememberedAuthorizer` authorizer
 - `allowAjaxRequests` for a default configuration of the `CorsAuthorizer` authorizer with the `Access-Control-Allow-Origin` header set to `*`.
+
+These short names are defined as constants in [`DefaultAuthorizers`](https://github.com/pac4j/pac4j/blob/master/pac4j-core/src/main/java/org/pac4j/core/context/DefaultAuthorizers.java).

--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/checker/DefaultAuthorizationChecker.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/checker/DefaultAuthorizationChecker.java
@@ -2,6 +2,7 @@ package org.pac4j.core.authorization.checker;
 
 import org.pac4j.core.authorization.authorizer.*;
 import org.pac4j.core.authorization.authorizer.csrf.*;
+import org.pac4j.core.context.DefaultAuthorizers;
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.HttpAction;
@@ -59,38 +60,38 @@ public class DefaultAuthorizationChecker implements AuthorizationChecker {
             final int nb = names.length;
             for (int i = 0; i < nb; i++) {
                 final String name = names[i].trim();
-                if ("hsts".equalsIgnoreCase(name)) {
+                if (DefaultAuthorizers.HSTS.equalsIgnoreCase(name)) {
                     authorizers.add(STRICT_TRANSPORT_SECURITY_HEADER);
-                } else if ("nosniff".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.NOSNIFF.equalsIgnoreCase(name)) {
                     authorizers.add(X_CONTENT_TYPE_OPTIONS_HEADER);
-                } else if ("noframe".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.NOFRAME.equalsIgnoreCase(name)) {
                     authorizers.add(X_FRAME_OPTIONS_HEADER);
-                } else if ("xssprotection".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.XSSPROTECTION.equalsIgnoreCase(name)) {
                     authorizers.add(XSS_PROTECTION_HEADER);
-                } else if ("nocache".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.NOCACHE.equalsIgnoreCase(name)) {
                     authorizers.add(CACHE_CONTROL_HEADER);
-                } else if ("securityheaders".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.SECURITYHEADERS.equalsIgnoreCase(name)) {
                     authorizers.add(CACHE_CONTROL_HEADER);
                     authorizers.add(X_CONTENT_TYPE_OPTIONS_HEADER);
                     authorizers.add(STRICT_TRANSPORT_SECURITY_HEADER);
                     authorizers.add(X_FRAME_OPTIONS_HEADER);
                     authorizers.add(XSS_PROTECTION_HEADER);
-                } else if ("csrfToken".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.CSRF_TOKEN.equalsIgnoreCase(name)) {
                     authorizers.add(CSRF_TOKEN_GENERATOR_AUTHORIZER);
-                } else if ("csrfCheck".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.CSRF_CHECK.equalsIgnoreCase(name)) {
                     authorizers.add(CSRF_AUTHORIZER);
-                } else if ("csrf".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.CSRF.equalsIgnoreCase(name)) {
                     authorizers.add(CSRF_TOKEN_GENERATOR_AUTHORIZER);
                     authorizers.add(CSRF_AUTHORIZER);
-                } else if ("allowAjaxRequests".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.ALLOW_AJAX_REQUESTS.equalsIgnoreCase(name)) {
                     authorizers.add(CORS_AUTHORIZER);
-                } else if ("isAnonymous".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.IS_ANONYMOUS.equalsIgnoreCase(name)) {
                     authorizers.add(IS_ANONYMOUS_AUTHORIZER);
-                } else if ("isAuthenticated".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.IS_AUTHENTICATED.equalsIgnoreCase(name)) {
                     authorizers.add(IS_AUTHENTICATED_AUTHORIZER);
-                } else if ("isFullyAuthenticated".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.IS_FULLY_AUTHENTICATED.equalsIgnoreCase(name)) {
                     authorizers.add(IS_FULLY_AUTHENTICATED_AUTHORIZER);
-                } else if ("isRemembered".equalsIgnoreCase(name)) {
+                } else if (DefaultAuthorizers.IS_REMEMBERED.equalsIgnoreCase(name)) {
                     authorizers.add(IS_REMEMBERED_AUTHORIZER);
                 } else {
                     // we must have authorizers

--- a/pac4j-core/src/main/java/org/pac4j/core/context/DefaultAuthorizers.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/DefaultAuthorizers.java
@@ -1,0 +1,53 @@
+package org.pac4j.core.context;
+
+/**
+ * Constants for authorizers.
+ *
+ * @author Richard Walker
+ * @since 2.0.0
+ */
+public interface DefaultAuthorizers {
+
+    /** The "allowAjaxRequests" authorizer. */
+    String ALLOW_AJAX_REQUESTS = "allowAjaxRequests";
+
+    /** The "csrf" authorizer. */
+    String CSRF = "csrf";
+
+    /** The "csrfCheck" authorizer. */
+    String CSRF_CHECK = "csrfCheck";
+
+    /** The "csrfToken" authorizer. */
+    String CSRF_TOKEN = "csrfToken";
+
+    /** The "hsts" authorizer. */
+    String HSTS = "hsts";
+
+    /** The "isAnonymous" authorizer. */
+    String IS_ANONYMOUS = "isAnonymous";
+
+    /** The "isAuthenticated" authorizer. */
+    String IS_AUTHENTICATED = "isAuthenticated";
+
+    /** The "isFullyAuthenticated" authorizer. */
+    String IS_FULLY_AUTHENTICATED = "isFullyAuthenticated";
+
+    /** The "isRemembered" authorizer. */
+    String IS_REMEMBERED = "isRemembered";
+
+    /** The "nocache" authorizer. */
+    String NOCACHE = "nocache";
+
+    /** The "noframe" authorizer. */
+    String NOFRAME = "noframe";
+
+    /** The "nosniff" authorizer. */
+    String NOSNIFF = "nosniff";
+
+    /** The "securityheaders" authorizer. */
+    String SECURITYHEADERS = "securityheaders";
+
+    /** The "xssprotection" authorizer. */
+    String XSSPROTECTION = "xssprotection";
+
+}

--- a/pac4j-core/src/test/java/org/pac4j/core/authorization/checker/DefaultAuthorizationCheckerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/authorization/checker/DefaultAuthorizationCheckerTests.java
@@ -163,7 +163,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     public void testHsts() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
         context.setScheme(SCHEME_HTTPS);
-        checker.isAuthorized(context, profiles, "hsts", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.HSTS, null);
         assertNotNull(context.getResponseHeaders().get("Strict-Transport-Security"));
     }
 
@@ -178,28 +178,28 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     @Test
     public void testNosniff() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        checker.isAuthorized(context, profiles, "nosniff", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.NOSNIFF, null);
         assertNotNull(context.getResponseHeaders().get("X-Content-Type-Options"));
     }
 
     @Test
     public void testNoframe() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        checker.isAuthorized(context, profiles, "noframe", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.NOFRAME, null);
         assertNotNull(context.getResponseHeaders().get("X-Frame-Options"));
     }
 
     @Test
     public void testXssprotection() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        checker.isAuthorized(context, profiles, "xssprotection", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.XSSPROTECTION, null);
         assertNotNull(context.getResponseHeaders().get("X-XSS-Protection"));
     }
 
     @Test
     public void testNocache() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        checker.isAuthorized(context, profiles, "nocache", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.NOCACHE, null);
         assertNotNull(context.getResponseHeaders().get("Cache-Control"));
         assertNotNull(context.getResponseHeaders().get("Pragma"));
         assertNotNull(context.getResponseHeaders().get("Expires"));
@@ -208,7 +208,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     @Test
     public void testAllowAjaxRequests() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        checker.isAuthorized(context, profiles, "allowAjaxRequests", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.ALLOW_AJAX_REQUESTS, null);
         assertEquals("*", context.getResponseHeaders().get(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
         assertEquals("true", context.getResponseHeaders().get(ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER));
         final String methods = context.getResponseHeaders().get(ACCESS_CONTROL_ALLOW_METHODS_HEADER);
@@ -224,7 +224,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     public void testSecurityHeaders() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
         context.setScheme(SCHEME_HTTPS);
-        checker.isAuthorized(context, profiles, "securityHeaders", null);
+        checker.isAuthorized(context, profiles, DefaultAuthorizers.SECURITYHEADERS, null);
         assertNotNull(context.getResponseHeaders().get("Strict-Transport-Security"));
         assertNotNull(context.getResponseHeaders().get("X-Content-Type-Options"));
         assertNotNull(context.getResponseHeaders().get("X-Content-Type-Options"));
@@ -237,7 +237,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     @Test
     public void testCsrf() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        assertTrue(checker.isAuthorized(context, profiles, "csrf", null));
+        assertTrue(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF, null));
         assertNotNull(context.getRequestAttribute(Pac4jConstants.CSRF_TOKEN));
         assertNotNull(ContextHelper.getCookie(context.getResponseCookies(), Pac4jConstants.CSRF_TOKEN));
     }
@@ -245,7 +245,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     @Test
     public void testCsrfToken() throws HttpAction {
         final MockWebContext context = MockWebContext.create();
-        assertTrue(checker.isAuthorized(context, profiles, "csrfToken", null));
+        assertTrue(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF_TOKEN, null));
         assertNotNull(context.getRequestAttribute(Pac4jConstants.CSRF_TOKEN));
         assertNotNull(ContextHelper.getCookie(context.getResponseCookies(), Pac4jConstants.CSRF_TOKEN));
     }
@@ -253,7 +253,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     @Test
     public void testCsrfPost() throws HttpAction {
         final MockWebContext context = MockWebContext.create().setRequestMethod(HTTP_METHOD.POST.name());
-        assertFalse(checker.isAuthorized(context, profiles, "csrf", null));
+        assertFalse(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF, null));
         assertNotNull(context.getRequestAttribute(Pac4jConstants.CSRF_TOKEN));
         assertNotNull(ContextHelper.getCookie(context.getResponseCookies(), Pac4jConstants.CSRF_TOKEN));
     }
@@ -261,7 +261,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
     @Test
     public void testCsrfTokenPost() throws HttpAction {
         final MockWebContext context = MockWebContext.create().setRequestMethod(HTTP_METHOD.POST.name());
-        assertTrue(checker.isAuthorized(context, profiles, "csrfToken", null));
+        assertTrue(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF_TOKEN, null));
         assertNotNull(context.getRequestAttribute(Pac4jConstants.CSRF_TOKEN));
         assertNotNull(ContextHelper.getCookie(context.getResponseCookies(), Pac4jConstants.CSRF_TOKEN));
     }
@@ -272,7 +272,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
         final DefaultCsrfTokenGenerator generator = new DefaultCsrfTokenGenerator();
         final String token = generator.get(context);
         context.addRequestParameter(Pac4jConstants.CSRF_TOKEN, token);
-        assertTrue(checker.isAuthorized(context, profiles, "csrf", null));
+        assertTrue(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF, null));
         assertNotNull(context.getRequestAttribute(Pac4jConstants.CSRF_TOKEN));
         assertNotNull(ContextHelper.getCookie(context.getResponseCookies(), Pac4jConstants.CSRF_TOKEN));
     }
@@ -282,7 +282,7 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
         final MockWebContext context = MockWebContext.create().setRequestMethod(HTTP_METHOD.POST.name());
         final DefaultCsrfTokenGenerator generator = new DefaultCsrfTokenGenerator();
         generator.get(context);
-        assertFalse(checker.isAuthorized(context, profiles, "csrfCheck", null));
+        assertFalse(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF_CHECK, null));
     }
 
     @Test
@@ -291,29 +291,29 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
         final DefaultCsrfTokenGenerator generator = new DefaultCsrfTokenGenerator();
         final String token = generator.get(context);
         context.addRequestParameter(Pac4jConstants.CSRF_TOKEN, token);
-        assertTrue(checker.isAuthorized(context, profiles, "csrfCheck", null));
+        assertTrue(checker.isAuthorized(context, profiles, DefaultAuthorizers.CSRF_CHECK, null));
     }
 
     @Test
     public void testIsAnonymous() throws HttpAction {
         profiles.clear();
         profiles.add(new AnonymousProfile());
-        assertTrue(checker.isAuthorized(null, profiles, "isAnonymous", null));
+        assertTrue(checker.isAuthorized(null, profiles, DefaultAuthorizers.IS_ANONYMOUS, null));
     }
 
     @Test
     public void testIsAuthenticated() throws HttpAction {
-        assertTrue(checker.isAuthorized(null, profiles, "isAuthenticated", null));
+        assertTrue(checker.isAuthorized(null, profiles, DefaultAuthorizers.IS_AUTHENTICATED, null));
     }
 
     @Test
     public void testIsFullyAuthenticated() throws HttpAction {
-        assertTrue(checker.isAuthorized(null, profiles, "isFullyAuthenticated", null));
+        assertTrue(checker.isAuthorized(null, profiles, DefaultAuthorizers.IS_FULLY_AUTHENTICATED, null));
     }
 
     @Test
     public void testIsRemembered() throws HttpAction {
         profile.setRemembered(true);
-        assertTrue(checker.isAuthorized(null, profiles, "isRemembered", null));
+        assertTrue(checker.isAuthorized(null, profiles, DefaultAuthorizers.IS_REMEMBERED, null));
     }
 }


### PR DESCRIPTION
Create a DefaultAuthorizers interface with constants for the
authorizers recognised by DefaultAuthorizationChecker.
Use them in DefaultAuthorizationCheckerTests.

One subtle difference: it was "securityHeaders" in the test, versus "securityheaders" in the main code.
