### PR TITLE
DropBoxClient based on DropBox API V2, without conflicts on master branch

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
@@ -1,8 +1,9 @@
 package org.pac4j.oauth.client;
 
 import org.pac4j.core.redirect.RedirectAction;
-import org.pac4j.oauth.profile.dropbox.DropBoxProfileDefinition;
 import org.pac4j.oauth.profile.dropbox.DropBoxProfile;
+import org.pac4j.oauth.profile.dropbox.DropBoxProfileCreator;
+import org.pac4j.oauth.profile.dropbox.DropBoxProfileDefinition;
 import org.pac4j.scribe.builder.api.DropboxApi20;
 
 /**
@@ -11,6 +12,7 @@ import org.pac4j.scribe.builder.api.DropboxApi20;
  * <p>More information at https://www.dropbox.com/developers/reference/api#account-info</p>
  *
  * @author Jerome Leleu
+ * @author Matthias Bohlen
  * @since 1.2.0
  */
 public class DropBoxClient extends OAuth20Client<DropBoxProfile> {
@@ -27,7 +29,10 @@ public class DropBoxClient extends OAuth20Client<DropBoxProfile> {
     protected void clientInit() {
         configuration.setApi(DropboxApi20.INSTANCE);
         configuration.setProfileDefinition(new DropBoxProfileDefinition());
+        configuration.setTokenAsHeader(true);
+
         defaultLogoutActionBuilder((ctx, profile, targetUrl) -> RedirectAction.redirect("https://www.dropbox.com/logout"));
+        defaultProfileCreator(new DropBoxProfileCreator(configuration, this));
 
         super.clientInit();
     }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfile.java
@@ -13,29 +13,17 @@ import org.pac4j.oauth.profile.OAuth10Profile;
  * @since 1.2.0
  */
 public class DropBoxProfile extends OAuth10Profile {
-    
+
     private static final long serialVersionUID = 6671295443243112368L;
 
     @Override
     public Locale getLocale() {
         return (Locale) getAttribute(DropBoxProfileDefinition.COUNTRY);
     }
-    
+
     @Override
     public URI getProfileUrl() {
         return (URI) getAttribute(DropBoxProfileDefinition.REFERRAL_LINK);
-    }
-    
-    public Long getNormal() {
-        return (Long) getAttribute(DropBoxProfileDefinition.NORMAL);
-    }
-    
-    public Long getQuota() {
-        return (Long) getAttribute(DropBoxProfileDefinition.QUOTA);
-    }
-    
-    public Long getShared() {
-        return (Long) getAttribute(DropBoxProfileDefinition.SHARED);
     }
 
     public Boolean getEmailVerified() {

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileCreator.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileCreator.java
@@ -1,0 +1,22 @@
+package org.pac4j.oauth.profile.dropbox;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.oauth.OAuthService;
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.oauth.config.OAuth20Configuration;
+import org.pac4j.oauth.profile.creator.OAuth20ProfileCreator;
+
+public class DropBoxProfileCreator extends OAuth20ProfileCreator<DropBoxProfile> {
+
+    public DropBoxProfileCreator(OAuth20Configuration configuration, IndirectClient client) {
+        super(configuration, client);
+    }
+
+    @Override
+    protected void signRequest(OAuthService<OAuth2AccessToken> service, OAuth2AccessToken accessToken, OAuthRequest request) {
+        request.addHeader(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.BEARER_HEADER_PREFIX + accessToken.getAccessToken());
+    }
+
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileDefinition.java
@@ -2,6 +2,7 @@ package org.pac4j.oauth.profile.dropbox;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.Verb;
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.oauth.config.OAuth20Configuration;
@@ -18,9 +19,6 @@ public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxPr
 
     public static final String REFERRAL_LINK = "referral_link";
     public static final String COUNTRY = "country";
-    public static final String SHARED = "shared";
-    public static final String QUOTA = "quota";
-    public static final String NORMAL = "normal";
     public static final String EMAIL_VERIFIED = "email_verified";
 
     public DropBoxProfileDefinition() {
@@ -28,15 +26,18 @@ public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxPr
         primary(REFERRAL_LINK, Converters.STRING);
         primary(COUNTRY, Converters.LOCALE);
         primary(REFERRAL_LINK, Converters.URL);
+        primary(EMAIL, Converters.STRING);
         primary(EMAIL_VERIFIED, Converters.BOOLEAN);
-        secondary(SHARED, Converters.LONG);
-        secondary(QUOTA, Converters.LONG);
-        secondary(NORMAL, Converters.LONG);
     }
 
     @Override
     public String getProfileUrl(final OAuth2AccessToken token, final OAuth20Configuration configuration) {
-        return "https://api.dropbox.com/1/account/info";
+        return "https://api.dropboxapi.com/2/users/get_current_account";
+    }
+
+    @Override
+    public Verb getProfileVerb() {
+        return Verb.POST;
     }
 
     @Override
@@ -44,15 +45,15 @@ public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxPr
         final DropBoxProfile profile = newProfile();
         JsonNode json = JsonHelper.getFirstNode(body);
         if (json != null) {
-            profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "uid")));
+            profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "account_id")));
             for (final String attribute : getPrimaryAttributes()) {
                 convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
             }
