### PR TITLE
SAML2 Single Logout - More info in logout requests for MS ADFS [branch 2.2.x]

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.credentials.authenticator;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Conditions;
+import org.opensaml.saml.saml2.core.NameID;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.exception.CredentialsException;
@@ -32,6 +33,10 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
     public static final String SESSION_INDEX = "sessionindex";
     public static final String ISSUER_ID = "issuerId";
     public static final String AUTHN_CONTEXT = "authnContext";
+    public static final String SAML_NAME_ID_FORMAT = "samlNameIdFormat";
+    public static final String SAML_NAME_ID_NAME_QUALIFIER = "samlNameIdNameQualifier";
+    public static final String SAML_NAME_ID_SP_NAME_QUALIFIER = "samlNameIdSpNameQualifier";
+    public static final String SAML_NAME_ID_SP_PROVIDED_ID = "samlNameIdSpProvidedId";
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -44,9 +49,14 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
         init(context);
 
         final SAML2Profile profile = getProfileDefinition().newProfile();
-        profile.setId(credentials.getNameId().getValue());
+        final NameID nameId = credentials.getNameId();
+        profile.setId(nameId.getValue());
         profile.addAttribute(SESSION_INDEX, credentials.getSessionIndex());
-        
+        profile.addAuthenticationAttribute(SAML_NAME_ID_FORMAT, nameId.getFormat());
+        profile.addAuthenticationAttribute(SAML_NAME_ID_NAME_QUALIFIER, nameId.getNameQualifier());
+        profile.addAuthenticationAttribute(SAML_NAME_ID_SP_NAME_QUALIFIER, nameId.getSPNameQualifier());
+        profile.addAuthenticationAttribute(SAML_NAME_ID_SP_PROVIDED_ID, nameId.getSPProvidedID());
+
         for (final Attribute attribute : credentials.getAttributes()) {
             logger.debug("Processing profile attribute {}", attribute);
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java
@@ -39,4 +39,21 @@ public class SAML2Profile extends CommonProfile {
     public List<String> getAuthnContexts() {
         return (List<String>) getAuthenticationAttribute(SAML2Authenticator.AUTHN_CONTEXT);
     }
+
+    public String getSamlNameIdFormat() {
+        return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_FORMAT);
+    }
+
+    public String getSamlNameIdNameQualifier() {
+        return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_NAME_QUALIFIER);
+    }
+
+    public String getSamlNameIdSpNameQualifier() {
+        return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_SP_NAME_QUALIFIER);
+    }
+
+    public String getSamlNameIdSpProviderId() {
+        return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_SP_PROVIDED_ID);
+    }
+
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2LogoutRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2LogoutRequestBuilder.java
@@ -80,6 +80,10 @@ public class SAML2LogoutRequestBuilder implements SAML2ObjectBuilder<LogoutReque
                 .getBuilder(NameID.DEFAULT_ELEMENT_NAME);
             final NameID nameId = nameIdBuilder.buildObject();
             nameId.setValue(samlP.getId());
+            nameId.setFormat(samlP.getSamlNameIdFormat());
+            nameId.setNameQualifier(samlP.getSamlNameIdNameQualifier());
+            nameId.setSPNameQualifier(samlP.getSamlNameIdSpNameQualifier());
+            nameId.setSPProvidedID(samlP.getSamlNameIdSpProviderId());
             request.setNameID(nameId);
             // session index added
             final String sessIdx = (String) samlP.getAttribute("sessionindex");


### PR DESCRIPTION
MS ADFS requires all NameID attributes to match when it receives a SAML Single Logout request.
This pull request adds 4 attributes of NameID to the SAML2 profile; SAML2 single logout request will also have them set.

Please see the related discussion here: https://groups.google.com/forum/#!topic/pac4j-users/5wSbJIW-R1Q
