### PR TITLE
Use Dropbox V2 API because Dropbox has retired V1

### DIFF
--- a/pac4j-oauth/pom.xml
+++ b/pac4j-oauth/pom.xml
@@ -9,6 +9,7 @@
     </parent>
 
     <artifactId>pac4j-oauth</artifactId>
+    <version>2.1.0-USING-DROPBOX-API-V2</version>
     <packaging>jar</packaging>
     <name>pac4j for OAuth protocol</name>
 
@@ -20,6 +21,7 @@
         <dependency>
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-core</artifactId>
+            <version>2.1.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -43,6 +45,7 @@
         <dependency>
             <groupId>org.pac4j</groupId>
             <artifactId>pac4j-core</artifactId>
+            <version>2.1.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
@@ -2,23 +2,25 @@ package org.pac4j.oauth.client;
 
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.redirect.RedirectAction;
-import org.pac4j.oauth.profile.dropbox.DropBoxProfileDefinition;
 import org.pac4j.oauth.profile.dropbox.DropBoxProfile;
+import org.pac4j.oauth.profile.dropbox.DropBoxProfileCreator;
+import org.pac4j.oauth.profile.dropbox.DropBoxProfileDefinition;
 import org.pac4j.scribe.builder.api.DropboxApi20;
 
 /**
  * <p>This class is the OAuth client to authenticate users in DropBox.</p>
  * <p>It returns a {@link org.pac4j.oauth.profile.dropbox.DropBoxProfile}.</p>
  * <p>More information at https://www.dropbox.com/developers/reference/api#account-info</p>
- * 
+ *
  * @author Jerome Leleu
+ * @author Matthias Bohlen
  * @since 1.2.0
  */
 public class DropBoxClient extends OAuth20Client<DropBoxProfile> {
-    
+
     public DropBoxClient() {
     }
-    
+
     public DropBoxClient(final String key, final String secret) {
         setKey(key);
         setSecret(secret);
@@ -29,9 +31,10 @@ public class DropBoxClient extends OAuth20Client<DropBoxProfile> {
         configuration.setApi(DropboxApi20.INSTANCE);
         configuration.setProfileDefinition(new DropBoxProfileDefinition());
         configuration.setHasGrantType(true);
+        configuration.setTokenAsHeader(true);
         setConfiguration(configuration);
         defaultLogoutActionBuilder((ctx, profile, targetUrl) -> RedirectAction.redirect("https://www.dropbox.com/logout"));
-
+        defaultProfileCreator(new DropBoxProfileCreator(configuration));
         super.clientInit(context);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfile.java
@@ -13,29 +13,17 @@ import org.pac4j.oauth.profile.OAuth10Profile;
  * @since 1.2.0
  */
 public class DropBoxProfile extends OAuth10Profile {
-    
+
     private static final long serialVersionUID = 6671295443243112368L;
 
     @Override
     public Locale getLocale() {
         return (Locale) getAttribute(DropBoxProfileDefinition.COUNTRY);
     }
-    
+
     @Override
     public URI getProfileUrl() {
         return (URI) getAttribute(DropBoxProfileDefinition.REFERRAL_LINK);
-    }
-    
-    public Long getNormal() {
-        return (Long) getAttribute(DropBoxProfileDefinition.NORMAL);
-    }
-    
-    public Long getQuota() {
-        return (Long) getAttribute(DropBoxProfileDefinition.QUOTA);
-    }
-    
-    public Long getShared() {
-        return (Long) getAttribute(DropBoxProfileDefinition.SHARED);
     }
 
     public Boolean getEmailVerified() {

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileCreator.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileCreator.java
@@ -1,0 +1,31 @@
+package org.pac4j.oauth.profile.dropbox;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Verb;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.oauth.config.OAuth20Configuration;
+import org.pac4j.oauth.profile.creator.OAuth20ProfileCreator;
+
+public class DropBoxProfileCreator extends OAuth20ProfileCreator<DropBoxProfile> {
+
+    public DropBoxProfileCreator(OAuth20Configuration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    protected void signRequest(final OAuth2AccessToken accessToken, final OAuthRequest request) {
+        request.addHeader(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.BEARER_HEADER_PREFIX + accessToken.getAccessToken());
+    }
+
+    @Override
+    protected OAuthRequest createOAuthRequest(final String url, final Verb verb) {
+        return new OAuthRequest(verb, url, this.configuration.getService()) {
+            @Override
+            protected boolean hasBodyContent() {
+                return false;
+            }
+        };
+    }
+
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileDefinition.java
@@ -2,6 +2,7 @@ package org.pac4j.oauth.profile.dropbox;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.Verb;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.oauth.config.OAuth20Configuration;
@@ -10,17 +11,14 @@ import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
 /**
  * This class is the DropBox profile definition.
- * 
+ *
  * @author Jerome Leleu
  * @since 1.2.0
  */
 public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxProfile> {
-    
+
     public static final String REFERRAL_LINK = "referral_link";
     public static final String COUNTRY = "country";
-    public static final String SHARED = "shared";
-    public static final String QUOTA = "quota";
-    public static final String NORMAL = "normal";
     public static final String EMAIL_VERIFIED = "email_verified";
 
     public DropBoxProfileDefinition() {
@@ -28,15 +26,18 @@ public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxPr
         primary(REFERRAL_LINK, Converters.STRING);
         primary(COUNTRY, Converters.LOCALE);
         primary(REFERRAL_LINK, Converters.URL);
+        primary(EMAIL, Converters.STRING);
         primary(EMAIL_VERIFIED, Converters.BOOLEAN);
-        secondary(SHARED, Converters.LONG);
-        secondary(QUOTA, Converters.LONG);
-        secondary(NORMAL, Converters.LONG);
     }
 
     @Override
     public String getProfileUrl(final OAuth2AccessToken token, final OAuth20Configuration configuration) {
-        return "https://api.dropbox.com/1/account/info";
+        return "https://api.dropboxapi.com/2/users/get_current_account";
+    }
+
+    @Override
+    public Verb getProfileVerb() {
+        return Verb.POST;
     }
 
     @Override
@@ -44,15 +45,15 @@ public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxPr
         final DropBoxProfile profile = newProfile();
         JsonNode json = JsonHelper.getFirstNode(body);
         if (json != null) {
-            profile.setId(JsonHelper.getElement(json, "uid"));
+            profile.setId(JsonHelper.getElement(json, "account_id"));
             for (final String attribute : getPrimaryAttributes()) {
                 convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
             }
-            json = (JsonNode) JsonHelper.getElement(json, "quota_info");
+            json = (JsonNode) JsonHelper.getElement(json, "name");
             if (json != null) {
-                for (final String attribute : getSecondaryAttributes()) {
-                    convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
-                }
+                convertAndAdd(profile, FIRST_NAME, JsonHelper.getElement(json, "familiar_name"));
+                convertAndAdd(profile, FAMILY_NAME, JsonHelper.getElement(json, "surname"));
+                convertAndAdd(profile, DISPLAY_NAME, JsonHelper.getElement(json, "display_name"));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/DropboxApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/DropboxApi20.java
@@ -16,8 +16,8 @@ public class DropboxApi20 extends DefaultApi20 {
 
     public final static DropboxApi20 INSTANCE  = new DropboxApi20();
 
-    private static final String AUTH_URL = "https://www.dropbox.com/1/oauth2/authorize";
-    private static final String TOKEN_URL = "https://www.dropbox.com/1/oauth2/token";
+    private static final String AUTH_URL = "https://www.dropbox.com/oauth2/authorize";
+    private static final String TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
 
     @Override
     public String getAccessTokenEndpoint() {
@@ -31,8 +31,8 @@ public class DropboxApi20 extends DefaultApi20 {
     @Override
     protected String getAuthorizationBaseUrl() {
         return AUTH_URL;
-    }  
-    
+    }
+
     @Override
     public Verb getAccessTokenVerb() {
         return Verb.POST;

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunDropboxClient.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunDropboxClient.java
@@ -53,9 +53,6 @@ public final class RunDropboxClient extends RunClient {
         assertTrue(CommonHelper.isNotBlank(profile.getAccessToken()));
         assertCommonProfile(userProfile, getLogin(), null, null, "Test ScribeUP", null, Gender.UNSPECIFIED, Locale.FRENCH,
                 null, "https://db.tt/T0YkdWpF", null);
-        assertEquals(0L, profile.getShared().longValue());
-        assertEquals(1410412L, profile.getNormal().longValue());
-        assertEquals(2147483648L, profile.getQuota().longValue());
         assertEquals(true, profile.getEmailVerified());
         assertEquals(10, profile.getAttributes().size());
     }


### PR DESCRIPTION
Dropbox API V1 stopped working in September 2017 (it has been deprecated for a year now), and pac4j was still using it. So, OAuth with Dropbox did not work anymore.

I wrote some code to use Dropbox API V2 so that OAuth with Dropbox will work again!

Could you please merge it into master and release a new version? Would be cool.

Best wishes...
Matthias