### PR TITLE
#916

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
@@ -91,7 +91,7 @@ public class SAML2MessageContext extends MessageContext<SAMLObject> {
     		}
     	}
     	throw new SAMLException("Identity provider has no single logout service available for the selected profile"
-    	        + getIDPSSODescriptor());
+    	        + binding);
     }
 
     public final SingleSignOnService getIDPSingleSignOnService(final String binding) {
@@ -102,7 +102,7 @@ public class SAML2MessageContext extends MessageContext<SAMLObject> {
             }
         }
         throw new SAMLException("Identity provider has no single sign on service available for the selected profile"
-                + getIDPSSODescriptor());
+                + binding);
     }
 
     public final AssertionConsumerService getSPAssertionConsumerService() {


### PR DESCRIPTION
As suggested in the response to #916 I created a pull request for the small changes in SAML2MessageContext which allowed me identify the missing binding by replacing the error:
```
org.pac4j.saml.exceptions.SAMLException: Identity provider has no single sign on service available for the selected profileorg.opensaml.saml.saml2.metadata.impl.IDPSSODescriptorImpl@2d6719d3
```
with a much more clear:

```
org.pac4j.saml.exceptions.SAMLException: Identity provider has no single sign on service available for the selected profileurn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST
```

And the doc update for SimpleSAMLphp.

Thank you.