### PR TITLE
Use dedicated method to remove attribute from J2ESessionStore

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/session/J2ESessionStore.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/session/J2ESessionStore.java
@@ -36,7 +36,11 @@ public class J2ESessionStore implements SessionStore<J2EContext> {
 
     @Override
     public void set(final J2EContext context, final String key, final Object value) {
-        getHttpSession(context).setAttribute(key, value);
+        if (value == null) {
+            getHttpSession(context).removeAttribute(key);
+        } else {
+            getHttpSession(context).setAttribute(key, value);
+        }
     }
 
     @Override


### PR DESCRIPTION
It could happen that some implementation of the `HttpSession` from the Servlet API expects only non-null value when setting attributes.

Note that according to the documentation, `setAttribute` does accept null values and will behave like `removeAttribute`, but I considered that we could be on the safe side with this. So it's ok for me if you think we shouldn't merge that :)