### PR TITLE
Provides format and name qualifier for Issuer element into SAML authn request

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -134,6 +134,8 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
             .getBuilder(Issuer.DEFAULT_ELEMENT_NAME);
         final Issuer issuer = issuerBuilder.buildObject();
         issuer.setValue(spEntityId);
+        issuer.setFormat(Issuer.ENTITY);
+        issuer.setNameQualifier(spEntityId);
         return issuer;
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -31,7 +31,10 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
         final WebContext context = new J2EContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final RedirectAction action = client.getRedirectAction(context);
         assertTrue(getDecodedAuthnRequest(action.getContent())
-            .contains("<saml2:Issuer xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
+                .contains("<saml2:Issuer "
+                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
+                        + "NameQualifier=\"http://localhost:8080/cb\" "
+                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
     }
 
     @Test

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -42,7 +42,10 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         final String inflated = getInflatedAuthnRequest(action.getLocation());
 
         assertTrue(inflated.contains(
-                "<saml2:Issuer xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
+                "<saml2:Issuer "
+                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
+                        + "NameQualifier=\"http://localhost:8080/callback\" "
+                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
     }
 
     @Test


### PR DESCRIPTION
Issuer element missing format and name qualifier.
Unfortunately some IdP require this information mandatory.
This PR provides format and name qualifier by default.