### PR TITLE
Azure Ad OIDC delegation client remove client_name from redirect URL

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/AzureAdClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/AzureAdClient.java
@@ -17,14 +17,14 @@ import org.pac4j.oidc.profile.azuread.AzureAdProfileCreator;
  * Azure AD v2.0. Replace {@code tenantid} with the ID of the tenant to authenticate against. To
  * find this ID, fill in your tenant's domain name. Your tenant ID is the UUID in
  * {@code authorization_endpoint}.
- * 
+ *
  * For authentication against an unknown (or dynamic tenant), use {@code common} as ID.
  * Authentication against the common endpoint results in a ID token with a {@code issuer} different
  * from the {@code issuer} mentioned in the discovery data. This class uses to special validator
  * to correctly validate the issuer returned by Azure AD.
  *
  * More information at: https://msdn.microsoft.com/en-us/library/azure/dn645541.aspx
- * 
+ *
  * @author Emond Papegaaij
  * @since 1.8.3
  */
@@ -34,6 +34,9 @@ public class AzureAdClient extends OidcClient<AzureAdProfile> {
 
     public AzureAdClient(final OidcConfiguration configuration) {
         super(configuration);
+        // https://github.com/apereo/cas/issues/2711
+        // don't include clientName because its ignored and causes validation failure
+        setIncludeClientNameInCallbackUrl(false);
     }
 
     @Override

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/AzureAdClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/AzureAdClient.java
@@ -1,6 +1,7 @@
 package org.pac4j.oidc.client;
 
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.http.RelativeUrlResolver;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oidc.client.azuread.AzureAdResourceRetriever;
 import org.pac4j.oidc.config.OidcConfiguration;
@@ -17,12 +18,12 @@ import org.pac4j.oidc.profile.azuread.AzureAdProfileCreator;
  * Azure AD v2.0. Replace {@code tenantid} with the ID of the tenant to authenticate against. To
  * find this ID, fill in your tenant's domain name. Your tenant ID is the UUID in
  * {@code authorization_endpoint}.
- *
+ * <p>
  * For authentication against an unknown (or dynamic tenant), use {@code common} as ID.
  * Authentication against the common endpoint results in a ID token with a {@code issuer} different
  * from the {@code issuer} mentioned in the discovery data. This class uses to special validator
  * to correctly validate the issuer returned by Azure AD.
- *
+ * <p>
  * More information at: https://msdn.microsoft.com/en-us/library/azure/dn645541.aspx
  *
  * @author Emond Papegaaij
@@ -30,7 +31,8 @@ import org.pac4j.oidc.profile.azuread.AzureAdProfileCreator;
  */
 public class AzureAdClient extends OidcClient<AzureAdProfile> {
 
-    public AzureAdClient() {}
+    public AzureAdClient() {
+    }
 
     public AzureAdClient(final OidcConfiguration configuration) {
         super(configuration);
@@ -44,7 +46,20 @@ public class AzureAdClient extends OidcClient<AzureAdProfile> {
         CommonHelper.assertNotNull("configuration", getConfiguration());
         getConfiguration().setResourceRetriever(new AzureAdResourceRetriever());
         defaultProfileCreator(new AzureAdProfileCreator(getConfiguration()));
-
+        setUrlResolver(new AzureAdClientUrlResolver("/cas/delegatedAuthn/oidc/" + getName()));
         super.clientInit(context);
+    }
+
+    private static class AzureAdClientUrlResolver extends RelativeUrlResolver {
+        private final String contextPath;
+
+        AzureAdClientUrlResolver(String contextPath) {
+            this.contextPath = contextPath;
+        }
+
+        @Override
+        public String compute(String url, WebContext context) {
+            return super.compute(contextPath, context);
+        }
     }
 }


### PR DESCRIPTION
This is the proposal for solving the problem observed with at least Office 365 Azure AD Open ID Connect delagation client. The problem is described  in https://github.com/apereo/cas/issues/2711.

As initially discussed with  @mmoayyed , the `client_name` could be replaced by `/delegatedAuthn/<clientType>/<clientName>` context path. 

@leleuj please take a look at the problem. The proposal is just a first trial. I need some assistance at combining the redirect url (1. resolution of cas server context path (now */cas* hardcoded) 2. possibly, replacement of client type (here */oidc*) by constant/enum to make the solution more generic?)

The counterpart of this is proposed to cas for extending the cas-server-support-pac4j-clients accordingly .

Any review/feedback is highly appreciated!

Regards, Gena

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html