### PR TITLE
#1103: Check how authentication attributes are restored... [2.2.x branch]

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/credentials/authenticator/CasAuthenticator.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/credentials/authenticator/CasAuthenticator.java
@@ -11,6 +11,7 @@ import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.exception.HttpAction;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.InternalAttributeHandler;
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.definition.ProfileDefinitionAware;
 import org.pac4j.core.util.CommonHelper;
@@ -28,7 +29,7 @@ import java.util.Map;
  */
 public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> implements Authenticator<TokenCredentials> {
 
-    private final static Logger logger = LoggerFactory.getLogger(CasAuthenticator.class);
+    private static final Logger logger = LoggerFactory.getLogger(CasAuthenticator.class);
 
     private CasConfiguration configuration;
 
@@ -63,16 +64,19 @@ public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> impl
             logger.debug("principal: {}", principal);
 
             final String id = principal.getName();
-            final Map<String, Object> newAttributes = new HashMap<>();
-            // restore attributes
-            final Map<String, Object> attributes = principal.getAttributes();
-            if (attributes != null) {
-                for (final Map.Entry<String, Object> entry : attributes.entrySet()){
-                    final String key = entry.getKey();
-                    final Object value = entry.getValue();
-                    final Object restored = ProfileHelper.getInternalAttributeHandler().restore(value);
-                    newAttributes.put(key, restored);
-                }
+            final Map<String, Object> newPrincipalAttributes = new HashMap<>();
+            final Map<String, Object> newAuthenticationAttributes = new HashMap<>();
+            // restore both sets of attributes
+            final Map<String, Object> oldPrincipalAttributes = principal.getAttributes();
+            final Map<String, Object> oldAuthenticationAttributes = assertion.getAttributes();
+            final InternalAttributeHandler attrHandler = ProfileHelper.getInternalAttributeHandler();
+            if (oldPrincipalAttributes != null) {
+                oldPrincipalAttributes.entrySet().stream()
+                    .forEach(e -> newPrincipalAttributes.put(e.getKey(), attrHandler.restore(e.getValue())));
+            }
+            if (oldAuthenticationAttributes != null) {
+                oldAuthenticationAttributes.entrySet().stream()
+                    .forEach(e -> newAuthenticationAttributes.put(e.getKey(), attrHandler.restore(e.getValue())));
             }
 
             final CommonProfile profile;
@@ -80,10 +84,10 @@ public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> impl
             if (configuration.getProxyReceptor() != null) {
                 profile = getProfileDefinition().newProfile(principal, configuration.getProxyReceptor());
                 profile.setId(id);
-                getProfileDefinition().convertAndAdd(profile, newAttributes);
+                getProfileDefinition().convertAndAdd(profile, newPrincipalAttributes, newAuthenticationAttributes);
             } else {
-                profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), id, newAttributes, principal, 
-                    configuration.getProxyReceptor());
+                profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), id, newPrincipalAttributes,
+                        newAuthenticationAttributes, principal, configuration.getProxyReceptor());
             }
             logger.debug("profile returned by CAS: {}", profile);
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/AttributeLocation.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/AttributeLocation.java
@@ -5,6 +5,7 @@ package org.pac4j.core.profile;
  * Denotes where an attribute is placed in a profile.
  * 
  * @author jkacer