-            json = (JsonNode) JsonHelper.getElement(json, "quota_info");
+            json = (JsonNode) JsonHelper.getElement(json, "name");
             if (json != null) {
-                for (final String attribute : getSecondaryAttributes()) {
-                    convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
-                }
+                convertAndAdd(profile, FIRST_NAME, JsonHelper.getElement(json, "familiar_name"));
+                convertAndAdd(profile, FAMILY_NAME, JsonHelper.getElement(json, "surname"));
+                convertAndAdd(profile, DISPLAY_NAME, JsonHelper.getElement(json, "display_name"));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/DropboxApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/DropboxApi20.java
@@ -13,8 +13,8 @@ public class DropboxApi20 extends DefaultApi20 {
 
     public final static DropboxApi20 INSTANCE  = new DropboxApi20();
 
-    private static final String AUTH_URL = "https://www.dropbox.com/1/oauth2/authorize";
-    private static final String TOKEN_URL = "https://www.dropbox.com/1/oauth2/token";
+    private static final String AUTH_URL = "https://www.dropbox.com/oauth2/authorize";
+    private static final String TOKEN_URL = "https://api.dropboxapi.com/oauth2/token";
 
     @Override
     public String getAccessTokenEndpoint() {

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunDropboxClient.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunDropboxClient.java
@@ -53,9 +53,6 @@ public final class RunDropboxClient extends RunClient {
         assertTrue(CommonHelper.isNotBlank(profile.getAccessToken()));
         assertCommonProfile(userProfile, getLogin(), null, null, "Test ScribeUP", null, Gender.UNSPECIFIED, Locale.FRENCH,
                 null, "https://db.tt/T0YkdWpF", null);
-        assertEquals(0L, profile.getShared().longValue());
-        assertEquals(1410412L, profile.getNormal().longValue());
-        assertEquals(2147483648L, profile.getQuota().longValue());
         assertEquals(true, profile.getEmailVerified());
         assertEquals(10, profile.getAttributes().size());
     }


### PR DESCRIPTION
See https://github.com/pac4j/pac4j/pull/1009

Hi Jérôme,

I have resolved the two conflicts that I had with the master branch. They occurred because I created my patch based on V2.1.x instead of master

HOWEVER: Now, I get a NullPointerException when I run the code!

java.lang.NullPointerException
	at org.pac4j.core.client.IndirectClient.getRedirectAction(IndirectClient.java:95) ~[pac4j-core-3.0.0-SNAPSHOT.jar:?]
	at org.pac4j.core.client.IndirectClient.redirect(IndirectClient.java:68) ~[pac4j-core-3.0.0-SNAPSHOT.jar:?]
	at ratpack.pac4j.RatpackPac4j.lambda$initiateAuthentication$13(RatpackPac4j.java:518) ~[ratpack-pac4j-2.0.0.jar:?]

The source line looks like this:
final String attemptedAuth = (String) context.getSessionStore().get(context, getName() + ATTEMPTED_AUTHENTICATION_SUFFIX);

As far as I can see, the result of context.getSessionStore() is null.

Alas, I do not know Pac4j well enough to solve that problem! Could you please find out why the code in pull request #1009 works inside the V2.1.0 enivronment but this code here does not work in 3.0.0-SNAPSHOT?

Thanks...
Matthias
