### PR TITLE
Fixes InMemoryProfileService.update

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -21,71 +21,71 @@ import java.util.stream.Collectors;
 
 public class InMemoryProfileService<U extends CommonProfile> extends AbstractProfileService<U>  {
 
-	public Map<String,Map<String,Object>> profiles;
-	public Function<Object[], U> profileFactory;
+    public Map<String,Map<String,Object>> profiles;
+    public Function<Object[], U> profileFactory;
 
-	public InMemoryProfileService(final Function<Object[], U> profileFactory) {
-		this(new HashMap<>(), profileFactory);
-	}
+    public InMemoryProfileService(final Function<Object[], U> profileFactory) {
+        this(new HashMap<>(), profileFactory);
+    }
 
-	public InMemoryProfileService(final Map<String,Map<String,Object>> profiles, final Function<Object[], U> profileFactory) {
-		this.profiles = profiles;
-		this.profileFactory = profileFactory;
-	}
+    public InMemoryProfileService(final Map<String,Map<String,Object>> profiles, final Function<Object[], U> profileFactory) {
+        this.profiles = profiles;
+        this.profileFactory = profileFactory;
+    }
 
-	@Override
-	protected void internalInit(final WebContext context) {
-		CommonHelper.assertNotNull("passwordEncoder", getPasswordEncoder());
-		defaultProfileDefinition(new CommonProfileDefinition<U>(profileFactory));
-		super.internalInit(context);
-	}
+    @Override
+    protected void internalInit(final WebContext context) {
+        CommonHelper.assertNotNull("passwordEncoder", getPasswordEncoder());
+        defaultProfileDefinition(new CommonProfileDefinition<U>(profileFactory));
+        super.internalInit(context);
+    }
 
-	@Override
-	protected void insert(final Map<String, Object> attributes) {
-		final String id = (String) attributes.get(getIdAttribute());
-		logger.debug("Inserting doc id: {} with attributes: {}", id, attributes);
-		profiles.put(id, attributes);
-	}
+    @Override
+    protected void insert(final Map<String, Object> attributes) {
+        final String id = (String) attributes.get(getIdAttribute());
+        logger.debug("Inserting doc id: {} with attributes: {}", id, attributes);
+        profiles.put(id, attributes);
+    }
 
-	@Override
-	protected void update(final Map<String, Object> attributes) {
-		final String id = (String) attributes.get(getIdAttribute());
-		logger.debug("Updating id: {} with attributes: {}", id, attributes);
-		profiles.put(id, attributes);
-	}
+    @Override
+    protected void update(final Map<String, Object> attributes) {
+        final String id = (String) attributes.get(getIdAttribute());
+        logger.debug("Updating id: {} with attributes: {}", id, attributes);
+        profiles.put(id, attributes);
+    }
 
-	@Override
-	protected void deleteById(final String id) {
-		logger.debug("Delete id: {}", id);
-		profiles.remove(id);
-	}
+    @Override
+    protected void deleteById(final String id) {
+        logger.debug("Delete id: {}", id);
+        profiles.remove(id);
+    }
 
-	private Map<String, Object> populateAttributes(final Map<String, Object> rowAttributes, final List<String> names) {
+    private Map<String, Object> populateAttributes(final Map<String, Object> rowAttributes, final List<String> names) {
         return rowAttributes.entrySet().stream()
                 .filter(p -> names == null || names.contains(p.getKey()))
                 // not using Collators.toMap because of
                 // https://stackoverflow.com/questions/24630963/java-8-nullpointerexception-in-collectors-tomap
                 .collect(HashMap::new, (m,v)->m.put(v.getKey(), v.getValue()), HashMap::putAll);
-	}
+    }
 
-	@Override
-	protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
-		logger.debug("Reading key / value: {} / {}", key, value);
-		final List<Map<String, Object>> listAttributes;
-		if (key.equals(getIdAttribute())) {
-			listAttributes = new ArrayList<>();
-			final Map<String,Object> profile = profiles.get(value);
-			if (profile != null) {
-				listAttributes.add(populateAttributes(profile, names));
-			}
-		} else {
-			listAttributes = profiles.entrySet().stream()
-					.filter(p -> p.getValue().get(key).equals(value))
-					.map(p -> populateAttributes(p.getValue(), names))
-					.collect(Collectors.toList());
-		}
-		logger.debug("Found: {}", listAttributes);
-		return listAttributes;
-	}
+    @Override
+    protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
+        logger.debug("Reading key / value: {} / {}", key, value);
+        final List<Map<String, Object>> listAttributes;
+        if (key.equals(getIdAttribute())) {
+            listAttributes = new ArrayList<>();
+            final Map<String,Object> profile = profiles.get(value);
+            if (profile != null) {
+                listAttributes.add(populateAttributes(profile, names));
+            }
+        } else {
+            listAttributes = profiles.entrySet().stream()
+                    .filter(p -> p.getValue().get(key).equals(value))
+                    .map(p -> populateAttributes(p.getValue(), names))
+                    .collect(Collectors.toList());
+        }
+        logger.debug("Found: {}", listAttributes);
+        return listAttributes;
+    }
 
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -80,7 +80,7 @@ public class InMemoryProfileService<U extends CommonProfile> extends AbstractPro
             }
         } else {
             listAttributes = profiles.entrySet().stream()
-                    .filter(p -> p.getValue().get(key).equals(value))
+                    .filter(p -> p.getValue().get(key) != null && p.getValue().get(key).equals(value))
                     .map(p -> populateAttributes(p.getValue(), names))
                     .collect(Collectors.toList());
         }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * In-memory profile service.
