### PR TITLE
Allow different timeouts per configuration instance, using HttpUtils as default

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuthConfiguration.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuthConfiguration.java
@@ -6,9 +6,9 @@ import com.github.scribejava.core.model.SignatureType;
 import com.github.scribejava.core.model.Token;
 import com.github.scribejava.core.oauth.OAuthService;
 import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.util.CommonHelper;
-import org.pac4j.core.util.HttpUtils;
 import org.pac4j.core.util.InitializableWebObject;
 import org.pac4j.oauth.profile.definition.OAuthProfileDefinition;
 
@@ -48,6 +48,10 @@ public class OAuthConfiguration<C extends IndirectClient, S extends OAuthService
 
     protected S service;
 
+    private int connectTimeout = HttpConstants.DEFAULT_CONNECT_TIMEOUT;
+
+    private int readTimeout = HttpConstants.DEFAULT_READ_TIMEOUT;
+
     @Override
     protected void internalInit(final WebContext context) {
         CommonHelper.assertNotNull("client", this.client);
@@ -76,7 +80,7 @@ public class OAuthConfiguration<C extends IndirectClient, S extends OAuthService
         final String finalCallbackUrl = this.client.getUrlResolver().compute(this.client.getCallbackUrl(), context);
 
         return new OAuthConfig(this.key, this.secret, finalCallbackUrl, SignatureType.Header, this.scope,
-                null, state, this.responseType, null, HttpUtils.getConnectTimeout(), HttpUtils.getReadTimeout(),
+                null, state, this.responseType, null, this.connectTimeout, this.readTimeout,
                 null, null);
     }
 
@@ -116,24 +120,20 @@ public class OAuthConfiguration<C extends IndirectClient, S extends OAuthService
         this.tokenAsHeader = tokenAsHeader;
     }
 
-    @Deprecated
     public int getConnectTimeout() {
-        return HttpUtils.getConnectTimeout();
+        return connectTimeout;
     }
 
-    @Deprecated
     public void setConnectTimeout(final int connectTimeout) {
-        HttpUtils.setConnectTimeout(connectTimeout);
+        this.connectTimeout = connectTimeout;
     }
 
-    @Deprecated
     public int getReadTimeout() {
-        return HttpUtils.getReadTimeout();
+        return readTimeout;
     }
 
-    @Deprecated
     public void setReadTimeout(final int readTimeout) {
-        HttpUtils.setReadTimeout(readTimeout);
+        this.readTimeout = readTimeout;
     }
 
     public String getResponseType() {
@@ -187,7 +187,7 @@ public class OAuthConfiguration<C extends IndirectClient, S extends OAuthService
     @Override
     public String toString() {
         return CommonHelper.toString(this.getClass(), "key", key, "secret", "[protected]", "tokenAsHeader", tokenAsHeader,
-                "connectTimeout", HttpUtils.getConnectTimeout(), "readTimeout", HttpUtils.getReadTimeout(), "responseType", responseType,
+                "connectTimeout", connectTimeout, "readTimeout", readTimeout, "responseType", responseType,
                 "scope", scope, "api", api, "hasGrantType", hasGrantType, "service", service,
                 "hasBeenCancelledFactory", hasBeenCancelledFactory, "profileDefinition", profileDefinition);
     }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -6,10 +6,11 @@ import com.nimbusds.jose.util.ResourceRetriever;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.*;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+
+import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.util.CommonHelper;
-import org.pac4j.core.util.HttpUtils;
 import org.pac4j.core.util.InitializableWebObject;
 
 import java.io.IOException;
@@ -80,6 +81,10 @@ public class OidcConfiguration extends InitializableWebObject {
     private String responseMode;
 
     private String logoutUrl;
+
+    private int connectTimeout = HttpConstants.DEFAULT_CONNECT_TIMEOUT;
+
+    private int readTimeout = HttpConstants.DEFAULT_READ_TIMEOUT;
 
     @Override
     protected void internalInit(final WebContext context) {
@@ -201,24 +206,20 @@ public class OidcConfiguration extends InitializableWebObject {
         this.maxClockSkew = maxClockSkew;
     }
 
-    @Deprecated
     public int getConnectTimeout() {
-        return HttpUtils.getConnectTimeout();
+        return connectTimeout;
     }
 
-    @Deprecated
     public void setConnectTimeout(final int connectTimeout) {
-        HttpUtils.setConnectTimeout(connectTimeout);
+        this.connectTimeout = connectTimeout;
     }
 
-    @Deprecated
     public int getReadTimeout() {
-        return HttpUtils.getReadTimeout();
+        return readTimeout;
     }
 
-    @Deprecated
     public void setReadTimeout(final int readTimeout) {
-        HttpUtils.setReadTimeout(readTimeout);
+        this.readTimeout = readTimeout;
     }
 
     public ResourceRetriever getResourceRetriever() {
@@ -279,7 +280,7 @@ public class OidcConfiguration extends InitializableWebObject {
         return CommonHelper.toString(this.getClass(), "clientId", clientId, "secret", "[protected]", "discoveryURI", discoveryURI, 
                 "scope", scope, "customParams", customParams, "clientAuthenticationMethod", clientAuthenticationMethod, 
                 "useNonce", useNonce, "preferredJwsAlgorithm", preferredJwsAlgorithm, "maxClockSkew", maxClockSkew, 
-                "connectTimeout", HttpUtils.getConnectTimeout(), "readTimeout", HttpUtils.getReadTimeout(), 
+                "connectTimeout", connectTimeout, "readTimeout", readTimeout, 
                 "resourceRetriever", resourceRetriever, "callbackUrl", callbackUrl, "responseType", responseType, 
                 "responseMode", responseMode, "logoutUrl", logoutUrl);
     }


### PR DESCRIPTION
This PR restores the read and connect timeout settings in OAuthConfiguration and OidcConfiguration. HttpUtils now serves as default.