### PR TITLE
replace javax.xml.bind.DatatypeConverter with java.util.Base64

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/credentials/extractor/TicketAndLogoutRequestExtractor.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/credentials/extractor/TicketAndLogoutRequestExtractor.java
@@ -1,5 +1,6 @@
 package org.pac4j.cas.credentials.extractor;
 
+import java.util.Base64;
 import org.jasig.cas.client.util.CommonUtils;
 import org.pac4j.cas.config.CasConfiguration;
 import org.pac4j.cas.logout.CasLogoutHandler;
@@ -14,7 +15,6 @@ import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.util.zip.Inflater;
 
 /**
@@ -98,7 +98,7 @@ public class TicketAndLogoutRequestExtractor implements CredentialsExtractor<Tok
     }
 
     private String uncompressLogoutMessage(final String originalMessage) {
-        final byte[] binaryMessage = DatatypeConverter.parseBase64Binary(originalMessage);
+        final byte[] binaryMessage = Base64.getMimeDecoder().decode(originalMessage);
 
         Inflater decompresser = null;
         try {

--- a/pac4j-cas/src/test/java/org/pac4j/cas/client/CasClientTests.java
+++ b/pac4j-cas/src/test/java/org/pac4j/cas/client/CasClientTests.java
@@ -11,8 +11,8 @@ import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.zip.Deflater;
 
 import static org.junit.Assert.*;
@@ -173,7 +173,7 @@ public final class CasClientTests implements TestsConstants {
         final int resultSize = deflater.deflate(buffer);
         final byte[] output = new byte[resultSize];
         System.arraycopy(buffer, 0, output, 0, resultSize);
-        return DatatypeConverter.printBase64Binary(output);
+        return Base64.getEncoder().encodeToString(output);
     }
 
     @Test

--- a/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
@@ -3,10 +3,10 @@ package org.pac4j.core.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -34,7 +34,7 @@ public class JavaSerializationHelper {
      * @return the base64 string of the serialized object
      */
     public String serializeToBase64(final Serializable o) {
-        return DatatypeConverter.printBase64Binary(serializeToBytes(o));
+        return Base64.getEncoder().encodeToString(serializeToBytes(o));
     }
 
     /**
@@ -63,7 +63,7 @@ public class JavaSerializationHelper {
      * @return the unserialized Java object
      */
     public Serializable unserializeFromBase64(final String base64) {
-        return unserializeFromBytes(DatatypeConverter.parseBase64Binary(base64));
+        return unserializeFromBytes(Base64.getDecoder().decode(base64));
     }
 
     /**


### PR DESCRIPTION
fixes #1105

In `TicketAndLogoutRequestExtractor` i used `Base64::getMimeDecoder` because that's exactly the same lenient behaviour `DatatypeConverter` used (ignoring whitespace). In the other cases we control the input and output so it's fine to use the stricter `Base64::getDecoder`.