### PR TITLE
 Support HTTP-Redirect binding responses

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -88,7 +88,7 @@ public class SAML2ClientConfiguration extends InitializableObject {
     private List<String> signatureAlgorithms;
     private List<String> signatureReferenceDigestMethods;
     private String signatureCanonicalizationAlgorithm;
-    private boolean wantsAssertionsSigned = true;
+    private boolean wantsAssertionsSigned = false; // See section 2.4.4 of Metadata for the OASIS Security Assertion Markup Language (SAML) V2.0
 
     private String keyStoreAlias;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
@@ -11,7 +11,7 @@ import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.sso.SAML2MessageReceiver;
 import org.pac4j.saml.sso.SAML2ResponseValidator;
-import org.pac4j.saml.transport.Pac4jHTTPPostDecoder;
+import org.pac4j.saml.transport.Pac4jHTTPDecoder;
 import org.pac4j.saml.util.Configuration;
 
 /**
@@ -33,7 +33,7 @@ public class SAML2WebSSOMessageReceiver implements SAML2MessageReceiver {
 
         peerContext.setRole(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         context.getSAMLSelfProtocolContext().setProtocol(SAMLConstants.SAML20P_NS);
-        final Pac4jHTTPPostDecoder decoder = new Pac4jHTTPPostDecoder(context.getWebContext());
+        final Pac4jHTTPDecoder decoder = new Pac4jHTTPDecoder(context.getWebContext());
         try {
             decoder.setParserPool(Configuration.getParserPool());
             decoder.initialize();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPDecoder.java
@@ -3,9 +3,6 @@ package org.pac4j.saml.transport;
 import com.google.common.base.Strings;
 import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 import net.shibboleth.utilities.java.support.codec.Base64Support;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.logic.Constraint;
@@ -149,16 +146,11 @@ public class Pac4jHTTPDecoder extends AbstractMessageDecoder<SAMLObject> {
     protected XMLObject unmarshallMessage(InputStream messageStream) throws MessageDecodingException {
         try {
             XMLObject message = XMLObjectSupport.unmarshallFromInputStream(getParserPool(), messageStream);
-            TransformerFactory.newInstance().newTransformer().
-                transform(new DOMSource(message.getDOM()), new StreamResult(System.out));
-
             return message;
         } catch (XMLParserException e) {
             throw new MessageDecodingException("Error unmarshalling message from input stream", e);
         } catch (UnmarshallingException e) {
             throw new MessageDecodingException("Error unmarshalling message from input stream", e);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPDecoder.java
@@ -1,6 +1,11 @@
 package org.pac4j.saml.transport;
 
 import com.google.common.base.Strings;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import net.shibboleth.utilities.java.support.codec.Base64Support;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.logic.Constraint;
@@ -34,15 +39,15 @@ import java.io.UnsupportedEncodingException;
  * @author Misagh Moayyed
  * @since 1.8
  */
-public class Pac4jHTTPPostDecoder extends AbstractMessageDecoder<SAMLObject> {
-    private final static Logger logger = LoggerFactory.getLogger(Pac4jHTTPPostDecoder.class);
+public class Pac4jHTTPDecoder extends AbstractMessageDecoder<SAMLObject> {
+    private final static Logger logger = LoggerFactory.getLogger(Pac4jHTTPDecoder.class);
 
     /** Parser pool used to deserialize the message. */
     private ParserPool parserPool;
 
     private final WebContext context;
 
-    public Pac4jHTTPPostDecoder(final WebContext context) {
+    public Pac4jHTTPDecoder(final WebContext context) {
         this.context = context;
         if (this.context == null) {
             throw new TechnicalException("Context cannot be null");
@@ -52,20 +57,23 @@ public class Pac4jHTTPPostDecoder extends AbstractMessageDecoder<SAMLObject> {
     @Override
     protected void doDecode() throws MessageDecodingException {
         final MessageContext messageContext = new MessageContext();
-
-        if(!HttpConstants.HTTP_METHOD.POST.name().equalsIgnoreCase(this.context.getRequestMethod())) {
-            throw new MessageDecodingException("This message decoder only supports the HTTP POST method");
-        } else {
-            final String relayState = this.context.getRequestParameter("RelayState");
-            logger.debug("Decoded SAML relay state of: {}", relayState);
-            SAMLBindingSupport.setRelayState(messageContext, relayState);
-            final InputStream base64DecodedMessage = this.getBase64DecodedMessage();
-            final SAMLObject inboundMessage = (SAMLObject)this.unmarshallMessage(base64DecodedMessage);
-            messageContext.setMessage(inboundMessage);
-            logger.debug("Decoded SAML message");
-            this.populateBindingContext(messageContext);
-            this.setMessageContext(messageContext);
-        }
+        final String relayState = this.context.getRequestParameter("RelayState");
+        logger.debug("Decoded SAML relay state of: {}", relayState);
+        SAMLBindingSupport.setRelayState(messageContext, relayState);
+        final InputStream base64DecodedMessage = this.getBase64DecodedMessage();
+        final SAMLObject inboundMessage =
+            (SAMLObject)this.unmarshallMessage
+                (
+                    HttpConstants.HTTP_METHOD.POST.name()
+                        .equalsIgnoreCase(this.context.getRequestMethod()) ?
+                        base64DecodedMessage :
+                        new InflaterInputStream(base64DecodedMessage, new Inflater(true))
+                );
+        // TODO: verify signature of SAMLResponse
+        messageContext.setMessage(inboundMessage);
+        logger.debug("Decoded SAML message");
+        this.populateBindingContext(messageContext);
+        this.setMessageContext(messageContext);
     }
 
     protected InputStream getBase64DecodedMessage()
@@ -77,7 +85,7 @@ public class Pac4jHTTPPostDecoder extends AbstractMessageDecoder<SAMLObject> {
         }
 
         if(Strings.isNullOrEmpty(encodedMessage)) {
-            throw new MessageDecodingException("Request did not contain either a SAMLRequest or SAMLResponse parameter. " 
+            throw new MessageDecodingException("Request did not contain either a SAMLRequest or SAMLResponse parameter. "
                 + "Invalid request for SAML 2 HTTP POST binding.");
         } else {
             logger.trace("Base64 decoding SAML message:\n{}", encodedMessage);
@@ -141,11 +149,16 @@ public class Pac4jHTTPPostDecoder extends AbstractMessageDecoder<SAMLObject> {
     protected XMLObject unmarshallMessage(InputStream messageStream) throws MessageDecodingException {
         try {
             XMLObject message = XMLObjectSupport.unmarshallFromInputStream(getParserPool(), messageStream);
+            TransformerFactory.newInstance().newTransformer().
+                transform(new DOMSource(message.getDOM()), new StreamResult(System.out));
+
             return message;
         } catch (XMLParserException e) {
             throw new MessageDecodingException("Error unmarshalling message from input stream", e);
         } catch (UnmarshallingException e) {
             throw new MessageDecodingException("Error unmarshalling message from input stream", e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
The class Pac4jHTTPPostDecoder was slightly modified to also accept responses via GET (HTTP-Redirect binding). Therefore, it was renamed to Pac4jHTTPDecoder.