@@ -70,18 +71,18 @@ public class InMemoryProfileService<U extends CommonProfile> extends AbstractPro
 	@Override
 	protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
 		logger.debug("Reading key / value: {} / {}", key, value);
-		final List<Map<String, Object>> listAttributes = new ArrayList<>();
+		final List<Map<String, Object>> listAttributes;
 		if (key.equals(getIdAttribute())) {
+			listAttributes = new ArrayList<>();
 			final Map<String,Object> profile = profiles.get(value);
 			if (profile != null) {
 				listAttributes.add(populateAttributes(profile, names));
 			}
 		} else {
-			for (Map<String,Object> profile : profiles.values()) {
-				if (profile.get(key).equals(value)) {
-					listAttributes.add(populateAttributes(profile, names));
-				}
-			}
+			listAttributes = profiles.entrySet().stream()
+					.filter(p -> p.getValue().get(key).equals(value))
+					.map(p -> populateAttributes(p.getValue(), names))
+					.collect(Collectors.toList());
 		}
 		logger.debug("Found: {}", listAttributes);
 		return listAttributes;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -51,7 +51,10 @@ public class InMemoryProfileService<U extends CommonProfile> extends AbstractPro
     protected void update(final Map<String, Object> attributes) {
         final String id = (String) attributes.get(getIdAttribute());
         logger.debug("Updating id: {} with attributes: {}", id, attributes);
-        profiles.put(id, attributes);
+        final Map<String,Object> profile = profiles.get(id);
+        if (profile != null) {
+            profile.putAll(attributes);
+        }
     }
 
     @Override

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -55,7 +55,7 @@ public class InMemoryProfileService<U extends CommonProfile> extends AbstractPro
         if (profile != null) {
             profile.putAll(attributes);
         } else {
-            insert(attributes);
+            profiles.put(id, attributes);
         }
     }
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -54,6 +54,8 @@ public class InMemoryProfileService<U extends CommonProfile> extends AbstractPro
         final Map<String,Object> profile = profiles.get(id);
         if (profile != null) {
             profile.putAll(attributes);
+        } else {
+            insert(attributes);
         }
     }
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
  * In-memory profile service.
  *
  * @author Elie Roux
