### PR TITLE
Add CouchProfileService

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ It provides a comprehensive set of [**concepts and components**](http://www.pac4
 
 [CAS server](https://apereo.github.io/cas/4.2.x/integration/Delegate-Authentication.html) &bull; [JAX-RS](https://github.com/pac4j/jax-rs-pac4j) &bull; [Dropwizard](https://github.com/evnm/dropwizard-pac4j) &bull; [Apache Knox](http://knox.apache.org/books/knox-0-9-0/user-guide.html#Pac4j+Provider+-+CAS+/+OAuth+/+SAML+/+OpenID+Connect) &bull; [Jooby](http://jooby.org/doc/pac4j)
 
-## Authentication mechanims:
+## Authentication mechanisms:
 
 [OAuth (Facebook, Twitter, Google...)](http://www.pac4j.org/docs/clients/oauth.html) - [SAML](http://www.pac4j.org/docs/clients/saml.html) - [CAS](http://www.pac4j.org/docs/clients/cas.html) - [OpenID Connect](http://www.pac4j.org/docs/clients/openid-connect.html) - [HTTP](http://www.pac4j.org/docs/clients/http.html) - [OpenID](http://www.pac4j.org/docs/clients/openid.html) - [Google App Engine](http://www.pac4j.org/docs/clients/google-app-engine.html)
 
-[LDAP](http://www.pac4j.org/docs/authenticators/ldap.html) - [SQL](http://www.pac4j.org/docs/authenticators/sql.html) - [JWT](http://www.pac4j.org/docs/authenticators/jwt.html) - [MongoDB](http://www.pac4j.org/docs/authenticators/mongodb.html) - [Stormpath](http://www.pac4j.org/docs/authenticators/stormpath.html) - [IP address](http://www.pac4j.org/docs/authenticators/ip.html)
+[LDAP](http://www.pac4j.org/docs/authenticators/ldap.html) - [SQL](http://www.pac4j.org/docs/authenticators/sql.html) - [JWT](http://www.pac4j.org/docs/authenticators/jwt.html) - [MongoDB](http://www.pac4j.org/docs/authenticators/mongodb.html) - [CouchDB](http://www.pac4j.org/docs/authenticators/couchdb.html) - [Stormpath](http://www.pac4j.org/docs/authenticators/stormpath.html) - [IP address](http://www.pac4j.org/docs/authenticators/ip.html)
 
 ## Authorization mechanisms:
 

--- a/documentation/docs/authenticators.md
+++ b/documentation/docs/authenticators.md
@@ -20,6 +20,7 @@ You can use various `Authenticator` for many identity systems:
 - [SQL](authenticators/sql.html)
 - [JWT](authenticators/jwt.html)
 - [MongoDB](authenticators/mongodb.html)
+- [CouchDB](authenticators/couchdb.html)
 - [Stormpath](authenticators/stormpath.html)
 - [IP address](authenticators/ip.html)
 

--- a/documentation/docs/authenticators/couchdb.md
+++ b/documentation/docs/authenticators/couchdb.md
@@ -1,0 +1,66 @@
+---
+layout: doc
+title: CouchDB
+---
+
+*pac4j* allows you to validate username/password and create, update and delete users on a CouchDB database.
+
+## 1) Dependency
+
+You need to use the following module: `pac4j-couch`.
+
+**Example (Maven dependency):**
+
+```xml
+<dependency>
+    <groupId>org.pac4j</groupId>
+    <artifactId>pac4j-couch</artifactId>
+    <version>${pac4j.version}</version>
+</dependency>
+```
+
+## 2) `CouchProfileService`
+
+The [`CouchProfileService`](https://github.com/pac4j/pac4j/blob/master/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java):
+                                                                                                                                                                                                                                                                                                                 
+- validates a username/password on a CouchDB database (it can be defined for HTTP clients which deal with `UsernamePasswordCredentials`)
+- create, update or delete a user in the CouchDB database.
+
+It works with a [`CouchProfile`](https://github.com/pac4j/pac4j/blob/master/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java).
+
+It is built from a `org.ektorp.CouchDbConnector`.
+
+**Example:**
+
+```java
+HttpClient httpClient = new StdHttpClient.Builder().url(couchDbUrl).build();
+CouchDbInstance dbInstance = new StdCouchDbInstance(httpClient);
+CouchDbConnector couchDbConnector = dbInstance.createConnector("users", true);
+CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+```
+
+The choice of the database name is irrelevant to `CouchProfileService`. The database containing the users must contain the following design document:
+
+```json
+{
+	"_id": "_design/pac4j",
+	"language": "javascript",
+	"views": {
+		"by_username": {
+			"map": "function(doc) {if (doc.username) emit(doc.username, doc);}"
+		},
+		"by_linkedid": {
+			"map": "function(doc) {if (doc.linkedid) emit(doc.linkedid, doc);}"
+		}
+	}
+}
+```
+
+The `id`, `username` and `password` attribute names can be changed using the `setIdAttribute`, `setUsernameAttribute` and `setPasswordAttribute` methods. By default, the `id` attribute is CouchDB's `_id` attribute. If you change the `username` or `linkedid` attribute, please change the design document accordingly.
+
+The attributes of the user profile can be managed in the CouchDB collection in two ways:
+
+- either each attribute is explicitly saved in a specific attribute and all these attributes are defined as a list of names separated by commas via the `setAttributes` method (it's the legacy mode already existing in version 1.9)
+- or the whole user profile is serialized and saved in the `serializedprofile` attribute.
+
+This `CouchProfileService` supports the use of a specific [`PasswordEncoder`](authenticators.html#passwordencoder) to encode the passwords in the CouchDB database.

--- a/documentation/docs/authenticators/couchdb.md
+++ b/documentation/docs/authenticators/couchdb.md
@@ -56,7 +56,7 @@ The choice of the database name is irrelevant to `CouchProfileService`. The data
 }
 ```
 
-The `id`, `username` and `password` attribute names can be changed using the `setIdAttribute`, `setUsernameAttribute` and `setPasswordAttribute` methods. By default, the `id` attribute is CouchDB's `_id` attribute. If you change the `username` or `linkedid` attribute, please change the design document accordingly.
+The `id`, `username` and `password` attribute names can be changed using the `setIdAttribute`, `setUsernameAttribute` and `setPasswordAttribute` methods. By default, the `id` attribute is CouchDB's `_id` attribute. If you change the `username` or `linkedid` attribute, please change the design document accordingly. You can also get/set the ObjectMapper used to serialize the JSON data from CouchDB with `getObjectMapper()` and `setObjectMapper()`, the default one is a simple default one.
 
 The attributes of the user profile can be managed in the CouchDB collection in two ways:
 

--- a/pac4j-couch/pom.xml
+++ b/pac4j-couch/pom.xml
@@ -34,6 +34,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.bdrc</groupId>
+			<artifactId>mcouch-ektorp</artifactId>
+			<version>1.0.0-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/pac4j-couch/pom.xml
+++ b/pac4j-couch/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.pac4j</groupId>
+		<artifactId>pac4j</artifactId>
+		<version>2.0.0-RC3-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>pac4j-couch</artifactId>
+	<packaging>jar</packaging>
+	<name>pac4j for CouchDB</name>
+
+	<properties>
+		<ektorp.version>1.4.4</ektorp.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.pac4j</groupId>
+			<artifactId>pac4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ektorp</groupId>
+			<artifactId>org.ektorp</artifactId>
+			<version>${ektorp.version}</version>
+		</dependency>
+		<!-- for testing -->
+		<dependency>
+			<groupId>org.pac4j</groupId>
+			<artifactId>pac4j-core</artifactId>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.shiro</groupId>
+			<artifactId>shiro-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- for testing -->
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<configuration>
+					<instructions>
+						<Bundle-SymbolicName>org.pac4j.couch</Bundle-SymbolicName>
+						<Export-Package>org.pac4j.couch.*;version=${project.version}</Export-Package>
+						<Import-Package>*</Import-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/pac4j-couch/pom.xml
+++ b/pac4j-couch/pom.xml
@@ -36,7 +36,7 @@
 		<dependency>
 			<groupId>io.bdrc</groupId>
 			<artifactId>mcouch-ektorp</artifactId>
-			<version>1.0.0-SNAPSHOT</version>
+			<version>1.0.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java
+++ b/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java
@@ -3,11 +3,11 @@ package org.pac4j.couch.profile;
 import org.pac4j.core.profile.CommonProfile;
 
 /**
- * <p>The user profile returned from a MongoDB.</p>
+ * <p>The user profile returned from a CouchDB.</p>
  *
- * @see MongoAuthenticator
- * @author Jerome Leleu
- * @since 1.8.0
+ * @see CouchProfileService
+ * @author Elie Roux
+ * @since 2.0.0
  */
 public class CouchProfile extends CommonProfile {
 

--- a/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java
+++ b/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java
@@ -1,0 +1,15 @@
+package org.pac4j.couch.profile;
+
+import org.pac4j.core.profile.CommonProfile;
+
+/**
+ * <p>The user profile returned from a MongoDB.</p>
+ *
+ * @see MongoAuthenticator
+ * @author Jerome Leleu
+ * @since 1.8.0
+ */
+public class CouchProfile extends CommonProfile {
+
+    private static final long serialVersionUID = 1527226102386684236L;
+}

--- a/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java
+++ b/pac4j-couch/src/main/java/org/pac4j/couch/profile/CouchProfile.java
@@ -5,7 +5,7 @@ import org.pac4j.core.profile.CommonProfile;
 /**
  * <p>The user profile returned from a CouchDB.</p>
  *
- * @see CouchProfileService
+ * @see org.pac4j.couch.profile.service.CouchProfileService
  * @author Elie Roux
  * @since 2.0.0
  */

--- a/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java
+++ b/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java
@@ -32,9 +32,9 @@ import java.util.Map;
 public class CouchProfileService extends AbstractProfileService<CouchProfile> {
 
 	private CouchDbConnector couchDbConnector;
+	private ObjectMapper objectMapper;
 
 	public static final String COUCH_ID = "_id";
-	public ObjectMapper objectMapper;
 
 	public CouchProfileService(final CouchDbConnector couchDbConnector, final String attributes, final PasswordEncoder passwordEncoder) {
 		setIdAttribute(COUCH_ID);

--- a/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java
+++ b/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java
@@ -32,8 +32,6 @@ import java.util.Map;
 public class CouchProfileService extends AbstractProfileService<CouchProfile> {
 
     private CouchDbConnector couchDbConnector;
-
-    private String usersDatabase = "users";
     
     public static final String COUCH_ID = "_id";
     public static ObjectMapper objectMapper = new ObjectMapper();
@@ -70,7 +68,6 @@ public class CouchProfileService extends AbstractProfileService<CouchProfile> {
     protected void internalInit(final WebContext context) {
         CommonHelper.assertNotNull("passwordEncoder", getPasswordEncoder());
         CommonHelper.assertNotNull("couchDbConnector", this.couchDbConnector);
-        CommonHelper.assertNotBlank("usersDatabase", this.usersDatabase);
         defaultProfileDefinition(new CommonProfileDefinition<>(x -> new CouchProfile()));
 
         super.internalInit(context);
@@ -114,23 +111,6 @@ public class CouchProfileService extends AbstractProfileService<CouchProfile> {
 		}
     }
 
-    /*
-     * 
-     * {
-		  "_id": "_design/pac4j",
-		  "language": "javascript",
-		  "views": {
-		    "by_username": {
-		      "map": "function(doc) {\n    if (doc.username) emit(doc.username, doc);\n}"
-		    },
-		    "by_linkedid": {
-		      "map": "function(doc) {\n    if (doc.linkedid) emit(doc.linkedid, doc);\n}"
-		    }
-		  }
-		}
-     * 
-     */
-
     @Override
     protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
         logger.debug("Reading key / value: {} / {}", key, value);
@@ -154,6 +134,7 @@ public class CouchProfileService extends AbstractProfileService<CouchProfile> {
 			}
         }
         else {
+        	// supposes a by_$key view in the design document, see documentation
 	        final ViewQuery query = new ViewQuery()
 	                .designDocId("_design/pac4j")
 	                .viewName("by_"+key)
@@ -183,14 +164,6 @@ public class CouchProfileService extends AbstractProfileService<CouchProfile> {
         return listAttributes;
     }
 
-    public String getUsersDatabase() {
-        return usersDatabase;
-    }
-
-    public void setUsersDatabase(final String usersDatabase) {
-        this.usersDatabase = usersDatabase;
-    }
-
     public CouchDbConnector getCouchDbConnector() {
         return couchDbConnector;
     }
@@ -202,7 +175,7 @@ public class CouchProfileService extends AbstractProfileService<CouchProfile> {
     @Override
     public String toString() {
         return CommonHelper.toString(this.getClass(), "couchDbConnector", couchDbConnector, "passwordEncoder", getPasswordEncoder(),
-                "usersDatabase", usersDatabase, "attributes", getAttributes(), "profileDefinition", getProfileDefinition(),
+                "attributes", getAttributes(), "profileDefinition", getProfileDefinition(),
                 "idAttribute", getIdAttribute(), "usernameAttribute", getUsernameAttribute(), "passwordAttribute", getPasswordAttribute());
     }
 }

--- a/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java
+++ b/pac4j-couch/src/main/java/org/pac4j/couch/profile/service/CouchProfileService.java
@@ -1,0 +1,208 @@
+package org.pac4j.couch.profile.service;
+
+import org.pac4j.couch.profile.CouchProfile;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.ektorp.CouchDbConnector;
+import org.ektorp.DocumentNotFoundException;
+import org.ektorp.ViewQuery;
+import org.ektorp.ViewResult;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.password.PasswordEncoder;
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.profile.service.AbstractProfileService;
+import org.pac4j.core.util.CommonHelper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The MongoDB profile service.
+ *
+ * @author Elie Roux
+ * @since 2.0.0
+ */
+public class CouchProfileService extends AbstractProfileService<CouchProfile> {
+
+    private CouchDbConnector couchDbConnector;
+
+    private String usersDatabase = "users";
+    
+    public static final String COUCH_ID = "_id";
+    public static ObjectMapper objectMapper = new ObjectMapper();
+
+    public CouchProfileService() {
+    	setIdAttribute(COUCH_ID);
+    }
+
+    public CouchProfileService(final CouchDbConnector couchDbConnector) {
+    	setIdAttribute(COUCH_ID);
+        this.couchDbConnector = couchDbConnector;
+    }
+
+    public CouchProfileService(final CouchDbConnector couchDbConnector, final String attributes) {
+    	setIdAttribute(COUCH_ID);
+        this.couchDbConnector = couchDbConnector;
+        setAttributes(attributes);
+    }
+
+    public CouchProfileService(final CouchDbConnector couchDbConnector, final String attributes, final PasswordEncoder passwordEncoder) {
+    	setIdAttribute(COUCH_ID);
+        this.couchDbConnector = couchDbConnector;
+        setAttributes(attributes);
+        setPasswordEncoder(passwordEncoder);
+    }
+
+    public CouchProfileService(final CouchDbConnector couchDbConnector, final PasswordEncoder passwordEncoder) {
+    	setIdAttribute(COUCH_ID);
+        this.couchDbConnector = couchDbConnector;
+        setPasswordEncoder(passwordEncoder);
+    }
+
+    @Override
+    protected void internalInit(final WebContext context) {
+        CommonHelper.assertNotNull("passwordEncoder", getPasswordEncoder());
+        CommonHelper.assertNotNull("couchDbConnector", this.couchDbConnector);
+        CommonHelper.assertNotBlank("usersDatabase", this.usersDatabase);
+        defaultProfileDefinition(new CommonProfileDefinition<>(x -> new CouchProfile()));
+
+        super.internalInit(context);
+    }
+
+    @Override
+    protected void insert(final Map<String, Object> attributes) {
+    	logger.debug("Insert doc: {}", attributes);
+    	couchDbConnector.create(attributes);
+    }
+
+    @Override
+    protected void update(final Map<String, Object> attributes) {
+    	try {
+    		final String id = (String) attributes.get(COUCH_ID);
+			final InputStream oldDocStream = couchDbConnector.getAsStream(id);
+			final JsonNode oldDoc = objectMapper.readTree(oldDocStream);
+			final String rev = oldDoc.get("_rev").asText();
+			attributes.put("_rev", rev);
+			couchDbConnector.update(attributes);
+			logger.debug("Updating id: {} with attributes: {}", id, attributes);
+		} catch (DocumentNotFoundException e) {
+			couchDbConnector.create(attributes);
+		} catch (IOException e) {
+			logger.error("", e);
+		}
+    }
+
+    @Override
+    protected void deleteById(final String id) {
+        logger.debug("Delete id: {}", id);
+    	try {
+			final InputStream oldDocStream = couchDbConnector.getAsStream(id);
+			final JsonNode oldDoc = objectMapper.readTree(oldDocStream);
+			final String rev = oldDoc.get("_rev").asText();
+			couchDbConnector.delete(id, rev);
+		} catch (DocumentNotFoundException e) {
+			logger.debug("id {} is not in the database", id);
+		} catch (IOException e) {
+			logger.error("", e);
+		}
+    }
+
+    /*
+     * 
+     * {
+		  "_id": "_design/pac4j",
+		  "language": "javascript",
+		  "views": {
+		    "by_username": {
+		      "map": "function(doc) {\n    if (doc.username) emit(doc.username, doc);\n}"
+		    },
+		    "by_linkedid": {
+		      "map": "function(doc) {\n    if (doc.linkedid) emit(doc.linkedid, doc);\n}"
+		    }
+		  }
+		}
+     * 
+     */
+
+    @Override
+    protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
+        logger.debug("Reading key / value: {} / {}", key, value);
+        final List<Map<String, Object>> listAttributes = new ArrayList<>();
+        final TypeReference<HashMap<String,Object>> typeRef = new TypeReference<HashMap<String,Object>>() {};
+        if (key.equals(COUCH_ID)) {
+			try {
+				final InputStream oldDocStream = couchDbConnector.getAsStream(value);
+				final Map<String, Object> res = objectMapper.readValue(oldDocStream, typeRef);
+		        final Map<String, Object> newAttributes = new HashMap<>();
+		        for (final Map.Entry<String, Object> entry : res.entrySet()) {
+		            final String name = entry.getKey();
+		            if (names == null || names.contains(name)) {
+		                newAttributes.put(name, entry.getValue());
+		            }
+		        }
+				listAttributes.add(newAttributes);
+			} catch (DocumentNotFoundException e) {
+			} catch (IOException e) {
+				logger.error("", e);
+			}
+        }
+        else {
+	        final ViewQuery query = new ViewQuery()
+	                .designDocId("_design/pac4j")
+	                .viewName("by_"+key)
+	                .key(value);
+	        final ViewResult result = couchDbConnector.queryView(query);
+	        for (ViewResult.Row row : result.getRows()) {
+	            final String stringValue = row.getValue();
+	            Map<String, Object> res = null;
+				try {
+					res = objectMapper.readValue(stringValue, typeRef);
+			        final Map<String, Object> newAttributes = new HashMap<>();
+			        for (final Map.Entry<String, Object> entry : res.entrySet()) {
+			            final String name = entry.getKey();
+			            if (names == null || names.contains(name)) {
+			                newAttributes.put(name, entry.getValue());
+			            }
+			        }
+					listAttributes.add(newAttributes);
+				} catch (IOException e) {
+					logger.error("", e);
+				}
+	        }
+        }
+        
+        logger.debug("Found: {}", listAttributes);
+
+        return listAttributes;
+    }
+
+    public String getUsersDatabase() {
+        return usersDatabase;
+    }
+
+    public void setUsersDatabase(final String usersDatabase) {
+        this.usersDatabase = usersDatabase;
+    }
+
+    public CouchDbConnector getCouchDbConnector() {
+        return couchDbConnector;
+    }
+
+    public void setCouchDbConnector(final CouchDbConnector couchDbConnector) {
+        this.couchDbConnector = couchDbConnector;
+    }
+
+    @Override
+    public String toString() {
+        return CommonHelper.toString(this.getClass(), "couchDbConnector", couchDbConnector, "passwordEncoder", getPasswordEncoder(),
+                "usersDatabase", usersDatabase, "attributes", getAttributes(), "profileDefinition", getProfileDefinition(),
+                "idAttribute", getIdAttribute(), "usernameAttribute", getUsernameAttribute(), "passwordAttribute", getPasswordAttribute());
+    }
+}

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -29,7 +29,6 @@ import static org.junit.Assert.*;
  */
 public final class CouchProfileServiceTests implements TestsConstants {
 
-	private static final int PORT = 5984;
 	private static final String COUCH_ID_FIELD = CouchProfileService.COUCH_ID;
 	private static final String COUCH_ID = "couchId";
 	private static final String COUCH_LINKED_ID = "couchLinkedId";
@@ -48,7 +47,7 @@ public final class CouchProfileServiceTests implements TestsConstants {
 
 	@BeforeClass
 	public static void setUp() {
-		couchDbConnector = couchServer.start(PORT);
+		couchDbConnector = couchServer.start();
 		final String password = PASSWORD_ENCODER.encode(PASSWORD);
 		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
 		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -1,0 +1,186 @@
+package org.pac4j.couch.profile.service;
+
+import org.apache.shiro.authc.credential.DefaultPasswordService;
+import org.ektorp.CouchDbConnector;
+import org.junit.*;
+import org.pac4j.core.exception.*;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.service.AbstractProfileService;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.credentials.password.PasswordEncoder;
+import org.pac4j.core.credentials.password.ShiroPasswordEncoder;
+import org.pac4j.core.util.TestsHelper;
+import org.pac4j.couch.profile.CouchProfile;
+import org.pac4j.couch.test.tools.CouchServer;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the {@link MongoAuthenticator}.
+ *
+ * @author Elie Roux
+ * @since 2.0.0
+ */
+public final class CouchProfileServiceTests implements TestsConstants {
+
+    private static final int PORT = 13598;
+    private static final String COUCH_ID_FIELD = CouchProfileService.COUCH_ID;
+    private static final String COUCH_ID = "couchId";
+    private static final String COUCH_LINKED_ID = "couchLinkedId";
+    private static final String COUCH_USER = "couchUser";
+    private static final String COUCH_USER2 = "couchUser2";
+    private static final String COUCH_PASS = "couchPass";
+    private static final String COUCH_PASS2 = "couchPass2";
+    private static final String IDPERSON1 = "idperson1";
+    private static final String IDPERSON2 = "idperson2";
+    private static final String IDPERSON3 = "idperson3";
+    
+    public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
+    public static CouchDbConnector couchDbConnector = null;
+    private static final CouchServer couchServer = new CouchServer();
+
+
+    @BeforeClass
+    public static void setUp() {
+        couchDbConnector = couchServer.start(PORT);
+        final String password = PASSWORD_ENCODER.encode(PASSWORD);
+		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        // insert sample data
+        final Map<String, Object> properties1 = new HashMap<>();
+		properties1.put(USERNAME, GOOD_USERNAME);
+		properties1.put(FIRSTNAME, FIRSTNAME_VALUE);
+		CouchProfile couchProfile = new CouchProfile();
+		couchProfile.build(IDPERSON1, properties1);
+		couchProfileService.create(couchProfile, PASSWORD);
+		// second person, 
+		final Map<String, Object> properties2 = new HashMap<>();
+		properties2.put(USERNAME, MULTIPLE_USERNAME);
+		couchProfile = new CouchProfile();
+		couchProfile.build(IDPERSON2, properties2);
+		couchProfileService.create(couchProfile, PASSWORD);
+		final Map<String, Object> properties3 = new HashMap<>();
+		properties3.put(USERNAME, MULTIPLE_USERNAME);
+		properties3.put(PASSWORD, password);
+		couchProfile = new CouchProfile();
+		couchProfile.build(IDPERSON3, properties3);
+		couchProfileService.create(couchProfile, PASSWORD);
+		
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        //couchServer.stop();
+    }
+
+    @Test
+    public void testNullConnector() {
+        final CouchProfileService couchProfileService = new CouchProfileService(null);
+        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        TestsHelper.expectException(() -> couchProfileService.init(null), TechnicalException.class, "couchDbConnector cannot be null");
+    }
+
+    @Test(expected = AccountNotFoundException.class)
+    public void authentFailed() throws HttpAction, CredentialsException {
+        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
+        couchProfileService.validate(credentials, null);
+    }
+
+    @Test
+    public void authentSuccessNoAttribute() throws HttpAction, CredentialsException {
+        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
+        couchProfileService.validate(credentials, null);
+
+        final CommonProfile profile = credentials.getUserProfile();
+        assertNotNull(profile);
+        assertTrue(profile instanceof CouchProfile);
+        final CouchProfile couchProfile = (CouchProfile) profile;
+        assertEquals(GOOD_USERNAME, couchProfile.getId());
+        assertEquals(0, couchProfile.getAttributes().size());
+    }
+
+    @Test
+    public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
+        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        couchProfileService.setUsernameAttribute(COUCH_ID_FIELD);
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
+        couchProfileService.validate(credentials, null);
+
+        final CommonProfile profile = credentials.getUserProfile();
+        assertNotNull(profile);
+        assertTrue(profile instanceof CouchProfile);
+        final CouchProfile ldapProfile = (CouchProfile) profile;
+        assertEquals(GOOD_USERNAME, ldapProfile.getId());
+        assertEquals(1, ldapProfile.getAttributes().size());
+        assertEquals(FIRSTNAME_VALUE, ldapProfile.getAttribute(USERNAME));
+    }
+
+    @Test
+    public void testCreateUpdateFindDelete() throws HttpAction, CredentialsException {
+        final CouchProfile profile = new CouchProfile();
+        profile.setId(COUCH_ID);
+        profile.setLinkedId(COUCH_LINKED_ID);
+        profile.addAttribute(USERNAME, COUCH_USER);
+        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        couchProfileService.setPasswordAttribute("userPassword");
+        // create
+        couchProfileService.create(profile, COUCH_PASS);
+        // check credentials
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(COUCH_ID, COUCH_PASS, CLIENT_NAME);
+        couchProfileService.validate(credentials, null);
+        final CommonProfile profile1 = credentials.getUserProfile();
+        assertNotNull(profile1);
+        // check data
+        final List<Map<String, Object>> results = getData(couchProfileService, COUCH_ID);
+        assertEquals(1, results.size());
+        final Map<String, Object> result = results.get(0);
+        assertEquals(4, result.size());
+        assertEquals(COUCH_ID, result.get(COUCH_ID_FIELD));
+        assertEquals(COUCH_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
+        assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
+        assertEquals(COUCH_USER, result.get(USERNAME));
+        // findById
+        final CouchProfile profile2 = couchProfileService.findById(COUCH_ID);
+        assertEquals(COUCH_ID, profile2.getId());
+        assertEquals(COUCH_LINKED_ID, profile2.getLinkedId());
+        assertEquals(COUCH_USER, profile2.getUsername());
+        assertEquals(1, profile2.getAttributes().size());
+        // update
+        profile.addAttribute(USERNAME, COUCH_USER2);
+        couchProfileService.update(profile, COUCH_PASS2);
+        final List<Map<String, Object>> results2 = getData(couchProfileService, COUCH_ID);
+        assertEquals(1, results2.size());
+        final Map<String, Object> result2 = results2.get(0);
+        assertEquals(4, result2.size());
+        assertEquals(COUCH_ID, result2.get(COUCH_ID_FIELD));
+        assertEquals(COUCH_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
+        assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
+        assertEquals(COUCH_USER2, result2.get(USERNAME));
+        // check credentials
+        final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(COUCH_ID, COUCH_PASS2, CLIENT_NAME);
+        couchProfileService.validate(credentials2, null);
+        final CommonProfile profile3 = credentials.getUserProfile();
+        assertNotNull(profile3);
+        // remove
+        couchProfileService.remove(profile);
+        final List<Map<String, Object>> results3 = getData(couchProfileService, COUCH_ID);
+        assertEquals(0, results3.size());
+    }
+
+    private List<Map<String, Object>> getData(final CouchProfileService couchProfileService, final String id) {
+        return couchProfileService.read(Arrays.asList(COUCH_ID_FIELD, "username", "linkedid", "password", "serializedprofile"), COUCH_ID_FIELD, id);
+    }
+}

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import static org.junit.Assert.*;
 
 /**
- * Tests the {@link MongoAuthenticator}.
+ * Tests the {@link CouchProfileService}.
  *
  * @author Elie Roux
  * @since 2.0.0

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
  */
 public final class CouchProfileServiceTests implements TestsConstants {
 
-	private static final int PORT = 13598;
+	private static final int PORT = 5984;
 	private static final String COUCH_ID_FIELD = CouchProfileService.COUCH_ID;
 	private static final String COUCH_ID = "couchId";
 	private static final String COUCH_LINKED_ID = "couchLinkedId";

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -72,7 +72,6 @@ public final class CouchProfileServiceTests implements TestsConstants {
 		couchProfile = new CouchProfile();
 		couchProfile.build(IDPERSON3, properties3);
 		couchProfileService.create(couchProfile, PASSWORD);
-		
     }
 
     @AfterClass
@@ -96,7 +95,7 @@ public final class CouchProfileServiceTests implements TestsConstants {
     }
 
     @Test
-    public void authentSuccessNoAttribute() throws HttpAction, CredentialsException {
+    public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
         final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
         couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
         final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
@@ -106,25 +105,9 @@ public final class CouchProfileServiceTests implements TestsConstants {
         assertNotNull(profile);
         assertTrue(profile instanceof CouchProfile);
         final CouchProfile couchProfile = (CouchProfile) profile;
-        assertEquals(GOOD_USERNAME, couchProfile.getId());
-        assertEquals(0, couchProfile.getAttributes().size());
-    }
-
-    @Test
-    public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
-        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
-        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        couchProfileService.setUsernameAttribute(COUCH_ID_FIELD);
-        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
-        couchProfileService.validate(credentials, null);
-
-        final CommonProfile profile = credentials.getUserProfile();
-        assertNotNull(profile);
-        assertTrue(profile instanceof CouchProfile);
-        final CouchProfile ldapProfile = (CouchProfile) profile;
-        assertEquals(GOOD_USERNAME, ldapProfile.getId());
-        assertEquals(1, ldapProfile.getAttributes().size());
-        assertEquals(FIRSTNAME_VALUE, ldapProfile.getAttribute(USERNAME));
+        assertEquals(GOOD_USERNAME, couchProfile.getUsername());
+        assertEquals(2, couchProfile.getAttributes().size());
+        assertEquals(FIRSTNAME_VALUE, couchProfile.getAttribute(FIRSTNAME));
     }
 
     @Test
@@ -135,11 +118,10 @@ public final class CouchProfileServiceTests implements TestsConstants {
         profile.addAttribute(USERNAME, COUCH_USER);
         final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
         couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        couchProfileService.setPasswordAttribute("userPassword");
         // create
         couchProfileService.create(profile, COUCH_PASS);
         // check credentials
-        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(COUCH_ID, COUCH_PASS, CLIENT_NAME);
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(COUCH_USER, COUCH_PASS, CLIENT_NAME);
         couchProfileService.validate(credentials, null);
         final CommonProfile profile1 = credentials.getUserProfile();
         assertNotNull(profile1);
@@ -147,7 +129,7 @@ public final class CouchProfileServiceTests implements TestsConstants {
         final List<Map<String, Object>> results = getData(couchProfileService, COUCH_ID);
         assertEquals(1, results.size());
         final Map<String, Object> result = results.get(0);
-        assertEquals(4, result.size());
+        assertEquals(5, result.size());
         assertEquals(COUCH_ID, result.get(COUCH_ID_FIELD));
         assertEquals(COUCH_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
         assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
@@ -164,13 +146,13 @@ public final class CouchProfileServiceTests implements TestsConstants {
         final List<Map<String, Object>> results2 = getData(couchProfileService, COUCH_ID);
         assertEquals(1, results2.size());
         final Map<String, Object> result2 = results2.get(0);
-        assertEquals(4, result2.size());
+        assertEquals(5, result2.size());
         assertEquals(COUCH_ID, result2.get(COUCH_ID_FIELD));
         assertEquals(COUCH_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
         assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
         assertEquals(COUCH_USER2, result2.get(USERNAME));
         // check credentials
-        final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(COUCH_ID, COUCH_PASS2, CLIENT_NAME);
+        final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(COUCH_USER2, COUCH_PASS2, CLIENT_NAME);
         couchProfileService.validate(credentials2, null);
         final CommonProfile profile3 = credentials.getUserProfile();
         assertNotNull(profile3);

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -15,7 +15,6 @@ import org.pac4j.couch.profile.CouchProfile;
 import org.pac4j.couch.test.tools.CouchServer;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -29,31 +29,31 @@ import static org.junit.Assert.*;
  */
 public final class CouchProfileServiceTests implements TestsConstants {
 
-    private static final int PORT = 13598;
-    private static final String COUCH_ID_FIELD = CouchProfileService.COUCH_ID;
-    private static final String COUCH_ID = "couchId";
-    private static final String COUCH_LINKED_ID = "couchLinkedId";
-    private static final String COUCH_USER = "couchUser";
-    private static final String COUCH_USER2 = "couchUser2";
-    private static final String COUCH_PASS = "couchPass";
-    private static final String COUCH_PASS2 = "couchPass2";
-    private static final String IDPERSON1 = "idperson1";
-    private static final String IDPERSON2 = "idperson2";
-    private static final String IDPERSON3 = "idperson3";
-    
-    public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
-    public static CouchDbConnector couchDbConnector = null;
-    private static final CouchServer couchServer = new CouchServer();
+	private static final int PORT = 13598;
+	private static final String COUCH_ID_FIELD = CouchProfileService.COUCH_ID;
+	private static final String COUCH_ID = "couchId";
+	private static final String COUCH_LINKED_ID = "couchLinkedId";
+	private static final String COUCH_USER = "couchUser";
+	private static final String COUCH_USER2 = "couchUser2";
+	private static final String COUCH_PASS = "couchPass";
+	private static final String COUCH_PASS2 = "couchPass2";
+	private static final String IDPERSON1 = "idperson1";
+	private static final String IDPERSON2 = "idperson2";
+	private static final String IDPERSON3 = "idperson3";
+
+	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
+	public static CouchDbConnector couchDbConnector = null;
+	private static final CouchServer couchServer = new CouchServer();
 
 
-    @BeforeClass
-    public static void setUp() {
-        couchDbConnector = couchServer.start(PORT);
-        final String password = PASSWORD_ENCODER.encode(PASSWORD);
+	@BeforeClass
+	public static void setUp() {
+		couchDbConnector = couchServer.start(PORT);
+		final String password = PASSWORD_ENCODER.encode(PASSWORD);
 		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
-        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        // insert sample data
-        final Map<String, Object> properties1 = new HashMap<>();
+		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+		// insert sample data
+		final Map<String, Object> properties1 = new HashMap<>();
 		properties1.put(USERNAME, GOOD_USERNAME);
 		properties1.put(FIRSTNAME, FIRSTNAME_VALUE);
 		CouchProfile couchProfile = new CouchProfile();
@@ -71,97 +71,97 @@ public final class CouchProfileServiceTests implements TestsConstants {
 		couchProfile = new CouchProfile();
 		couchProfile.build(IDPERSON3, properties3);
 		couchProfileService.create(couchProfile, PASSWORD);
-    }
+	}
 
-    @AfterClass
-    public static void tearDown() {
-        //couchServer.stop();
-    }
+	@AfterClass
+	public static void tearDown() {
+		//couchServer.stop();
+	}
 
-    @Test
-    public void testNullConnector() {
-        final CouchProfileService couchProfileService = new CouchProfileService(null);
-        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        TestsHelper.expectException(() -> couchProfileService.init(null), TechnicalException.class, "couchDbConnector cannot be null");
-    }
+	@Test
+	public void testNullConnector() {
+		final CouchProfileService couchProfileService = new CouchProfileService(null);
+		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+		TestsHelper.expectException(() -> couchProfileService.init(null), TechnicalException.class, "couchDbConnector cannot be null");
+	}
 
-    @Test(expected = AccountNotFoundException.class)
-    public void authentFailed() throws HttpAction, CredentialsException {
-        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
-        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
-        couchProfileService.validate(credentials, null);
-    }
+	@Test(expected = AccountNotFoundException.class)
+	public void authentFailed() throws HttpAction, CredentialsException {
+		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
+		couchProfileService.validate(credentials, null);
+	}
 
-    @Test
-    public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
-        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
-        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
-        couchProfileService.validate(credentials, null);
+	@Test
+	public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
+		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
+		couchProfileService.validate(credentials, null);
 
-        final CommonProfile profile = credentials.getUserProfile();
-        assertNotNull(profile);
-        assertTrue(profile instanceof CouchProfile);
-        final CouchProfile couchProfile = (CouchProfile) profile;
-        assertEquals(GOOD_USERNAME, couchProfile.getUsername());
-        assertEquals(2, couchProfile.getAttributes().size());
-        assertEquals(FIRSTNAME_VALUE, couchProfile.getAttribute(FIRSTNAME));
-    }
+		final CommonProfile profile = credentials.getUserProfile();
+		assertNotNull(profile);
+		assertTrue(profile instanceof CouchProfile);
+		final CouchProfile couchProfile = (CouchProfile) profile;
+		assertEquals(GOOD_USERNAME, couchProfile.getUsername());
+		assertEquals(2, couchProfile.getAttributes().size());
+		assertEquals(FIRSTNAME_VALUE, couchProfile.getAttribute(FIRSTNAME));
+	}
 
-    @Test
-    public void testCreateUpdateFindDelete() throws HttpAction, CredentialsException {
-        final CouchProfile profile = new CouchProfile();
-        profile.setId(COUCH_ID);
-        profile.setLinkedId(COUCH_LINKED_ID);
-        profile.addAttribute(USERNAME, COUCH_USER);
-        final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
-        couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-        // create
-        couchProfileService.create(profile, COUCH_PASS);
-        // check credentials
-        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(COUCH_USER, COUCH_PASS, CLIENT_NAME);
-        couchProfileService.validate(credentials, null);
-        final CommonProfile profile1 = credentials.getUserProfile();
-        assertNotNull(profile1);
-        // check data
-        final List<Map<String, Object>> results = getData(couchProfileService, COUCH_ID);
-        assertEquals(1, results.size());
-        final Map<String, Object> result = results.get(0);
-        assertEquals(5, result.size());
-        assertEquals(COUCH_ID, result.get(COUCH_ID_FIELD));
-        assertEquals(COUCH_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
-        assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
-        assertEquals(COUCH_USER, result.get(USERNAME));
-        // findById
-        final CouchProfile profile2 = couchProfileService.findById(COUCH_ID);
-        assertEquals(COUCH_ID, profile2.getId());
-        assertEquals(COUCH_LINKED_ID, profile2.getLinkedId());
-        assertEquals(COUCH_USER, profile2.getUsername());
-        assertEquals(1, profile2.getAttributes().size());
-        // update
-        profile.addAttribute(USERNAME, COUCH_USER2);
-        couchProfileService.update(profile, COUCH_PASS2);
-        final List<Map<String, Object>> results2 = getData(couchProfileService, COUCH_ID);
-        assertEquals(1, results2.size());
-        final Map<String, Object> result2 = results2.get(0);
-        assertEquals(5, result2.size());
-        assertEquals(COUCH_ID, result2.get(COUCH_ID_FIELD));
-        assertEquals(COUCH_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
-        assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
-        assertEquals(COUCH_USER2, result2.get(USERNAME));
-        // check credentials
-        final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(COUCH_USER2, COUCH_PASS2, CLIENT_NAME);
-        couchProfileService.validate(credentials2, null);
-        final CommonProfile profile3 = credentials.getUserProfile();
-        assertNotNull(profile3);
-        // remove
-        couchProfileService.remove(profile);
-        final List<Map<String, Object>> results3 = getData(couchProfileService, COUCH_ID);
-        assertEquals(0, results3.size());
-    }
+	@Test
+	public void testCreateUpdateFindDelete() throws HttpAction, CredentialsException {
+		final CouchProfile profile = new CouchProfile();
+		profile.setId(COUCH_ID);
+		profile.setLinkedId(COUCH_LINKED_ID);
+		profile.addAttribute(USERNAME, COUCH_USER);
+		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
+		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+		// create
+		couchProfileService.create(profile, COUCH_PASS);
+		// check credentials
+		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(COUCH_USER, COUCH_PASS, CLIENT_NAME);
+		couchProfileService.validate(credentials, null);
+		final CommonProfile profile1 = credentials.getUserProfile();
+		assertNotNull(profile1);
+		// check data
+		final List<Map<String, Object>> results = getData(couchProfileService, COUCH_ID);
+		assertEquals(1, results.size());
+		final Map<String, Object> result = results.get(0);
+		assertEquals(5, result.size());
+		assertEquals(COUCH_ID, result.get(COUCH_ID_FIELD));
+		assertEquals(COUCH_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
+		assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
+		assertEquals(COUCH_USER, result.get(USERNAME));
+		// findById
+		final CouchProfile profile2 = couchProfileService.findById(COUCH_ID);
+		assertEquals(COUCH_ID, profile2.getId());
+		assertEquals(COUCH_LINKED_ID, profile2.getLinkedId());
+		assertEquals(COUCH_USER, profile2.getUsername());
+		assertEquals(1, profile2.getAttributes().size());
+		// update
+		profile.addAttribute(USERNAME, COUCH_USER2);
+		couchProfileService.update(profile, COUCH_PASS2);
+		final List<Map<String, Object>> results2 = getData(couchProfileService, COUCH_ID);
+		assertEquals(1, results2.size());
+		final Map<String, Object> result2 = results2.get(0);
+		assertEquals(5, result2.size());
+		assertEquals(COUCH_ID, result2.get(COUCH_ID_FIELD));
+		assertEquals(COUCH_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
+		assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
+		assertEquals(COUCH_USER2, result2.get(USERNAME));
+		// check credentials
+		final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(COUCH_USER2, COUCH_PASS2, CLIENT_NAME);
+		couchProfileService.validate(credentials2, null);
+		final CommonProfile profile3 = credentials.getUserProfile();
+		assertNotNull(profile3);
+		// remove
+		couchProfileService.remove(profile);
+		final List<Map<String, Object>> results3 = getData(couchProfileService, COUCH_ID);
+		assertEquals(0, results3.size());
+	}
 
-    private List<Map<String, Object>> getData(final CouchProfileService couchProfileService, final String id) {
-        return couchProfileService.read(Arrays.asList(COUCH_ID_FIELD, "username", "linkedid", "password", "serializedprofile"), COUCH_ID_FIELD, id);
-    }
+	private List<Map<String, Object>> getData(final CouchProfileService couchProfileService, final String id) {
+		return couchProfileService.read(Arrays.asList(COUCH_ID_FIELD, "username", "linkedid", "password", "serializedprofile"), COUCH_ID_FIELD, id);
+	}
 }

--- a/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/profile/service/CouchProfileServiceTests.java
@@ -41,13 +41,12 @@ public final class CouchProfileServiceTests implements TestsConstants {
 	private static final String IDPERSON3 = "idperson3";
 
 	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
-	public static CouchDbConnector couchDbConnector = null;
 	private static final CouchServer couchServer = new CouchServer();
+	private static final CouchDbConnector couchDbConnector = couchServer.start();
 
 
 	@BeforeClass
 	public static void setUp() {
-		couchDbConnector = couchServer.start();
 		final String password = PASSWORD_ENCODER.encode(PASSWORD);
 		final CouchProfileService couchProfileService = new CouchProfileService(couchDbConnector);
 		couchProfileService.setPasswordEncoder(PASSWORD_ENCODER);

--- a/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
@@ -28,7 +28,7 @@ public final class CouchServer implements TestsConstants {
 	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
 
 	public CouchDbConnector start(final int port) {
-		String couchUrl = "http://localhost:13598/";
+		String couchUrl = "http://localhost:"+port+"/";
 		HttpClient httpClient;
 		CouchDbInstance dbInstance;
 		try {

--- a/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
@@ -2,8 +2,6 @@ package org.pac4j.couch.test.tools;
 
 import org.apache.shiro.authc.credential.DefaultPasswordService;
 import org.ektorp.CouchDbConnector;
-import org.ektorp.CouchDbInstance;
-import org.ektorp.http.HttpClient;
 import org.ektorp.http.StdHttpClient;
 import org.ektorp.impl.StdCouchDbConnector;
 import org.ektorp.impl.StdCouchDbInstance;
@@ -12,10 +10,11 @@ import org.pac4j.core.util.TestsConstants;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import mcouch.core.InMemoryCouchDb;
+
 import org.pac4j.core.credentials.password.PasswordEncoder;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 
 /**
  * Uses a local CouchDB server.
@@ -27,20 +26,19 @@ public final class CouchServer implements TestsConstants {
 
 	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
 
-	public CouchDbConnector start(final int port) {
-		String couchUrl = "http://localhost:"+port+"/";
-		HttpClient httpClient;
-		CouchDbInstance dbInstance;
+	public CouchDbConnector start() {
+		InMemoryCouchDb couchDbClient = new InMemoryCouchDb();
+		couchDbClient.createDatabase("users");
+		StdHttpClient stdHttpClient = new StdHttpClient(couchDbClient);
+		StdCouchDbInstance stdCouchDbInstance = new StdCouchDbInstance(stdHttpClient);
 		try {
-			httpClient = new StdHttpClient.Builder()
-					.url(couchUrl)
-					.build();
-		} catch (MalformedURLException e) {
-			e.printStackTrace();
+			stdCouchDbInstance = new StdCouchDbInstance(stdHttpClient);
+		} catch (Exception e1) {
+			e1.printStackTrace();
 			return null;
 		}
-		dbInstance = new StdCouchDbInstance(httpClient);
-		CouchDbConnector couchDbConnector = new StdCouchDbConnector("users", dbInstance);
+		StdCouchDbConnector couchDbConnector    = new StdCouchDbConnector("users", stdCouchDbInstance);
+
 		couchDbConnector.createDatabaseIfNotExists();
 
 		// uploading design doc:

--- a/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
@@ -31,12 +31,6 @@ public final class CouchServer implements TestsConstants {
 		couchDbClient.createDatabase("users");
 		StdHttpClient stdHttpClient = new StdHttpClient(couchDbClient);
 		StdCouchDbInstance stdCouchDbInstance = new StdCouchDbInstance(stdHttpClient);
-		try {
-			stdCouchDbInstance = new StdCouchDbInstance(stdHttpClient);
-		} catch (Exception e1) {
-			e1.printStackTrace();
-			return null;
-		}
 		StdCouchDbConnector couchDbConnector    = new StdCouchDbConnector("users", stdCouchDbInstance);
 
 		couchDbConnector.createDatabaseIfNotExists();

--- a/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
@@ -10,15 +10,12 @@ import org.ektorp.impl.StdCouchDbInstance;
 import org.pac4j.core.credentials.password.ShiroPasswordEncoder;
 import org.pac4j.core.util.TestsConstants;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.pac4j.core.credentials.password.PasswordEncoder;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Uses a local CouchDB server.
@@ -62,8 +59,5 @@ public final class CouchServer implements TestsConstants {
     }
 
     public void stop() {
-//        if (mongodExecutable != null) {
-//            mongodExecutable.stop();
-//        }
     }
 }

--- a/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
@@ -25,39 +25,37 @@ import java.net.MalformedURLException;
  */
 public final class CouchServer implements TestsConstants {
 
-    public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
+	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
 
-//    private MongodExecutable mongodExecutable;
-
-    public CouchDbConnector start(final int port) {
-    	String couchUrl = "http://localhost:13598/";
-    	HttpClient httpClient;
+	public CouchDbConnector start(final int port) {
+		String couchUrl = "http://localhost:13598/";
+		HttpClient httpClient;
 		CouchDbInstance dbInstance;
-        try {
+		try {
 			httpClient = new StdHttpClient.Builder()
-			        .url(couchUrl)
-			        .build();
+					.url(couchUrl)
+					.build();
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
 			return null;
 		}
-        dbInstance = new StdCouchDbInstance(httpClient);
-        CouchDbConnector couchDbConnector = new StdCouchDbConnector("users", dbInstance);
-        couchDbConnector.createDatabaseIfNotExists();
-        
-        // uploading design doc:
-        String designDocString = "{\"_id\":\"_design/pac4j\",\"language\":\"javascript\",\"views\":{\"by_username\":{\"map\":\"function(doc){if (doc.username) emit(doc.username, doc);}\"},\"by_linkedid\":{\"map\":\"function(doc) {if (doc.linkedid) emit(doc.linkedid, doc);}\"}}}";
-        ObjectMapper objectMapper = new ObjectMapper();
-        try {
+		dbInstance = new StdCouchDbInstance(httpClient);
+		CouchDbConnector couchDbConnector = new StdCouchDbConnector("users", dbInstance);
+		couchDbConnector.createDatabaseIfNotExists();
+
+		// uploading design doc:
+		String designDocString = "{\"_id\":\"_design/pac4j\",\"language\":\"javascript\",\"views\":{\"by_username\":{\"map\":\"function(doc){if (doc.username) emit(doc.username, doc);}\"},\"by_linkedid\":{\"map\":\"function(doc) {if (doc.linkedid) emit(doc.linkedid, doc);}\"}}}";
+		ObjectMapper objectMapper = new ObjectMapper();
+		try {
 			couchDbConnector.create(objectMapper.readTree(designDocString));
 		} catch (IOException e) {
 			e.printStackTrace();
 			return null;
 		}
-        
-        return couchDbConnector;
-    }
 
-    public void stop() {
-    }
+		return couchDbConnector;
+	}
+
+	public void stop() {
+	}
 }

--- a/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
+++ b/pac4j-couch/src/test/java/org/pac4j/couch/test/tools/CouchServer.java
@@ -1,0 +1,69 @@
+package org.pac4j.couch.test.tools;
+
+import org.apache.shiro.authc.credential.DefaultPasswordService;
+import org.ektorp.CouchDbConnector;
+import org.ektorp.CouchDbInstance;
+import org.ektorp.http.HttpClient;
+import org.ektorp.http.StdHttpClient;
+import org.ektorp.impl.StdCouchDbConnector;
+import org.ektorp.impl.StdCouchDbInstance;
+import org.pac4j.core.credentials.password.ShiroPasswordEncoder;
+import org.pac4j.core.util.TestsConstants;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.pac4j.core.credentials.password.PasswordEncoder;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Uses a local CouchDB server.
+ *
+ * @author Elie Roux
+ * @since 2.0.0
+ */
+public final class CouchServer implements TestsConstants {
+
+    public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
+
+//    private MongodExecutable mongodExecutable;
+
+    public CouchDbConnector start(final int port) {
+    	String couchUrl = "http://localhost:13598/";
+    	HttpClient httpClient;
+		CouchDbInstance dbInstance;
+        try {
+			httpClient = new StdHttpClient.Builder()
+			        .url(couchUrl)
+			        .build();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+			return null;
+		}
+        dbInstance = new StdCouchDbInstance(httpClient);
+        CouchDbConnector couchDbConnector = new StdCouchDbConnector("users", dbInstance);
+        couchDbConnector.createDatabaseIfNotExists();
+        
+        // uploading design doc:
+        String designDocString = "{\"_id\":\"_design/pac4j\",\"language\":\"javascript\",\"views\":{\"by_username\":{\"map\":\"function(doc){if (doc.username) emit(doc.username, doc);}\"},\"by_linkedid\":{\"map\":\"function(doc) {if (doc.linkedid) emit(doc.linkedid, doc);}\"}}}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+			couchDbConnector.create(objectMapper.readTree(designDocString));
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+        
+        return couchDbConnector;
+    }
+
+    public void stop() {
+//        if (mongodExecutable != null) {
+//            mongodExecutable.stop();
+//        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
 		<module>pac4j-ldap</module>
 		<module>pac4j-sql</module>
 		<module>pac4j-mongo</module>
+		<module>pac4j-couch</module>
 		<module>pac4j-stormpath</module>
 	</modules>
 


### PR DESCRIPTION
This adds and documents a CouchDB authenticator and fixes #902.

The tests in the current state of the PR require a CouchDB server running on `http://localhost:13598` so I think it still needs some more work to find a proper CouchDB mocking. But I'm opening the pull request to see if you have some comments other than this one...?