### PR TITLE
Remove use of unmodifiable maps

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -140,7 +140,7 @@ public final class ProfileHelper {
      * @return the list of profiles
      */
     public static <U extends CommonProfile> List<U> flatIntoAProfileList(final Map<String, U> profiles) {
-        return Collections.unmodifiableList(new ArrayList<>(profiles.values()));
+        return new ArrayList<>(profiles.values());
     }
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -183,14 +183,14 @@ public abstract class UserProfile implements Serializable, Externalizable {
         return getImmutableAttributeMap(this.authenticationAttributes);
     }
 
-    private Map<String, Object> getImmutableAttributeMap(Map<String, Object> attributeMap) {
+    private static Map<String, Object> getImmutableAttributeMap(Map<String, Object> attributeMap) {
         final Map<String, Object> newAttributes = new HashMap<>();
         for (Map.Entry<String, Object> entries : attributeMap.entrySet()) {
             final String key = entries.getKey();
             final Object value = ProfileHelper.getInternalAttributeHandler().restore(attributeMap.get(key));
             newAttributes.put(key, value);
         }
-        return Collections.unmodifiableMap(newAttributes);
+        return newAttributes;
     }
 
     /**
@@ -342,7 +342,7 @@ public abstract class UserProfile implements Serializable, Externalizable {
      * @return the user roles.
      */
     public Set<String> getRoles() {
-        return Collections.unmodifiableSet(this.roles);
+        return new LinkedHashSet<>(this.roles);
     }
 
     /**
@@ -351,7 +351,7 @@ public abstract class UserProfile implements Serializable, Externalizable {
      * @return the user permissions.
      */
     public Set<String> getPermissions() {
-        return Collections.unmodifiableSet(this.permissions);
+        return new LinkedHashSet<>(this.permissions);
     }
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -171,7 +171,7 @@ public abstract class UserProfile implements Serializable, Externalizable {
      * @return the immutable attributes
      */
     public Map<String, Object> getAttributes() {
-        return getImmutableAttributeMap(this.attributes);
+        return getAttributeMap(this.attributes);
     }
 
     /**
@@ -180,10 +180,10 @@ public abstract class UserProfile implements Serializable, Externalizable {
      * @return the immutable authentication attributes
      */
     public Map<String, Object> getAuthenticationAttributes() {
-        return getImmutableAttributeMap(this.authenticationAttributes);
+        return getAttributeMap(this.authenticationAttributes);
     }
 
-    private static Map<String, Object> getImmutableAttributeMap(Map<String, Object> attributeMap) {
+    private static Map<String, Object> getAttributeMap(Map<String, Object> attributeMap) {
         final Map<String, Object> newAttributes = new HashMap<>();
         for (Map.Entry<String, Object> entries : attributeMap.entrySet()) {
             final String key = entries.getKey();

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
@@ -77,9 +77,8 @@ public final class CommonProfileTests implements TestsConstants {
         final CommonProfile userProfile = new CommonProfile();
         try {
             userProfile.getAttributes().put(KEY, VALUE);
-            fail();
         } catch (final UnsupportedOperationException e) {
-            assertNull(e.getMessage());
+            fail();
         }
     }
     @Test
@@ -87,9 +86,8 @@ public final class CommonProfileTests implements TestsConstants {
         final CommonProfile userProfile = new CommonProfile();
         try {
             userProfile.getAuthenticationAttributes().put(KEY, VALUE);
-            fail();
         } catch (final UnsupportedOperationException e) {
-            assertNull(e.getMessage());
+            fail();
         }
     }
 


### PR DESCRIPTION
Ran into a problem with profile attributes constructed and returned as unmodifiable maps. If the profile is put inside a cache such as Memcached, the unmodifiable map instance cannot be reconstructed when it's fetched from the cache and populated. 