- * @since 2.0.0
+ * @since 2.1.0
  */
 
 public class InMemoryProfileService<U extends CommonProfile> extends AbstractProfileService<U>  {

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -1,6 +1,11 @@
 package org.pac4j.core.profile.service;
 
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.util.CommonHelper;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,15 +19,31 @@ import java.util.Map;
  */
 
 public class InMemoryProfileService<U extends CommonProfile> extends AbstractProfileService<U>  {
-	
+
 	public Map<String,Map<String,Object>> profiles;
-	
-	public InMemoryProfileService() {
-		 this(new HashMap<String,Map<String,Object>>());
+	//public AuthenticatorProfileCreator<UsernamePasswordCredentials, U> creator;
+	public Class<U> typeArgumentClass;
+
+	public InMemoryProfileService(Class<U> typeArgumentClass) {
+		this(new HashMap<String,Map<String,Object>>(), typeArgumentClass);
 	}
-	
-	public InMemoryProfileService(Map<String,Map<String,Object>> profiles) {
-		 this.profiles = profiles;
+
+	public InMemoryProfileService(Map<String,Map<String,Object>> profiles, Class<U> typeArgumentClass) {
+		this.profiles = profiles;
+		this.typeArgumentClass = typeArgumentClass;
+	}
+
+	@Override
+	protected void internalInit(final WebContext context) {
+		CommonHelper.assertNotNull("passwordEncoder", getPasswordEncoder());
+		defaultProfileDefinition(new CommonProfileDefinition<U>(x -> {
+			try {
+				return typeArgumentClass.newInstance();
+			} catch (InstantiationException | IllegalAccessException e) {
+				throw new TechnicalException("Unable to instanciate "+typeArgumentClass+", replace with 'CommonProfile' in simple cases");
+			}
+		}));
+		super.internalInit(context);
 	}
 
 	@Override
@@ -55,22 +76,22 @@ public class InMemoryProfileService<U extends CommonProfile> extends AbstractPro
 		}
 		return newAttributes;
 	}
-	
+
 	@Override
 	protected List<Map<String, Object>> read(List<String> names, String key, String value) {
 		logger.debug("Reading key / value: {} / {}", key, value);
 		final List<Map<String, Object>> listAttributes = new ArrayList<>();
-		
+
 		if (key.equals(getIdAttribute())) {
-			Map<String,Object> profile = profiles.get(key);
+			Map<String,Object> profile = profiles.get(value);
 			if (profile != null) {
 				listAttributes.add(populateAttributes(profile, names));
 			}
 		} else {
 			for (Map<String,Object> profile : profiles.values()) {
-			    if (profile.get(key).equals(value)) {
-			    	listAttributes.add(populateAttributes(profile, names));
-			    }
+				if (profile.get(key).equals(value)) {
+					listAttributes.add(populateAttributes(profile, names));
+				}
 			}
 		}
 		logger.debug("Found: {}", listAttributes);

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -1,0 +1,80 @@
+package org.pac4j.core.profile.service;
+
+import org.pac4j.core.profile.CommonProfile;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * In-memory profile service.
+ *
+ * @author Elie Roux
+ * @since 2.0.0
+ */
+
+public class InMemoryProfileService<U extends CommonProfile> extends AbstractProfileService<U>  {
+	
+	public Map<String,Map<String,Object>> profiles;
+	
+	public InMemoryProfileService() {
+		 this(new HashMap<String,Map<String,Object>>());
+	}
+	
+	public InMemoryProfileService(Map<String,Map<String,Object>> profiles) {
+		 this.profiles = profiles;
+	}
+
+	@Override
+	protected void insert(Map<String, Object> attributes) {
+		String id = (String) attributes.get(getIdAttribute());
+		logger.debug("Inserting doc id: {} with attributes: {}", id, attributes);
+		profiles.put(id, attributes);
+	}
+
+	@Override
+	protected void update(Map<String, Object> attributes) {
+		String id = (String) attributes.get(getIdAttribute());
+		logger.debug("Updating id: {} with attributes: {}", id, attributes);
+		profiles.put(id, attributes);
+	}
+
+	@Override
+	protected void deleteById(String id) {
+		logger.debug("Delete id: {}", id);
+		profiles.remove(id);
+	}
+
+	private Map<String, Object> populateAttributes(final Map<String, Object> rowAttributes, final List<String> names) {
+		final Map<String, Object> newAttributes = new HashMap<>();
+		for (final Map.Entry<String, Object> entry : rowAttributes.entrySet()) {
+			final String name = entry.getKey();
+			if (names == null || names.contains(name)) {
+				newAttributes.put(name, entry.getValue());
+			}
+		}
+		return newAttributes;
+	}
+	
+	@Override
+	protected List<Map<String, Object>> read(List<String> names, String key, String value) {
+		logger.debug("Reading key / value: {} / {}", key, value);
+		final List<Map<String, Object>> listAttributes = new ArrayList<>();
+		
+		if (key.equals(getIdAttribute())) {
+			Map<String,Object> profile = profiles.get(key);
+			if (profile != null) {
+				listAttributes.add(populateAttributes(profile, names));
+			}
+		} else {
+			for (Map<String,Object> profile : profiles.values()) {
+			    if (profile.get(key).equals(value)) {
+			    	listAttributes.add(populateAttributes(profile, names));
+			    }
+			}
+		}
+		logger.debug("Found: {}", listAttributes);
+		return listAttributes;
+	}
+
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -1,7 +1,6 @@
 package org.pac4j.core.profile.service;
 
 import org.pac4j.core.context.WebContext;
-import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.core.util.CommonHelper;
@@ -10,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 /**
  * In-memory profile service.
@@ -21,69 +21,58 @@ import java.util.Map;
 public class InMemoryProfileService<U extends CommonProfile> extends AbstractProfileService<U>  {
 
 	public Map<String,Map<String,Object>> profiles;
-	//public AuthenticatorProfileCreator<UsernamePasswordCredentials, U> creator;
-	public Class<U> typeArgumentClass;
+	public Function<Object[], U> profileFactory;
 
-	public InMemoryProfileService(Class<U> typeArgumentClass) {
-		this(new HashMap<String,Map<String,Object>>(), typeArgumentClass);
+	public InMemoryProfileService(final Function<Object[], U> profileFactory) {
+		this(new HashMap<>(), profileFactory);
 	}
 
-	public InMemoryProfileService(Map<String,Map<String,Object>> profiles, Class<U> typeArgumentClass) {
+	public InMemoryProfileService(final Map<String,Map<String,Object>> profiles, final Function<Object[], U> profileFactory) {
 		this.profiles = profiles;
-		this.typeArgumentClass = typeArgumentClass;
+		this.profileFactory = profileFactory;
 	}
 
 	@Override
 	protected void internalInit(final WebContext context) {
 		CommonHelper.assertNotNull("passwordEncoder", getPasswordEncoder());
-		defaultProfileDefinition(new CommonProfileDefinition<U>(x -> {
-			try {
-				return typeArgumentClass.newInstance();
-			} catch (InstantiationException | IllegalAccessException e) {
-				throw new TechnicalException("Unable to instanciate "+typeArgumentClass+", replace with 'CommonProfile' in simple cases");
-			}
-		}));
+		defaultProfileDefinition(new CommonProfileDefinition<U>(profileFactory));
 		super.internalInit(context);
 	}
 
 	@Override
-	protected void insert(Map<String, Object> attributes) {
-		String id = (String) attributes.get(getIdAttribute());
+	protected void insert(final Map<String, Object> attributes) {
+		final String id = (String) attributes.get(getIdAttribute());
 		logger.debug("Inserting doc id: {} with attributes: {}", id, attributes);
 		profiles.put(id, attributes);
 	}
 
 	@Override
-	protected void update(Map<String, Object> attributes) {
-		String id = (String) attributes.get(getIdAttribute());
+	protected void update(final Map<String, Object> attributes) {
+		final String id = (String) attributes.get(getIdAttribute());
 		logger.debug("Updating id: {} with attributes: {}", id, attributes);
 		profiles.put(id, attributes);
 	}
 
 	@Override
-	protected void deleteById(String id) {
+	protected void deleteById(final String id) {
 		logger.debug("Delete id: {}", id);
 		profiles.remove(id);
 	}
 
 	private Map<String, Object> populateAttributes(final Map<String, Object> rowAttributes, final List<String> names) {
-		final Map<String, Object> newAttributes = new HashMap<>();
-		for (final Map.Entry<String, Object> entry : rowAttributes.entrySet()) {
-			final String name = entry.getKey();
-			if (names == null || names.contains(name)) {
-				newAttributes.put(name, entry.getValue());
-			}
-		}
-		return newAttributes;
+        return rowAttributes.entrySet().stream()
+                .filter(p -> names == null || names.contains(p.getKey()))
+                // not using Collators.toMap because of
+                // https://stackoverflow.com/questions/24630963/java-8-nullpointerexception-in-collectors-tomap
+                .collect(HashMap::new, (m,v)->m.put(v.getKey(), v.getValue()), HashMap::putAll);
 	}
 
 	@Override
-	protected List<Map<String, Object>> read(List<String> names, String key, String value) {
+	protected List<Map<String, Object>> read(final List<String> names, final String key, final String value) {
 		logger.debug("Reading key / value: {} / {}", key, value);
 		final List<Map<String, Object>> listAttributes = new ArrayList<>();
-
 		if (key.equals(getIdAttribute())) {
-			Map<String,Object> profile = profiles.get(value);
+			final Map<String,Object> profile = profiles.get(value);
 			if (profile != null) {
 				listAttributes.add(populateAttributes(profile, names));
 			}

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -35,14 +35,13 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
 	private static final String IDPERSON3 = "idperson3";
 
 	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
-	public final static InMemoryProfileService<CommonProfile> inMemoryProfileService = new InMemoryProfileService<CommonProfile>(x -> new CommonProfile());
-	static {
+	public InMemoryProfileService<CommonProfile> inMemoryProfileService;
+
+
+	@Before
+	public void setUp() {
+		inMemoryProfileService = new InMemoryProfileService<CommonProfile>(x -> new CommonProfile());
 		inMemoryProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-	}
-
-
-	@BeforeClass
-	public static void setUp() {
 		final String password = PASSWORD_ENCODER.encode(PASSWORD);
 		// insert sample data
 		final Map<String, Object> properties1 = new HashMap<>();
@@ -132,7 +131,7 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
 		assertEquals(0, results3.size());
 	}
 
-	private static List<Map<String, Object>> getData(final String id) {
+	private List<Map<String, Object>> getData(final String id) {
 		return inMemoryProfileService.read(Arrays.asList("id", "username", "linkedid", "password", "serializedprofile"), "id", id);
 	}
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -35,7 +35,7 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
 	private static final String IDPERSON3 = "idperson3";
 
 	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
-	public final static InMemoryProfileService<CommonProfile> inMemoryProfileService = new InMemoryProfileService<CommonProfile>();
+	public final static InMemoryProfileService<CommonProfile> inMemoryProfileService = new InMemoryProfileService<CommonProfile>(CommonProfile.class);
 	static {
 		inMemoryProfileService.setPasswordEncoder(PASSWORD_ENCODER);
 	}

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -1,0 +1,139 @@
+package org.pac4j.core.profile.service;
+
+import org.apache.shiro.authc.credential.DefaultPasswordService;
+import org.junit.*;
+import org.pac4j.core.exception.*;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.service.AbstractProfileService;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.core.credentials.UsernamePasswordCredentials;
+import org.pac4j.core.credentials.password.PasswordEncoder;
+import org.pac4j.core.credentials.password.ShiroPasswordEncoder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the {@link InMemoryProfileService}.
+ *
+ * @author Elie Roux
+ * @since 2.0.0
+ */
+public final class InMemoryProfileServiceTests implements TestsConstants {
+
+	private static final String TEST_ID = "testId";
+	private static final String TEST_LINKED_ID = "testLinkedId";
+	private static final String TEST_USER = "testUser";
+	private static final String TEST_USER2 = "testUser2";
+	private static final String TEST_PASS = "testPass";
+	private static final String TEST_PASS2 = "testPass2";
+	private static final String IDPERSON1 = "idperson1";
+	private static final String IDPERSON2 = "idperson2";
+	private static final String IDPERSON3 = "idperson3";
+
+	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
+	public final static InMemoryProfileService<CommonProfile> inMemoryProfileService = new InMemoryProfileService<CommonProfile>();
+	static {
+		inMemoryProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+	}
+
+
+	@BeforeClass
+	public static void setUp() {
+		final String password = PASSWORD_ENCODER.encode(PASSWORD);
+		// insert sample data
+		final Map<String, Object> properties1 = new HashMap<>();
+		properties1.put(USERNAME, GOOD_USERNAME);
+		properties1.put(FIRSTNAME, FIRSTNAME_VALUE);
+		CommonProfile profile = new CommonProfile();
+		profile.build(IDPERSON1, properties1);
+		inMemoryProfileService.create(profile, PASSWORD);
+		// second person, 
+		final Map<String, Object> properties2 = new HashMap<>();
+		properties2.put(USERNAME, MULTIPLE_USERNAME);
+		profile = new CommonProfile();
+		profile.build(IDPERSON2, properties2);
+		inMemoryProfileService.create(profile, PASSWORD);
+		final Map<String, Object> properties3 = new HashMap<>();
+		properties3.put(USERNAME, MULTIPLE_USERNAME);
+		properties3.put(PASSWORD, password);
+		profile = new CommonProfile();
+		profile.build(IDPERSON3, properties3);
+		inMemoryProfileService.create(profile, PASSWORD);
+	}
+
+	@Test(expected = AccountNotFoundException.class)
+	public void authentFailed() throws HttpAction, CredentialsException {
+		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
+		inMemoryProfileService.validate(credentials, null);
+	}
+
+	@Test
+	public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
+		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
+		inMemoryProfileService.validate(credentials, null);
+		final CommonProfile profile = credentials.getUserProfile();
+		assertNotNull(profile);
+		assertEquals(GOOD_USERNAME, profile.getUsername());
+		assertEquals(2, profile.getAttributes().size());
+		assertEquals(FIRSTNAME_VALUE, profile.getAttribute(FIRSTNAME));
+	}
+
+	@Test
+	public void testCreateUpdateFindDelete() throws HttpAction, CredentialsException {
+		final CommonProfile profile = new CommonProfile();
+		profile.setId(TEST_ID);
+		profile.setLinkedId(TEST_LINKED_ID);
+		profile.addAttribute(USERNAME, TEST_USER);
+		// create
+		inMemoryProfileService.create(profile, TEST_PASS);
+		// check credentials
+		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(TEST_USER, TEST_PASS, CLIENT_NAME);
+		inMemoryProfileService.validate(credentials, null);
+		final CommonProfile profile1 = credentials.getUserProfile();
+		assertNotNull(profile1);
+		// check data
+		final List<Map<String, Object>> results = getData(TEST_ID);
+		assertEquals(1, results.size());
+		final Map<String, Object> result = results.get(0);
+		assertEquals(5, result.size());
+		assertEquals(TEST_ID, result.get("id"));
+		assertEquals(TEST_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
+		assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
+		assertEquals(TEST_USER, result.get(USERNAME));
+		// findById
+		final CommonProfile profile2 = inMemoryProfileService.findById(TEST_ID);
+		assertEquals(TEST_ID, profile2.getId());
+		assertEquals(TEST_LINKED_ID, profile2.getLinkedId());
+		assertEquals(TEST_USER, profile2.getUsername());
+		assertEquals(1, profile2.getAttributes().size());
+		// update
+		profile.addAttribute(USERNAME, TEST_USER2);
+		inMemoryProfileService.update(profile, TEST_PASS2);
+		final List<Map<String, Object>> results2 = getData(TEST_ID);
+		assertEquals(1, results2.size());
+		final Map<String, Object> result2 = results2.get(0);
+		assertEquals(5, result2.size());
+		assertEquals(TEST_ID, result2.get("id"));
+		assertEquals(TEST_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
+		assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
+		assertEquals(TEST_USER2, result2.get(USERNAME));
+		// check credentials
+		final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(TEST_USER2, TEST_PASS2, CLIENT_NAME);
+		inMemoryProfileService.validate(credentials2, null);
+		final CommonProfile profile3 = credentials.getUserProfile();
+		assertNotNull(profile3);
+		// remove
+		inMemoryProfileService.remove(profile);
+		final List<Map<String, Object>> results3 = getData(TEST_ID);
+		assertEquals(0, results3.size());
+	}
+
+	private static List<Map<String, Object>> getData(final String id) {
+		return inMemoryProfileService.read(Arrays.asList("id", "username", "linkedid", "password", "serializedprofile"), "id", id);
+	}
+}

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
  * Tests the {@link InMemoryProfileService}.
  *
  * @author Elie Roux
- * @since 2.0.0
+ * @since 2.1.0
  */
 public final class InMemoryProfileServiceTests implements TestsConstants {
 

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -24,107 +24,107 @@ import static org.junit.Assert.*;
  */
 public final class InMemoryProfileServiceTests implements TestsConstants {
 
-	private static final String TEST_ID = "testId";
-	private static final String TEST_LINKED_ID = "testLinkedId";
-	private static final String TEST_USER = "testUser";
-	private static final String TEST_USER2 = "testUser2";
-	private static final String TEST_PASS = "testPass";
-	private static final String TEST_PASS2 = "testPass2";
-	private static final String IDPERSON1 = "idperson1";
-	private static final String IDPERSON2 = "idperson2";
-	private static final String IDPERSON3 = "idperson3";
+    private static final String TEST_ID = "testId";
+    private static final String TEST_LINKED_ID = "testLinkedId";
+    private static final String TEST_USER = "testUser";
+    private static final String TEST_USER2 = "testUser2";
+    private static final String TEST_PASS = "testPass";
+    private static final String TEST_PASS2 = "testPass2";
+    private static final String IDPERSON1 = "idperson1";
+    private static final String IDPERSON2 = "idperson2";
+    private static final String IDPERSON3 = "idperson3";
 
-	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
-	public InMemoryProfileService<CommonProfile> inMemoryProfileService;
+    public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
+    public InMemoryProfileService<CommonProfile> inMemoryProfileService;
 
 
-	@Before
-	public void setUp() {
-		inMemoryProfileService = new InMemoryProfileService<CommonProfile>(x -> new CommonProfile());
-		inMemoryProfileService.setPasswordEncoder(PASSWORD_ENCODER);
-		final String password = PASSWORD_ENCODER.encode(PASSWORD);
-		// insert sample data
-		final Map<String, Object> properties1 = new HashMap<>();
-		properties1.put(USERNAME, GOOD_USERNAME);
-		properties1.put(FIRSTNAME, FIRSTNAME_VALUE);
-		CommonProfile profile = new CommonProfile();
-		profile.build(IDPERSON1, properties1);
-		inMemoryProfileService.create(profile, PASSWORD);
-		// second person, 
-		final Map<String, Object> properties2 = new HashMap<>();
-		properties2.put(USERNAME, MULTIPLE_USERNAME);
-		profile = new CommonProfile();
-		profile.build(IDPERSON2, properties2);
-		inMemoryProfileService.create(profile, PASSWORD);
-		final Map<String, Object> properties3 = new HashMap<>();
-		properties3.put(USERNAME, MULTIPLE_USERNAME);
-		properties3.put(PASSWORD, password);
-		profile = new CommonProfile();
-		profile.build(IDPERSON3, properties3);
-		inMemoryProfileService.create(profile, PASSWORD);
-	}
+    @Before
+    public void setUp() {
+        inMemoryProfileService = new InMemoryProfileService<CommonProfile>(x -> new CommonProfile());
+        inMemoryProfileService.setPasswordEncoder(PASSWORD_ENCODER);
+        final String password = PASSWORD_ENCODER.encode(PASSWORD);
+        // insert sample data
+        final Map<String, Object> properties1 = new HashMap<>();
+        properties1.put(USERNAME, GOOD_USERNAME);
+        properties1.put(FIRSTNAME, FIRSTNAME_VALUE);
+        CommonProfile profile = new CommonProfile();
+        profile.build(IDPERSON1, properties1);
+        inMemoryProfileService.create(profile, PASSWORD);
+        // second person, 
+        final Map<String, Object> properties2 = new HashMap<>();
+        properties2.put(USERNAME, MULTIPLE_USERNAME);
+        profile = new CommonProfile();
+        profile.build(IDPERSON2, properties2);
+        inMemoryProfileService.create(profile, PASSWORD);
+        final Map<String, Object> properties3 = new HashMap<>();
+        properties3.put(USERNAME, MULTIPLE_USERNAME);
+        properties3.put(PASSWORD, password);
+        profile = new CommonProfile();
+        profile.build(IDPERSON3, properties3);
+        inMemoryProfileService.create(profile, PASSWORD);
+    }
 
-	@Test(expected = AccountNotFoundException.class)
-	public void authentFailed() throws HttpAction, CredentialsException {
-		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
-		inMemoryProfileService.validate(credentials, null);
-	}
+    @Test(expected = AccountNotFoundException.class)
+    public void authentFailed() throws HttpAction, CredentialsException {
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(BAD_USERNAME, PASSWORD, CLIENT_NAME);
+        inMemoryProfileService.validate(credentials, null);
+    }
 
-	@Test
-	public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
-		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
-		inMemoryProfileService.validate(credentials, null);
-		final CommonProfile profile = credentials.getUserProfile();
-		assertNotNull(profile);
-		assertEquals(GOOD_USERNAME, profile.getUsername());
-		assertEquals(2, profile.getAttributes().size());
-		assertEquals(FIRSTNAME_VALUE, profile.getAttribute(FIRSTNAME));
-	}
+    @Test
+    public void authentSuccessSingleAttribute() throws HttpAction, CredentialsException {
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(GOOD_USERNAME, PASSWORD, CLIENT_NAME);
+        inMemoryProfileService.validate(credentials, null);
+        final CommonProfile profile = credentials.getUserProfile();
+        assertNotNull(profile);
+        assertEquals(GOOD_USERNAME, profile.getUsername());
+        assertEquals(2, profile.getAttributes().size());
+        assertEquals(FIRSTNAME_VALUE, profile.getAttribute(FIRSTNAME));
+    }
 
-	@Test
-	public void testCreateUpdateFindDelete() throws HttpAction, CredentialsException {
-		final CommonProfile profile = new CommonProfile();
-		profile.setId(TEST_ID);
-		profile.setLinkedId(TEST_LINKED_ID);
-		profile.addAttribute(USERNAME, TEST_USER);
-		// create
-		inMemoryProfileService.create(profile, TEST_PASS);
-		// check credentials
-		final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(TEST_USER, TEST_PASS, CLIENT_NAME);
-		inMemoryProfileService.validate(credentials, null);
-		final CommonProfile profile1 = credentials.getUserProfile();
-		assertNotNull(profile1);
-		// check data
-		final List<Map<String, Object>> results = getData(TEST_ID);
-		assertEquals(1, results.size());
-		final Map<String, Object> result = results.get(0);
-		assertEquals(5, result.size());
-		assertEquals(TEST_ID, result.get("id"));
-		assertEquals(TEST_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
-		assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
-		assertEquals(TEST_USER, result.get(USERNAME));
-		// findById
-		final CommonProfile profile2 = inMemoryProfileService.findById(TEST_ID);
-		assertEquals(TEST_ID, profile2.getId());
-		assertEquals(TEST_LINKED_ID, profile2.getLinkedId());
-		assertEquals(TEST_USER, profile2.getUsername());
-		assertEquals(1, profile2.getAttributes().size());
-		// update with password
-		profile.addAttribute(USERNAME, TEST_USER2);
-		inMemoryProfileService.update(profile, TEST_PASS2);
-		List<Map<String, Object>> results2 = getData(TEST_ID);
-		assertEquals(1, results2.size());
-		Map<String, Object> result2 = results2.get(0);
-		assertEquals(5, result2.size());
-		assertEquals(TEST_ID, result2.get("id"));
-		assertEquals(TEST_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
-		assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
-		assertEquals(TEST_USER2, result2.get(USERNAME));
-		// check credentials
-		final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(TEST_USER2, TEST_PASS2, CLIENT_NAME);
-		inMemoryProfileService.validate(credentials2, null);
-		final CommonProfile profile3 = credentials.getUserProfile();
-		assertNotNull(profile3);
+    @Test
+    public void testCreateUpdateFindDelete() throws HttpAction, CredentialsException {
+        final CommonProfile profile = new CommonProfile();
+        profile.setId(TEST_ID);
+        profile.setLinkedId(TEST_LINKED_ID);
+        profile.addAttribute(USERNAME, TEST_USER);
+        // create
+        inMemoryProfileService.create(profile, TEST_PASS);
+        // check credentials
+        final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(TEST_USER, TEST_PASS, CLIENT_NAME);
+        inMemoryProfileService.validate(credentials, null);
+        final CommonProfile profile1 = credentials.getUserProfile();
+        assertNotNull(profile1);
+        // check data
+        final List<Map<String, Object>> results = getData(TEST_ID);
+        assertEquals(1, results.size());
+        final Map<String, Object> result = results.get(0);
+        assertEquals(5, result.size());
+        assertEquals(TEST_ID, result.get("id"));
+        assertEquals(TEST_LINKED_ID, result.get(AbstractProfileService.LINKEDID));
+        assertNotNull(result.get(AbstractProfileService.SERIALIZED_PROFILE));
+        assertEquals(TEST_USER, result.get(USERNAME));
+        // findById
+        final CommonProfile profile2 = inMemoryProfileService.findById(TEST_ID);
+        assertEquals(TEST_ID, profile2.getId());
+        assertEquals(TEST_LINKED_ID, profile2.getLinkedId());
+        assertEquals(TEST_USER, profile2.getUsername());
+        assertEquals(1, profile2.getAttributes().size());
+        // update with password
+        profile.addAttribute(USERNAME, TEST_USER2);
+        inMemoryProfileService.update(profile, TEST_PASS2);
+        List<Map<String, Object>> results2 = getData(TEST_ID);
+        assertEquals(1, results2.size());
+        Map<String, Object> result2 = results2.get(0);
+        assertEquals(5, result2.size());
+        assertEquals(TEST_ID, result2.get("id"));
+        assertEquals(TEST_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
+        assertNotNull(result2.get(AbstractProfileService.SERIALIZED_PROFILE));
+        assertEquals(TEST_USER2, result2.get(USERNAME));
+        // check credentials
+        final UsernamePasswordCredentials credentials2 = new UsernamePasswordCredentials(TEST_USER2, TEST_PASS2, CLIENT_NAME);
+        inMemoryProfileService.validate(credentials2, null);
+        final CommonProfile profile3 = credentials.getUserProfile();
+        assertNotNull(profile3);
         // update with no password update
         inMemoryProfileService.update(profile, null);
         results2 = getData(TEST_ID);
@@ -136,13 +136,13 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
         inMemoryProfileService.validate(credentials2, null);
         final CommonProfile profile4 = credentials.getUserProfile();
         assertNotNull(profile4);
-		// remove
-		inMemoryProfileService.remove(profile);
-		final List<Map<String, Object>> results3 = getData(TEST_ID);
-		assertEquals(0, results3.size());
-	}
+        // remove
+        inMemoryProfileService.remove(profile);
+        final List<Map<String, Object>> results3 = getData(TEST_ID);
+        assertEquals(0, results3.size());
+    }
 
-	private List<Map<String, Object>> getData(final String id) {
-		return inMemoryProfileService.read(Arrays.asList("id", "username", "linkedid", "password", "serializedprofile"), "id", id);
-	}
+    private List<Map<String, Object>> getData(final String id) {
+        return inMemoryProfileService.read(Arrays.asList("id", "username", "linkedid", "password", "serializedprofile"), "id", id);
+    }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -35,7 +35,7 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
 	private static final String IDPERSON3 = "idperson3";
 
 	public final static PasswordEncoder PASSWORD_ENCODER = new ShiroPasswordEncoder(new DefaultPasswordService());
-	public final static InMemoryProfileService<CommonProfile> inMemoryProfileService = new InMemoryProfileService<CommonProfile>(CommonProfile.class);
+	public final static InMemoryProfileService<CommonProfile> inMemoryProfileService = new InMemoryProfileService<CommonProfile>(x -> new CommonProfile());
 	static {
 		inMemoryProfileService.setPasswordEncoder(PASSWORD_ENCODER);
 	}

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -109,12 +109,12 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
 		assertEquals(TEST_LINKED_ID, profile2.getLinkedId());
 		assertEquals(TEST_USER, profile2.getUsername());
 		assertEquals(1, profile2.getAttributes().size());
-		// update
+		// update with password
 		profile.addAttribute(USERNAME, TEST_USER2);
 		inMemoryProfileService.update(profile, TEST_PASS2);
-		final List<Map<String, Object>> results2 = getData(TEST_ID);
+		List<Map<String, Object>> results2 = getData(TEST_ID);
 		assertEquals(1, results2.size());
-		final Map<String, Object> result2 = results2.get(0);
+		Map<String, Object> result2 = results2.get(0);
 		assertEquals(5, result2.size());
 		assertEquals(TEST_ID, result2.get("id"));
 		assertEquals(TEST_LINKED_ID, result2.get(AbstractProfileService.LINKEDID));
@@ -125,6 +125,17 @@ public final class InMemoryProfileServiceTests implements TestsConstants {
 		inMemoryProfileService.validate(credentials2, null);
 		final CommonProfile profile3 = credentials.getUserProfile();
 		assertNotNull(profile3);
+        // update with no password update
+        inMemoryProfileService.update(profile, null);
+        results2 = getData(TEST_ID);
+        assertEquals(1, results2.size());
+        result2 = results2.get(0);
+        assertEquals(5, result2.size());
+        assertEquals(TEST_USER2, result2.get(USERNAME));
+        // check credentials
+        inMemoryProfileService.validate(credentials2, null);
+        final CommonProfile profile4 = credentials.getUserProfile();
+        assertNotNull(profile4);
 		// remove
 		inMemoryProfileService.remove(profile);
 		final List<Map<String, Object>> results3 = getData(TEST_ID);

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/service/InMemoryProfileServiceTests.java
@@ -4,7 +4,6 @@ import org.apache.shiro.authc.credential.DefaultPasswordService;
 import org.junit.*;
 import org.pac4j.core.exception.*;
 import org.pac4j.core.profile.CommonProfile;
-import org.pac4j.core.profile.service.AbstractProfileService;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.credentials.password.PasswordEncoder;


### PR DESCRIPTION
The `InMemoryProfileService.update()` function used to erroneously assume that all attributes were present during an update so it just replaced the previous profile entry with the asked one, overwriting attritutes that were not meant to be overwritten. This PR fixes this behavior and adds a test. I'll send a separate PR for CouchProfileService which is doing the same mistake.