### PR TITLE
OIDC use provided data (#886)

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -264,6 +264,9 @@ public class OidcConfiguration extends InitializableWebObject {
     }
 
     public String getLogoutUrl() {
+        if(logoutUrl == null && getProviderMetadata().getEndSessionEndpointURI() != null) {
+            return getProviderMetadata().getEndSessionEndpointURI().toString();
+        }
         return logoutUrl;
     }
 


### PR DESCRIPTION
Uses the end session endpoint url from the provider meta data as fallback, if available.