### PR TITLE
Ensure private key password is used when generating saml metadata

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -479,7 +479,8 @@ public class SAML2ClientConfiguration extends InitializableObject {
             final PrivateKey signingKey = kp.getPrivate();
             final X509Certificate certificate = cert.generate(signingKey, "BC");
 
-            ks.setKeyEntry(this.keyStoreAlias, signingKey, password, new Certificate[]{certificate});
+            final char[] keyPassword = this.privateKeyPassword.toCharArray();
+            ks.setKeyEntry(this.keyStoreAlias, signingKey, keyPassword, new Certificate[]{certificate});
 
             try (final FileOutputStream fos = new FileOutputStream(this.keystoreResource.getFile().getCanonicalPath())) {
                 ks.store(fos, password);


### PR DESCRIPTION
The present method of generating a keystore for SAML2 uses the keystore password, rather than the private key password, which is of course a problem. 