+ * @since 2.3.0
  */
 public enum AttributeLocation {
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/AttributeLocation.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/AttributeLocation.java
@@ -1,0 +1,16 @@
+package org.pac4j.core.profile;
+
+
+/**
+ * Denotes where an attribute is placed in a profile.
+ * 
+ * @author jkacer
+ */
+public enum AttributeLocation {
+
+    /** Profile "basic" attribute. */
+    PROFILE_ATTRIBUTE,
+
+    /** Profile authentication attribute. */
+    AUTHENTICATION_ATTRIBUTE;
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -43,15 +43,34 @@ public final class ProfileHelper {
 
     /**
      * Restore or build a profile.
+     * 
+     * You may want to use {@link #restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} which supports authentication
+     * attributes.
      *
      * @param profileDefinition the profile definition
      * @param typedId the typed identifier
-     * @param attributes the attributes
+     * @param attributes The profile attributes. May be {@code null}.
+     * @param parameters additional parameters for the profile definition
+     * @return the restored or built profile
+     */
+    public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition,
+        final String typedId, final Map<String, Object> attributes, final Object... parameters) {
+        return restoreOrBuildProfile(profileDefinition, typedId, attributes, null, parameters);
+    }
+
+    /**
+     * Restore or build a profile.
+     *
+     * @param profileDefinition the profile definition
+     * @param typedId the typed identifier
+     * @param profileAttributes The profile attributes. May be {@code null}.
+     * @param authenticationAttributes The authentication attributes. May be {@code null}.
      * @param parameters additional parameters for the profile definition
      * @return the restored or built profile
      */
     public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition, 
-        final String typedId, final Map<String, Object> attributes, final Object... parameters) {
+            final String typedId, final Map<String, Object> profileAttributes, final Map<String, Object> authenticationAttributes,
+            final Object... parameters) {
         if (CommonHelper.isBlank(typedId)) {
             return null;
         }
@@ -66,10 +85,11 @@ public final class ProfileHelper {
                 logger.error("Cannot build instance for class name: {}", className, e);
                 return null;
             }
-            profile.addAttributes(attributes);
+            profile.addAttributes(profileAttributes);
+            profile.addAuthenticationAttributes(authenticationAttributes);
         } else {
             profile = profileDefinition.newProfile(parameters);
-            profileDefinition.convertAndAdd(profile, attributes);
+            profileDefinition.convertAndAdd(profile, profileAttributes, authenticationAttributes);
         }
         profile.setId(typedId);
         return profile;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -52,7 +52,10 @@ public final class ProfileHelper {
      * @param attributes The profile attributes. May be {@code null}.
      * @param parameters additional parameters for the profile definition
      * @return the restored or built profile
+     * 
+     * @deprecated Use {@link #restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} instead.
      */
+    @Deprecated
     public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition,
         final String typedId, final Map<String, Object> attributes, final Object... parameters) {
         return restoreOrBuildProfile(profileDefinition, typedId, attributes, null, parameters);

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -63,7 +63,8 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
      * @param name The attribute name.
      * @param value The attribute value.
      */
-    public void convertAndAdd(final CommonProfile profile, final AttributeLocation attributeLocation, final String name, final Object value) {
+    public void convertAndAdd(final CommonProfile profile, final AttributeLocation attributeLocation, final String name,
+            final Object value) {
         if (value != null) {
             final Object convertedValue;
             final AttributeConverter<? extends Object> converter = this.converters.get(name);
@@ -78,15 +79,15 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
             }
 
             switch (attributeLocation) {
-            case PROFILE_ATTRIBUTE:
-                profile.addAttribute(name, convertedValue);
-                break;
-            case AUTHENTICATION_ATTRIBUTE:
-                profile.addAuthenticationAttribute(name, convertedValue);
-                break;
-            default:
-                logger.debug("Unsupported attribute location {}.", attributeLocation);
-                break;
+                case PROFILE_ATTRIBUTE:
+                    profile.addAttribute(name, convertedValue);
+                    break;
+                case AUTHENTICATION_ATTRIBUTE:
+                    profile.addAuthenticationAttribute(name, convertedValue);
+                    break;
+                default:
+                    logger.debug("Unsupported attribute location {}.", attributeLocation);
+                    break;
             }
         }
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -1,10 +1,14 @@
 package org.pac4j.core.profile.definition;
 
+import org.pac4j.core.profile.AttributeLocation;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.converter.AttributeConverter;
 import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.pac4j.core.profile.AttributeLocation.AUTHENTICATION_ATTRIBUTE;
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,13 +45,25 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
     }
 
     /**
-     * Convert the attribute if necessary and add it to the profile.
+     * Convert a profile attribute, if necessary, and add it to the profile.
      *
      * @param profile the profile
      * @param name the attribute name
      * @param value the attribute value
      */
     public void convertAndAdd(final CommonProfile profile, final String name, final Object value) {
+        convertAndAdd(profile, PROFILE_ATTRIBUTE, name, value);
+    }
+
+    /**
+     * Convert a profile or authentication attribute, if necessary, and add it to the profile.
+     *
+     * @param profile The profile.
+     * @param attributeLocation Location of the attribute inside the profile: classic profile attribute, authentication attribute, ...
+     * @param name The attribute name.
+     * @param value The attribute value.
+     */
+    public void convertAndAdd(final CommonProfile profile, final AttributeLocation attributeLocation, final String name, final Object value) {
         if (value != null) {
             final Object convertedValue;
             final AttributeConverter<? extends Object> converter = this.converters.get(name);
@@ -55,29 +71,55 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
                 convertedValue = converter.convert(value);
                 if (convertedValue != null) {
                     logger.debug("converted to => key: {} / value: {} / {}", name, convertedValue, convertedValue.getClass());
-                    profile.addAttribute(name, convertedValue);
                 }
             } else {
                 convertedValue = value;
                 logger.debug("no conversion => key: {} / value: {} / {}", name, convertedValue, convertedValue.getClass());
+            }
+
+            switch (attributeLocation) {
+            case PROFILE_ATTRIBUTE:
                 profile.addAttribute(name, convertedValue);
+                break;
+            case AUTHENTICATION_ATTRIBUTE:
+                profile.addAuthenticationAttribute(name, convertedValue);
+                break;
+            default:
+                logger.debug("Unsupported attribute location {}.", attributeLocation);
+                break;
             }
         }
     }
 
     /**
-     * Convert the attributes if necessary and add them to the profile.
+     * Convert the profile attributes, if necessary, and add them to the profile.
+     * 
+     * You may want to use {@link #convertAndAdd(CommonProfile, Map, Map)} which supports adding authentication attributes.
      *
-     * @param profile the profile
-     * @param attributes the attributes
+     * @param profile The profile.
+     * @param attributes The profile attributes. May be {@code null}.
      */
     public void convertAndAdd(final CommonProfile profile, final Map<String, Object> attributes) {
-        if (attributes != null) {
-            for (final Map.Entry<String, Object> entry : attributes.entrySet()){
-                final String key = entry.getKey();
-                final Object value = entry.getValue();
-                convertAndAdd(profile, key, value);
-            }
+        convertAndAdd(profile, attributes, null);
+    }
+
+    /**
+     * Convert the profile and authentication attributes, if necessary, and add them to the profile.
+     *
+     * @param profile The profile.
+     * @param profileAttributes The profile attributes. May be {@code null}.
+     * @param authenticationAttributes The authentication attributes. May be {@code null}.
+     */
+    public void convertAndAdd(final CommonProfile profile,
+            final Map<String, Object> profileAttributes,
+            final Map<String, Object> authenticationAttributes) {
+        if (profileAttributes != null) {
+            profileAttributes.entrySet().stream()
+                .forEach(entry -> convertAndAdd(profile, PROFILE_ATTRIBUTE, entry.getKey(), entry.getValue()));
+        }
+        if (authenticationAttributes != null) {
+            authenticationAttributes.entrySet().stream()
+                .forEach(entry -> convertAndAdd(profile, AUTHENTICATION_ATTRIBUTE, entry.getKey(), entry.getValue()));
         }
     }
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -50,7 +50,10 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
      * @param profile the profile
      * @param name the attribute name
      * @param value the attribute value
+     * 
+     * @deprecated Use {@link #convertAndAdd(CommonProfile, AttributeLocation, String, Object)} instead.
      */
+    @Deprecated
     public void convertAndAdd(final CommonProfile profile, final String name, final Object value) {
         convertAndAdd(profile, PROFILE_ATTRIBUTE, name, value);
     }
@@ -78,16 +81,10 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
                 logger.debug("no conversion => key: {} / value: {} / {}", name, convertedValue, convertedValue.getClass());
             }
 
-            switch (attributeLocation) {
-                case PROFILE_ATTRIBUTE:
-                    profile.addAttribute(name, convertedValue);
-                    break;
-                case AUTHENTICATION_ATTRIBUTE:
-                    profile.addAuthenticationAttribute(name, convertedValue);
-                    break;
-                default:
-                    logger.debug("Unsupported attribute location {}.", attributeLocation);
-                    break;
+            if (attributeLocation.equals(AUTHENTICATION_ATTRIBUTE)) {
+                profile.addAuthenticationAttribute(name, convertedValue);
+            } else {
+                profile.addAttribute(name, convertedValue);
             }
         }
     }
@@ -99,7 +96,10 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
      *
      * @param profile The profile.
      * @param attributes The profile attributes. May be {@code null}.
+     * 
+     * @deprecated Use {@link #convertAndAdd(CommonProfile, Map, Map)} instead.
      */
+    @Deprecated
     public void convertAndAdd(final CommonProfile profile, final Map<String, Object> attributes) {
         convertAndAdd(profile, attributes, null);
     }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileHelperTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileHelperTests.java
@@ -68,24 +68,7 @@ public final class ProfileHelperTests implements TestsConstants {
     @Test
     public void testProfileRestoreFromClassName() {
         final String typedId = CommonProfile.class.getName() + CommonProfile.SEPARATOR;
-        profileRestoreMustBringBackAllAttributes(typedId);
-    }
-
-    /**
-     * Tests {@link ProfileHelper#restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} when the profile is created using
-     * through the profile definition's create function. The Typed ID does not contain a separator.
-     */
-    @Test
-    public void testProfileRestoreFromProfileDefinitionCreateFunction() {
-        final String typedId = CommonProfile.class.getName();
-        profileRestoreMustBringBackAllAttributes(typedId);
-    }
-
-    private void profileRestoreMustBringBackAllAttributes(final String typedId) {
-        final ProfileDefinition<CommonProfile> pd = new CommonProfileDefinition<>();
-        final Map<String,Object> profileAttributes = exampleSamlProfileAttributes();
-        final Map<String,Object> authenticationAttributes = exampleSamlAuthenticationAttributes();
-        final CommonProfile restoredProfile = ProfileHelper.restoreOrBuildProfile(pd, typedId, profileAttributes, authenticationAttributes);
+        final CommonProfile restoredProfile = profileRestoreMustBringBackAllAttributes(typedId);
 
         assertNotNull(restoredProfile);
         assertEquals("a@b.cc", restoredProfile.getEmail());
@@ -108,6 +91,45 @@ public final class ProfileHelperTests implements TestsConstants {
         assertEquals("NameIdSpProvidedId", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_PROVIDED_ID));
         assertEquals(notBeforeTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
         assertEquals(notOnOrAfterTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+    }
+
+    /**
+     * Tests {@link ProfileHelper#restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} when the profile is created using
+     * through the profile definition's create function. The Typed ID does not contain a separator.
+     */
+    @Test
+    public void testProfileRestoreFromProfileDefinitionCreateFunction() {
+        final String typedId = CommonProfile.class.getName();
+        final CommonProfile restoredProfile = profileRestoreMustBringBackAllAttributes(typedId);
+
+        assertNotNull(restoredProfile);
+        assertEquals("a@b.cc", restoredProfile.getEmail());
+        assertEquals("John", restoredProfile.getFirstName());
+        assertEquals("Doe", restoredProfile.getFamilyName());
+        assertEquals(Gender.UNSPECIFIED, restoredProfile.getGender()); // Because it was not set
+        assertNull(restoredProfile.getDisplayName()); // Was not set either
+
+        assertEquals("12345-67890", restoredProfile.getAttribute(SESSION_INDEX));
+        assertEquals(notBeforeTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+
+        assertEquals("IssuerId", restoredProfile.getAuthenticationAttribute(ISSUER_ID));
+        List<String> context = (List<String>) restoredProfile.getAuthenticationAttribute(AUTHN_CONTEXT);
+        assertThat(context, CoreMatchers.hasItem("ContextItem1"));
+        assertThat(context, CoreMatchers.hasItem("ContextItem2"));
+        assertEquals("NameIdFormat", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_FORMAT));
+        assertEquals("NameIdNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_NAME_QUALIFIER));
+        assertEquals("NameIdSpNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_NAME_QUALIFIER));
+        assertEquals("NameIdSpProvidedId", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_PROVIDED_ID));
+        assertEquals(notBeforeTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+    }
+
+    private CommonProfile profileRestoreMustBringBackAllAttributes(final String typedId) {
+        final ProfileDefinition<CommonProfile> pd = new CommonProfileDefinition<>();
+        final Map<String,Object> profileAttributes = exampleSamlProfileAttributes();
+        final Map<String,Object> authenticationAttributes = exampleSamlAuthenticationAttributes();
+        return ProfileHelper.restoreOrBuildProfile(pd, typedId, profileAttributes, authenticationAttributes);
     }
 
     private Map<String, Object> exampleSamlProfileAttributes() {

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileHelperTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileHelperTests.java
@@ -1,9 +1,19 @@
 package org.pac4j.core.profile;
 
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
 import org.junit.Test;
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.profile.definition.ProfileDefinition;
 import org.pac4j.core.util.TestsConstants;
 
 import static org.junit.Assert.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tests {@link ProfileHelper}.
@@ -12,6 +22,27 @@ import static org.junit.Assert.*;
  * @since 1.9.0
  */
 public final class ProfileHelperTests implements TestsConstants {
+
+    // Examples of attribute keys, borrowed from the SAML module to have something realistic.
+    private static final String SAML_CONDITION_NOT_BEFORE_ATTRIBUTE = "notBefore";
+    private static final String SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE = "notOnOrAfter";
+    private static final String SESSION_INDEX = "sessionindex";
+    private static final String ISSUER_ID = "issuerId"; 
+    private static final String AUTHN_CONTEXT = "authnContext";
+    private static final String SAML_NAME_ID_FORMAT = "samlNameIdFormat";
+    private static final String SAML_NAME_ID_NAME_QUALIFIER = "samlNameIdNameQualifier";
+    private static final String SAML_NAME_ID_SP_NAME_QUALIFIER = "samlNameIdSpNameQualifier";
+    private static final String SAML_NAME_ID_SP_PROVIDED_ID = "samlNameIdSpProvidedId";
+
+    private LocalDateTime notBeforeTime;
+    private LocalDateTime notOnOrAfterTime;
+
+
+    @Before
+    public void setUpTestData() {
+        notBeforeTime = LocalDateTime.now();
+        notOnOrAfterTime = notBeforeTime.plusHours(1L);
+    }
 
     @Test
     public void testIsTypedIdOf() {
@@ -29,4 +60,78 @@ public final class ProfileHelperTests implements TestsConstants {
         final CommonProfile profile2 = ProfileHelper.buildUserProfileByClassCompleteName(CommonProfile.class.getName());
         assertNotNull(profile2);
     }
+
+    /**
+     * Tests {@link ProfileHelper#restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} when the profile is created using
+     * its constructor. The Typed ID contains a separator.
+     */
+    @Test
+    public void testProfileRestoreFromClassName() {
+        final String typedId = CommonProfile.class.getName() + CommonProfile.SEPARATOR;
+        profileRestoreMustBringBackAllAttributes(typedId);
+    }
+
+    /**
+     * Tests {@link ProfileHelper#restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} when the profile is created using
+     * through the profile definition's create function. The Typed ID does not contain a separator.
+     */
+    @Test
+    public void testProfileRestoreFromProfileDefinitionCreateFunction() {
+        final String typedId = CommonProfile.class.getName();
+        profileRestoreMustBringBackAllAttributes(typedId);
+    }
+
+    private void profileRestoreMustBringBackAllAttributes(final String typedId) {
+        final ProfileDefinition<CommonProfile> pd = new CommonProfileDefinition<>();
+        final Map<String,Object> profileAttributes = exampleSamlProfileAttributes();
+        final Map<String,Object> authenticationAttributes = exampleSamlAuthenticationAttributes();
+        final CommonProfile restoredProfile = ProfileHelper.restoreOrBuildProfile(pd, typedId, profileAttributes, authenticationAttributes);
+
+        assertNotNull(restoredProfile);
+        assertEquals("a@b.cc", restoredProfile.getEmail());
+        assertEquals("John", restoredProfile.getFirstName());
+        assertEquals("Doe", restoredProfile.getFamilyName());
+        assertEquals(Gender.UNSPECIFIED, restoredProfile.getGender()); // Because it was not set
+        assertNull(restoredProfile.getDisplayName()); // Was not set either
+
+        assertEquals("12345-67890", restoredProfile.getAttribute(SESSION_INDEX));
+        assertEquals(notBeforeTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+
+        assertEquals("IssuerId", restoredProfile.getAuthenticationAttribute(ISSUER_ID));
+        List<String> context = (List<String>) restoredProfile.getAuthenticationAttribute(AUTHN_CONTEXT);
+        assertThat(context, CoreMatchers.hasItem("ContextItem1"));
+        assertThat(context, CoreMatchers.hasItem("ContextItem2"));
+        assertEquals("NameIdFormat", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_FORMAT));
+        assertEquals("NameIdNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_NAME_QUALIFIER));
+        assertEquals("NameIdSpNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_NAME_QUALIFIER));
+        assertEquals("NameIdSpProvidedId", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_PROVIDED_ID));
+        assertEquals(notBeforeTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+    }
+
+    private Map<String, Object> exampleSamlProfileAttributes() {
+        final Map<String, Object> attr = new HashMap<>();
+        attr.put(CommonProfileDefinition.EMAIL, "a@b.cc");
+        attr.put(CommonProfileDefinition.FIRST_NAME, "John");
+        attr.put(CommonProfileDefinition.FAMILY_NAME, "Doe");
+        attr.put(SESSION_INDEX, "12345-67890");
+        attr.put(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, notBeforeTime);
+        attr.put(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, notOnOrAfterTime);
+        return attr;
+    }
+
+    private Map<String, Object> exampleSamlAuthenticationAttributes() {
+        final Map<String, Object> attr = new HashMap<>();
+        attr.put(ISSUER_ID, "IssuerId");
+        attr.put(AUTHN_CONTEXT, Arrays.asList("ContextItem1", "ContextItem2"));
+        attr.put(SAML_NAME_ID_FORMAT, "NameIdFormat");
+        attr.put(SAML_NAME_ID_NAME_QUALIFIER, "NameIdNameQualifier");
+        attr.put(SAML_NAME_ID_SP_NAME_QUALIFIER, "NameIdSpNameQualifier");
+        attr.put(SAML_NAME_ID_SP_PROVIDED_ID, "NameIdSpProvidedId");
+        attr.put(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, notBeforeTime);
+        attr.put(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, notOnOrAfterTime);
+        return attr;
+    }
+
 }


### PR DESCRIPTION
This is a pull request to solve issue #1103 for the 2.2.x branch.
I can provide it for master too, if this PR is found OK.
I have enhanced the ProfileHelper and the ProfileDefinition with a few new methods that support authentication attributes. Existing methods were kept for backward compatibility.