### PR TITLE
Improve security logic

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
@@ -20,7 +20,7 @@ import org.pac4j.core.matching.MatchingChecker;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.ProfileManager;
 
-import java.util.List;
+import java.util.*;
 
 import static org.pac4j.core.util.CommonHelper.*;
 
@@ -131,7 +131,7 @@ public class DefaultSecurityLogic<R, C extends WebContext> extends AbstractExcep
                     logger.debug("authorizers: {}", authorizers);
                     if (authorizationChecker.isAuthorized(context, profiles, authorizers, config.getAuthorizers())) {
                         logger.debug("authenticated and authorized -> grant access");
-                        return securityGrantedAccessAdapter.adapt(context, parameters);
+                        return securityGrantedAccessAdapter.adapt(context, profiles, parameters);
                     } else {
                         logger.debug("forbidden");
                         action = forbidden(context, currentClients, profiles, authorizers);
@@ -150,7 +150,7 @@ public class DefaultSecurityLogic<R, C extends WebContext> extends AbstractExcep
             } else {
 
                 logger.debug("no matching for this request -> grant access");
-                return securityGrantedAccessAdapter.adapt(context, parameters);
+                return securityGrantedAccessAdapter.adapt(context, Arrays.asList(), parameters);
             }
 
         } catch (final Exception e) {

--- a/pac4j-core/src/main/java/org/pac4j/core/engine/SecurityGrantedAccessAdapter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/SecurityGrantedAccessAdapter.java
@@ -1,6 +1,9 @@
 package org.pac4j.core.engine;
 
+import java.util.Collection;
+
 import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.CommonProfile;
 
 /**
  * Success adapter.
@@ -15,8 +18,9 @@ public interface SecurityGrantedAccessAdapter<R, C extends WebContext> {
      *
      * @param context the web context
      * @param parameters additional parameters
+     * @param profiles the profiles granted, can be empty
      * @return an adapted result
      * @throws Exception any exception
      */
-    R adapt(C context, Object... parameters) throws Exception;
+    R adapt(C context, Collection<CommonProfile> profiles, Object... parameters) throws Exception;
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -122,41 +122,25 @@ public final class ProfileHelper {
     }
 
     /**
-     * Flat the linked hashmap of profiles into a single optional profile.
+     * Flat the list of profiles into a single optional profile.
      *
-     * @param profiles the linked hashmap of profiles
+     * @param profiles the list of profiles
      * @param <U> the kind of profile
      * @return the (optional) profile
      */
-    public static <U extends CommonProfile> Optional<U> flatIntoOneProfile(final LinkedHashMap<String, U> profiles) {
-        if (profiles.size() == 0) {
-            return Optional.empty();
-        } else {
-            U profile = null;
-            final Iterator<U> profilesList = profiles.values().iterator();
-            while (profilesList.hasNext()) {
-                final U nextProfile = profilesList.next();
-                if (profile == null || profile instanceof AnonymousProfile) {
-                    profile = nextProfile;
-                }
-            }
-            return Optional.of(profile);
-        }
+    public static <U extends CommonProfile> Optional<U> flatIntoOneProfile(final Collection<U> profiles) {
+        return profiles.stream().filter(p -> p != null && !(p instanceof AnonymousProfile)).findFirst();
     }
 
     /**
-     * Flat the linked hashmap of profiles into a list of profiles.
+     * Flat the map of profiles into a list of profiles.
      *
-     * @param profiles the linked hashmap of profiles
+     * @param profiles the map of profiles
      * @param <U> the kind of profile
      * @return the list of profiles
      */
-    public static <U extends CommonProfile> List<U> flatIntoAProfileList(final LinkedHashMap<String, U> profiles) {
-        final List<U> listProfiles = new ArrayList<>();
-        for (final Map.Entry<String, U> entry : profiles.entrySet()) {
-            listProfiles.add(entry.getValue());
-        }
-        return Collections.unmodifiableList(listProfiles);
+    public static <U extends CommonProfile> List<U> flatIntoAProfileList(final Map<String, U> profiles) {
+        return Collections.unmodifiableList(new ArrayList<>(profiles.values()));
     }
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
@@ -46,7 +46,7 @@ public class ProfileManager<U extends CommonProfile> {
      */
     public Optional<U> get(final boolean readFromSession) {
         final LinkedHashMap<String, U> allProfiles = retrieveAll(readFromSession);
-        return ProfileHelper.flatIntoOneProfile(allProfiles);
+        return ProfileHelper.flatIntoOneProfile(allProfiles.values());
     }
 
     /**

--- a/pac4j-core/src/test/java/org/pac4j/core/engine/DefaultSecurityLogicTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/engine/DefaultSecurityLogicTests.java
@@ -53,7 +53,7 @@ public final class DefaultSecurityLogicTests implements TestsConstants {
         logic = new DefaultSecurityLogic();
         context = MockWebContext.create();
         config = new Config();
-        securityGrantedAccessAdapter = (context, parameters) -> { nbCall++; return null; };
+        securityGrantedAccessAdapter = (context, profiles, parameters) -> { nbCall++; return null; };
         httpActionAdapter = (code, ctx) -> null;
         clients = null;
         authorizers = null;


### PR DESCRIPTION
This depends on #1027.

It is needed to implement pac4j/j2e-pac4j#44 and I think it makes sense to give this information here since it's complex to retrieve it from the `WebContext` itself (because from the `WebContext`, you need to know if session as used or not and stuffs like this that only the `SecurityLogic` knows!).

I know I will exploit this also in jax-rs-pac4j for example.

This maybe highlights a problem with the current architecture too and this solution is maybe over simplistic for the problem of retrieving the profiles of a request...