### PR TITLE
#1103: Check how authentication attributes are restored... [master branch]

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/credentials/authenticator/CasAuthenticator.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/credentials/authenticator/CasAuthenticator.java
@@ -90,9 +90,9 @@ public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> impl
             if (configuration.getProxyReceptor() != null) {
                 profile = getProfileDefinition().newProfile(principal, configuration.getProxyReceptor());
                 profile.setId(ProfileHelper.sanitizeIdentifier(profile, id));
-                getProfileDefinition().convertAndAdd(profile, newAttributes);
+                getProfileDefinition().convertAndAdd(profile, newAttributes, null);
             } else {
-                profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), id, newAttributes, principal,
+                profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), id, newAttributes, null, principal,
                     configuration.getProxyReceptor());
             }
             logger.debug("profile returned by CAS: {}", profile);

--- a/pac4j-cas/src/main/java/org/pac4j/cas/credentials/authenticator/CasAuthenticator.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/credentials/authenticator/CasAuthenticator.java
@@ -12,6 +12,7 @@ import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.http.callback.CallbackUrlResolver;
 import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.InternalAttributeHandler;
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.definition.ProfileDefinitionAware;
 import org.pac4j.core.util.CommonHelper;
@@ -29,7 +30,7 @@ import java.util.Map;
  */
 public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> implements Authenticator<TokenCredentials> {
 
-    private final static Logger logger = LoggerFactory.getLogger(CasAuthenticator.class);
+    private static final Logger logger = LoggerFactory.getLogger(CasAuthenticator.class);
 
     protected CasConfiguration configuration;
 
@@ -73,16 +74,19 @@ public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> impl
             logger.debug("principal: {}", principal);
 
             final String id = principal.getName();
-            final Map<String, Object> newAttributes = new HashMap<>();
-            // restore attributes
-            final Map<String, Object> attributes = principal.getAttributes();
-            if (attributes != null) {
-                for (final Map.Entry<String, Object> entry : attributes.entrySet()){
-                    final String key = entry.getKey();
-                    final Object value = entry.getValue();
-                    final Object restored = ProfileHelper.getInternalAttributeHandler().restore(value);
-                    newAttributes.put(key, restored);
-                }
+            final Map<String, Object> newPrincipalAttributes = new HashMap<>();
+            final Map<String, Object> newAuthenticationAttributes = new HashMap<>();
+            // restore both sets of attributes
+            final Map<String, Object> oldPrincipalAttributes = principal.getAttributes();
+            final Map<String, Object> oldAuthenticationAttributes = assertion.getAttributes();
+            final InternalAttributeHandler attrHandler = ProfileHelper.getInternalAttributeHandler();
+            if (oldPrincipalAttributes != null) {
+                oldPrincipalAttributes.entrySet().stream()
+                    .forEach(e -> newPrincipalAttributes.put(e.getKey(), attrHandler.restore(e.getValue())));
+            }
+            if (oldAuthenticationAttributes != null) {
+                oldAuthenticationAttributes.entrySet().stream()
+                    .forEach(e -> newAuthenticationAttributes.put(e.getKey(), attrHandler.restore(e.getValue())));
             }
 
             final CommonProfile profile;
@@ -90,10 +94,10 @@ public class CasAuthenticator extends ProfileDefinitionAware<CommonProfile> impl
             if (configuration.getProxyReceptor() != null) {
                 profile = getProfileDefinition().newProfile(principal, configuration.getProxyReceptor());
                 profile.setId(ProfileHelper.sanitizeIdentifier(profile, id));
-                getProfileDefinition().convertAndAdd(profile, newAttributes, null);
+                getProfileDefinition().convertAndAdd(profile, newPrincipalAttributes, newAuthenticationAttributes);
             } else {
-                profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), id, newAttributes, null, principal,
-                    configuration.getProxyReceptor());
+                profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), id, newPrincipalAttributes,
+                        newAuthenticationAttributes, principal, configuration.getProxyReceptor());
             }
             logger.debug("profile returned by CAS: {}", profile);
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/AttributeLocation.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/AttributeLocation.java
@@ -1,0 +1,17 @@
+package org.pac4j.core.profile;
+
+
+/**
+ * Denotes where an attribute is placed in a profile.
+ * 
+ * @author jkacer
+ * @since 2.3.0
+ */
+public enum AttributeLocation {
+
+    /** Profile "basic" attribute. */
+    PROFILE_ATTRIBUTE,
+
+    /** Profile authentication attribute. */
+    AUTHENTICATION_ATTRIBUTE;
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -43,26 +43,6 @@ public final class ProfileHelper {
 
     /**
      * Restore or build a profile.
-     * 
-     * You may want to use {@link #restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} which supports authentication
-     * attributes.
-     *
-     * @param profileDefinition the profile definition
-     * @param typedId the typed identifier
-     * @param attributes The profile attributes. May be {@code null}.
-     * @param parameters additional parameters for the profile definition
-     * @return the restored or built profile
-     * 
-     * @deprecated Use {@link #restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} instead.
-     */
-    @Deprecated
-    public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition,
-        final String typedId, final Map<String, Object> attributes, final Object... parameters) {
-        return restoreOrBuildProfile(profileDefinition, typedId, attributes, null, parameters);
-    }
-
-    /**
-     * Restore or build a profile.
      *
      * @param profileDefinition the profile definition
      * @param typedId the typed identifier

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileHelper.java
@@ -43,15 +43,37 @@ public final class ProfileHelper {
 
     /**
      * Restore or build a profile.
+     * 
+     * You may want to use {@link #restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} which supports authentication
+     * attributes.
      *
      * @param profileDefinition the profile definition
      * @param typedId the typed identifier
-     * @param attributes the attributes
+     * @param attributes The profile attributes. May be {@code null}.
+     * @param parameters additional parameters for the profile definition
+     * @return the restored or built profile
+     * 
+     * @deprecated Use {@link #restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} instead.
+     */
+    @Deprecated
+    public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition,
+        final String typedId, final Map<String, Object> attributes, final Object... parameters) {
+        return restoreOrBuildProfile(profileDefinition, typedId, attributes, null, parameters);
+    }
+
+    /**
+     * Restore or build a profile.
+     *
+     * @param profileDefinition the profile definition
+     * @param typedId the typed identifier
+     * @param profileAttributes The profile attributes. May be {@code null}.
+     * @param authenticationAttributes The authentication attributes. May be {@code null}.
      * @param parameters additional parameters for the profile definition
      * @return the restored or built profile
      */
-    public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition,
-        final String typedId, final Map<String, Object> attributes, final Object... parameters) {
+    public static CommonProfile restoreOrBuildProfile(final ProfileDefinition<? extends CommonProfile> profileDefinition, 
+            final String typedId, final Map<String, Object> profileAttributes, final Map<String, Object> authenticationAttributes,
+            final Object... parameters) {
         if (CommonHelper.isBlank(typedId)) {
             return null;
         }
@@ -66,10 +88,11 @@ public final class ProfileHelper {
                 logger.error("Cannot build instance for class name: {}", className, e);
                 return null;
             }
-            profile.addAttributes(attributes);
+            profile.addAttributes(profileAttributes);
+            profile.addAuthenticationAttributes(authenticationAttributes);
         } else {
             profile = profileDefinition.newProfile(parameters);
-            profileDefinition.convertAndAdd(profile, attributes);
+            profileDefinition.convertAndAdd(profile, profileAttributes, authenticationAttributes);
         }
         profile.setId(ProfileHelper.sanitizeIdentifier(profile, typedId));
         return profile;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -47,20 +47,6 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
     }
 
     /**
-     * Convert a profile attribute, if necessary, and add it to the profile.
-     *
-     * @param profile the profile
-     * @param name the attribute name
-     * @param value the attribute value
-     * 
-     * @deprecated Use {@link #convertAndAdd(CommonProfile, AttributeLocation, String, Object)} instead.
-     */
-    @Deprecated
-    public void convertAndAdd(final CommonProfile profile, final String name, final Object value) {
-        convertAndAdd(profile, PROFILE_ATTRIBUTE, name, value);
-    }
-
-    /**
      * Convert a profile or authentication attribute, if necessary, and add it to the profile.
      *
      * @param profile The profile.
@@ -89,21 +75,6 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
                 profile.addAttribute(name, convertedValue);
             }
         }
-    }
-
-    /**
-     * Convert the profile attributes, if necessary, and add them to the profile.
-     * 
-     * You may want to use {@link #convertAndAdd(CommonProfile, Map, Map)} which supports adding authentication attributes.
-     *
-     * @param profile The profile.
-     * @param attributes The profile attributes. May be {@code null}.
-     * 
-     * @deprecated Use {@link #convertAndAdd(CommonProfile, Map, Map)} instead.
-     */
-    @Deprecated
-    public void convertAndAdd(final CommonProfile profile, final Map<String, Object> attributes) {
-        convertAndAdd(profile, attributes, null);
     }
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -1,10 +1,14 @@
 package org.pac4j.core.profile.definition;
 
+import org.pac4j.core.profile.AttributeLocation;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.converter.AttributeConverter;
 import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.pac4j.core.profile.AttributeLocation.AUTHENTICATION_ATTRIBUTE;
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,13 +47,29 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
     }
 
     /**
-     * Convert the attribute if necessary and add it to the profile.
+     * Convert a profile attribute, if necessary, and add it to the profile.
      *
      * @param profile the profile
      * @param name the attribute name
      * @param value the attribute value
+     * 
+     * @deprecated Use {@link #convertAndAdd(CommonProfile, AttributeLocation, String, Object)} instead.
      */
+    @Deprecated
     public void convertAndAdd(final CommonProfile profile, final String name, final Object value) {
+        convertAndAdd(profile, PROFILE_ATTRIBUTE, name, value);
+    }
+
+    /**
+     * Convert a profile or authentication attribute, if necessary, and add it to the profile.
+     *
+     * @param profile The profile.
+     * @param attributeLocation Location of the attribute inside the profile: classic profile attribute, authentication attribute, ...
+     * @param name The attribute name.
+     * @param value The attribute value.
+     */
+    public void convertAndAdd(final CommonProfile profile, final AttributeLocation attributeLocation, final String name,
+            final Object value) {
         if (value != null) {
             final Object convertedValue;
             final AttributeConverter<? extends Object> converter = this.converters.get(name);
@@ -57,29 +77,52 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
                 convertedValue = converter.convert(value);
                 if (convertedValue != null) {
                     logger.debug("converted to => key: {} / value: {} / {}", name, convertedValue, convertedValue.getClass());
-                    profile.addAttribute(name, convertedValue);
                 }
             } else {
                 convertedValue = value;
                 logger.debug("no conversion => key: {} / value: {} / {}", name, convertedValue, convertedValue.getClass());
+            }
+
+            if (attributeLocation.equals(AUTHENTICATION_ATTRIBUTE)) {
+                profile.addAuthenticationAttribute(name, convertedValue);
+            } else {
                 profile.addAttribute(name, convertedValue);
             }
         }
     }
 
     /**
-     * Convert the attributes if necessary and add them to the profile.
+     * Convert the profile attributes, if necessary, and add them to the profile.
+     * 
+     * You may want to use {@link #convertAndAdd(CommonProfile, Map, Map)} which supports adding authentication attributes.
      *
-     * @param profile the profile
-     * @param attributes the attributes
+     * @param profile The profile.
+     * @param attributes The profile attributes. May be {@code null}.
+     * 
+     * @deprecated Use {@link #convertAndAdd(CommonProfile, Map, Map)} instead.
      */
+    @Deprecated
     public void convertAndAdd(final CommonProfile profile, final Map<String, Object> attributes) {
-        if (attributes != null) {
-            for (final Map.Entry<String, Object> entry : attributes.entrySet()){
-                final String key = entry.getKey();
-                final Object value = entry.getValue();
-                convertAndAdd(profile, key, value);
-            }
+        convertAndAdd(profile, attributes, null);
+    }
+
+    /**
+     * Convert the profile and authentication attributes, if necessary, and add them to the profile.
+     *
+     * @param profile The profile.
+     * @param profileAttributes The profile attributes. May be {@code null}.
+     * @param authenticationAttributes The authentication attributes. May be {@code null}.
+     */
+    public void convertAndAdd(final CommonProfile profile,
+            final Map<String, Object> profileAttributes,
+            final Map<String, Object> authenticationAttributes) {
+        if (profileAttributes != null) {
+            profileAttributes.entrySet().stream()
+                .forEach(entry -> convertAndAdd(profile, PROFILE_ATTRIBUTE, entry.getKey(), entry.getValue()));
+        }
+        if (authenticationAttributes != null) {
+            authenticationAttributes.entrySet().stream()
+                .forEach(entry -> convertAndAdd(profile, AUTHENTICATION_ATTRIBUTE, entry.getKey(), entry.getValue()));
         }
     }
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/AbstractProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/AbstractProfileService.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 
 import static org.pac4j.core.context.Pac4jConstants.*;
-
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 import static org.pac4j.core.util.CommonHelper.*;
 
 /**
@@ -226,7 +226,7 @@ public abstract class AbstractProfileService<U extends CommonProfile> extends Pr
         if (isLegacyMode()) {
             final U profile = getProfileDefinition().newProfile();
             for (final String attributeName : attributeNames) {
-                getProfileDefinition().convertAndAdd(profile, attributeName, storageAttributes.get(attributeName));
+                getProfileDefinition().convertAndAdd(profile, PROFILE_ATTRIBUTE, attributeName, storageAttributes.get(attributeName));
             }
             final Object retrievedUsername = storageAttributes.get(getUsernameAttribute());
             if (retrievedUsername != null) {

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileHelperTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileHelperTests.java
@@ -1,9 +1,19 @@
 package org.pac4j.core.profile;
 
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
 import org.junit.Test;
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.profile.definition.ProfileDefinition;
 import org.pac4j.core.util.TestsConstants;
 
 import static org.junit.Assert.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tests {@link ProfileHelper}.
@@ -12,6 +22,27 @@ import static org.junit.Assert.*;
  * @since 1.9.0
  */
 public final class ProfileHelperTests implements TestsConstants {
+
+    // Examples of attribute keys, borrowed from the SAML module to have something realistic.
+    private static final String SAML_CONDITION_NOT_BEFORE_ATTRIBUTE = "notBefore";
+    private static final String SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE = "notOnOrAfter";
+    private static final String SESSION_INDEX = "sessionindex";
+    private static final String ISSUER_ID = "issuerId"; 
+    private static final String AUTHN_CONTEXT = "authnContext";
+    private static final String SAML_NAME_ID_FORMAT = "samlNameIdFormat";
+    private static final String SAML_NAME_ID_NAME_QUALIFIER = "samlNameIdNameQualifier";
+    private static final String SAML_NAME_ID_SP_NAME_QUALIFIER = "samlNameIdSpNameQualifier";
+    private static final String SAML_NAME_ID_SP_PROVIDED_ID = "samlNameIdSpProvidedId";
+
+    private LocalDateTime notBeforeTime;
+    private LocalDateTime notOnOrAfterTime;
+
+
+    @Before
+    public void setUpTestData() {
+        notBeforeTime = LocalDateTime.now();
+        notOnOrAfterTime = notBeforeTime.plusHours(1L);
+    }
 
     @Test
     public void testIsTypedIdOf() {
@@ -44,4 +75,102 @@ public final class ProfileHelperTests implements TestsConstants {
     public void testSanitize() {
         assertEquals("yes", ProfileHelper.sanitizeIdentifier(new CommonProfile(), "org.pac4j.core.profile.CommonProfile#yes"));
     }
+
+    /**
+     * Tests {@link ProfileHelper#restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} when the profile is created using
+     * its constructor. The Typed ID contains a separator.
+     */
+    @Test
+    public void testProfileRestoreFromClassName() {
+        final String typedId = CommonProfile.class.getName() + CommonProfile.SEPARATOR + ID;
+        final CommonProfile restoredProfile = profileRestoreMustBringBackAllAttributes(typedId);
+
+        assertNotNull(restoredProfile);
+        assertEquals(ID, restoredProfile.getId());
+        assertEquals("a@b.cc", restoredProfile.getEmail());
+        assertEquals("John", restoredProfile.getFirstName());
+        assertEquals("Doe", restoredProfile.getFamilyName());
+        assertEquals(Gender.UNSPECIFIED, restoredProfile.getGender()); // Because it was not set
+        assertNull(restoredProfile.getDisplayName()); // Was not set either
+
+        assertEquals("12345-67890", restoredProfile.getAttribute(SESSION_INDEX));
+        assertEquals(notBeforeTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+
+        assertEquals("IssuerId", restoredProfile.getAuthenticationAttribute(ISSUER_ID));
+        List<String> context = (List<String>) restoredProfile.getAuthenticationAttribute(AUTHN_CONTEXT);
+        assertThat(context, CoreMatchers.hasItem("ContextItem1"));
+        assertThat(context, CoreMatchers.hasItem("ContextItem2"));
+        assertEquals("NameIdFormat", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_FORMAT));
+        assertEquals("NameIdNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_NAME_QUALIFIER));
+        assertEquals("NameIdSpNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_NAME_QUALIFIER));
+        assertEquals("NameIdSpProvidedId", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_PROVIDED_ID));
+        assertEquals(notBeforeTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+    }
+
+    /**
+     * Tests {@link ProfileHelper#restoreOrBuildProfile(ProfileDefinition, String, Map, Map, Object...)} when the profile is created using
+     * through the profile definition's create function. The Typed ID does not contain a separator.
+     */
+    @Test
+    public void testProfileRestoreFromProfileDefinitionCreateFunction() {
+        final String typedId = ID;
+        final CommonProfile restoredProfile = profileRestoreMustBringBackAllAttributes(typedId);
+
+        assertNotNull(restoredProfile);
+        assertEquals(ID, restoredProfile.getId());
+        assertEquals("a@b.cc", restoredProfile.getEmail());
+        assertEquals("John", restoredProfile.getFirstName());
+        assertEquals("Doe", restoredProfile.getFamilyName());
+        assertEquals(Gender.UNSPECIFIED, restoredProfile.getGender()); // Because it was not set
+        assertNull(restoredProfile.getDisplayName()); // Was not set either
+
+        assertEquals("12345-67890", restoredProfile.getAttribute(SESSION_INDEX));
+        assertEquals(notBeforeTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+
+        assertEquals("IssuerId", restoredProfile.getAuthenticationAttribute(ISSUER_ID));
+        List<String> context = (List<String>) restoredProfile.getAuthenticationAttribute(AUTHN_CONTEXT);
+        assertThat(context, CoreMatchers.hasItem("ContextItem1"));
+        assertThat(context, CoreMatchers.hasItem("ContextItem2"));
+        assertEquals("NameIdFormat", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_FORMAT));
+        assertEquals("NameIdNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_NAME_QUALIFIER));
+        assertEquals("NameIdSpNameQualifier", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_NAME_QUALIFIER));
+        assertEquals("NameIdSpProvidedId", restoredProfile.getAuthenticationAttribute(SAML_NAME_ID_SP_PROVIDED_ID));
+        assertEquals(notBeforeTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE));
+        assertEquals(notOnOrAfterTime, restoredProfile.getAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE));
+    }
+
+    private CommonProfile profileRestoreMustBringBackAllAttributes(final String typedId) {
+        final ProfileDefinition<CommonProfile> pd = new CommonProfileDefinition<>();
+        final Map<String,Object> profileAttributes = exampleSamlProfileAttributes();
+        final Map<String,Object> authenticationAttributes = exampleSamlAuthenticationAttributes();
+        return ProfileHelper.restoreOrBuildProfile(pd, typedId, profileAttributes, authenticationAttributes);
+    }
+
+    private Map<String, Object> exampleSamlProfileAttributes() {
+        final Map<String, Object> attr = new HashMap<>();
+        attr.put(CommonProfileDefinition.EMAIL, "a@b.cc");
+        attr.put(CommonProfileDefinition.FIRST_NAME, "John");
+        attr.put(CommonProfileDefinition.FAMILY_NAME, "Doe");
+        attr.put(SESSION_INDEX, "12345-67890");
+        attr.put(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, notBeforeTime);
+        attr.put(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, notOnOrAfterTime);
+        return attr;
+    }
+
+    private Map<String, Object> exampleSamlAuthenticationAttributes() {
+        final Map<String, Object> attr = new HashMap<>();
+        attr.put(ISSUER_ID, "IssuerId");
+        attr.put(AUTHN_CONTEXT, Arrays.asList("ContextItem1", "ContextItem2"));
+        attr.put(SAML_NAME_ID_FORMAT, "NameIdFormat");
+        attr.put(SAML_NAME_ID_NAME_QUALIFIER, "NameIdNameQualifier");
+        attr.put(SAML_NAME_ID_SP_NAME_QUALIFIER, "NameIdSpNameQualifier");
+        attr.put(SAML_NAME_ID_SP_PROVIDED_ID, "NameIdSpProvidedId");
+        attr.put(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, notBeforeTime);
+        attr.put(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, notOnOrAfterTime);
+        return attr;
+    }
+
 }

--- a/pac4j-gae/src/main/java/org/pac4j/gae/client/GaeUserServiceClient.java
+++ b/pac4j-gae/src/main/java/org/pac4j/gae/client/GaeUserServiceClient.java
@@ -1,5 +1,7 @@
 package org.pac4j.gae.client;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.profile.definition.ProfileDefinition;
 import org.pac4j.core.redirect.RedirectAction;
@@ -46,8 +48,8 @@ public class GaeUserServiceClient extends IndirectClient<GaeUserCredentials, Gae
             if (user != null) {
                 final GaeUserServiceProfile profile = PROFILE_DEFINITION.newProfile();
                 profile.setId(user.getEmail());
-                PROFILE_DEFINITION.convertAndAdd(profile, CommonProfileDefinition.EMAIL, user.getEmail());
-                PROFILE_DEFINITION.convertAndAdd(profile, CommonProfileDefinition.DISPLAY_NAME, user.getNickname());
+                PROFILE_DEFINITION.convertAndAdd(profile, PROFILE_ATTRIBUTE, CommonProfileDefinition.EMAIL, user.getEmail());
+                PROFILE_DEFINITION.convertAndAdd(profile, PROFILE_ATTRIBUTE, CommonProfileDefinition.DISPLAY_NAME, user.getNickname());
                 if (service.isUserAdmin()) {
                     profile.addRole(GaeUserServiceProfile.PAC4J_GAE_GLOBAL_ADMIN_ROLE);
                 }

--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
@@ -245,7 +245,7 @@ public class JwtAuthenticator extends ProfileDefinitionAware<JwtProfile> impleme
         final List<String> permissions = (List<String>) attributes.get(JwtGenerator.INTERNAL_PERMISSIONS);
         attributes.remove(JwtGenerator.INTERNAL_PERMISSIONS);
 
-        final CommonProfile profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), subject, attributes);
+        final CommonProfile profile = ProfileHelper.restoreOrBuildProfile(getProfileDefinition(), subject, attributes, null);
 
         if (roles != null) {
             profile.addRoles(roles);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/bitbucket/BitbucketProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/bitbucket/BitbucketProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.oauth.config.OAuth10Configuration;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth10ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 
 /**
@@ -47,7 +49,7 @@ public class BitbucketProfileDefinition extends OAuth10ProfileDefinition<Bitbuck
             if (json != null) {
                 profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, Pac4jConstants.USERNAME)));
                 for (final String attribute : getPrimaryAttributes()) {
-                    convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                    convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
                 }
             }
         }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/casoauthwrapper/CasOAuthWrapperProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/casoauthwrapper/CasOAuthWrapperProfileDefinition.java
@@ -11,6 +11,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 import org.pac4j.scribe.builder.api.CasOAuthWrapperApi20;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Iterator;
 
 /**
@@ -55,14 +57,14 @@ public class CasOAuthWrapperProfileDefinition extends OAuth20ProfileDefinition<C
                     while (nodes.hasNext()) {
                         json = nodes.next();
                         final String attribute = json.fieldNames().next();
-                        convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                        convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
                     }
                     // CAS v5
                 } else if (json instanceof ObjectNode) {
                     final Iterator<String> keys = json.fieldNames();
                     while (keys.hasNext()) {
                         final String key = keys.next();
-                        convertAndAdd(profile, key, JsonHelper.getElement(json, key));
+                        convertAndAdd(profile, PROFILE_ATTRIBUTE, key, JsonHelper.getElement(json, key));
                     }
                 }
             }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/dropbox/DropBoxProfileDefinition.java
@@ -3,6 +3,9 @@ package org.pac4j.oauth.profile.dropbox;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.model.Verb;
+
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.oauth.config.OAuth20Configuration;
@@ -47,13 +50,13 @@ public class DropBoxProfileDefinition extends OAuth20ProfileDefinition<DropBoxPr
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "account_id")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
             json = (JsonNode) JsonHelper.getElement(json, "name");
             if (json != null) {
-                convertAndAdd(profile, FIRST_NAME, JsonHelper.getElement(json, "familiar_name"));
-                convertAndAdd(profile, FAMILY_NAME, JsonHelper.getElement(json, "surname"));
-                convertAndAdd(profile, DISPLAY_NAME, JsonHelper.getElement(json, "display_name"));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, FIRST_NAME, JsonHelper.getElement(json, "familiar_name"));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, FAMILY_NAME, JsonHelper.getElement(json, "surname"));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, DISPLAY_NAME, JsonHelper.getElement(json, "display_name"));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/facebook/FacebookProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/facebook/FacebookProfileDefinition.java
@@ -15,6 +15,9 @@ import org.pac4j.oauth.profile.facebook.converter.FacebookRelationshipStatusConv
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -148,7 +151,7 @@ public class FacebookProfileDefinition extends OAuth20ProfileDefinition<Facebook
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
             extractData(profile, json, FacebookProfileDefinition.FRIENDS);
             extractData(profile, json, FacebookProfileDefinition.MOVIES);
@@ -167,7 +170,7 @@ public class FacebookProfileDefinition extends OAuth20ProfileDefinition<Facebook
     protected void extractData(final FacebookProfile profile, final JsonNode json, final String name) {
         final JsonNode data = (JsonNode) JsonHelper.getElement(json, name);
         if (data != null) {
-            convertAndAdd(profile, name, JsonHelper.getElement(data, "data"));
+            convertAndAdd(profile, PROFILE_ATTRIBUTE, name, JsonHelper.getElement(data, "data"));
         }
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/foursquare/FoursquareProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/foursquare/FoursquareProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 
 /**
@@ -59,7 +61,7 @@ public class FoursquareProfileDefinition extends OAuth20ProfileDefinition<Foursq
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(user, "id")));
 
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(user, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(user, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericOAuth20ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/generic/GenericOAuth20ProfileDefinition.java
@@ -3,6 +3,9 @@ package org.pac4j.oauth.profile.generic;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import com.github.scribejava.core.model.Verb;
+
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -61,15 +64,15 @@ public class GenericOAuth20ProfileDefinition extends OAuth20ProfileDefinition<OA
                 profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, getProfileId())));
             }
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
             for (final String attribute : getSecondaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
             for (final Map.Entry<String, String> entry : getProfileAttributes().entrySet()) {
                 final String key = entry.getKey();
                 final String value = entry.getValue();
-                convertAndAdd(profile, key, JsonHelper.getElement(json, value));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, key, JsonHelper.getElement(json, value));
             }
 
         }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/github/GitHubProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/github/GitHubProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 
 /**
@@ -72,7 +74,7 @@ public class GitHubProfileDefinition extends OAuth20ProfileDefinition<GitHubProf
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
@@ -11,6 +11,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.List;
 
 /**
@@ -54,7 +56,7 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/linkedin2/LinkedIn2ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/linkedin2/LinkedIn2ProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -65,11 +67,12 @@ public class LinkedIn2ProfileDefinition extends OAuth20ProfileDefinition<LinkedI
         final JsonNode json = JsonHelper.getFirstNode(body);
         profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
         for (final String attribute : getPrimaryAttributes()) {
-            convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+            convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
         }
         final Object positions = JsonHelper.getElement(json, LinkedIn2ProfileDefinition.POSITIONS);
         if (positions != null && positions instanceof JsonNode) {
-            convertAndAdd(profile, LinkedIn2ProfileDefinition.POSITIONS, JsonHelper.getElement((JsonNode) positions, "values"));
+            convertAndAdd(profile, PROFILE_ATTRIBUTE, LinkedIn2ProfileDefinition.POSITIONS, JsonHelper.getElement((JsonNode) positions,
+                    "values"));
         }
         addUrl(profile, json, LinkedIn2ProfileDefinition.SITE_STANDARD_PROFILE_REQUEST);
         addUrl(profile, json, LinkedIn2ProfileDefinition.API_STANDARD_PROFILE_REQUEST);
@@ -78,6 +81,6 @@ public class LinkedIn2ProfileDefinition extends OAuth20ProfileDefinition<LinkedI
 
     private void addUrl(final LinkedIn2Profile profile, final JsonNode json, final String name) {
         final String url = (String) JsonHelper.getElement(json, name + ".url");
-        convertAndAdd(profile, name, url);
+        convertAndAdd(profile, PROFILE_ATTRIBUTE, name, url);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/ok/OkProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/ok/OkProfileDefinition.java
@@ -7,6 +7,8 @@ import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -85,7 +87,7 @@ public class OkProfileDefinition extends OAuth20ProfileDefinition<OkProfile, OkC
         if (userNode != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(userNode, OkProfileDefinition.UID)));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(userNode, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(userNode, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/orcid/OrcidProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/orcid/OrcidProfileDefinition.java
@@ -2,6 +2,9 @@ package org.pac4j.oauth.profile.orcid;
 
 import com.github.scribejava.core.exceptions.OAuthException;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.config.OAuth20Configuration;
@@ -47,7 +50,8 @@ public class OrcidProfileDefinition extends OAuth20ProfileDefinition<OrcidProfil
     public OrcidProfile extractUserProfile(String body) {
         OrcidProfile profile = newProfile();
         for(final String attribute : getPrimaryAttributes()) {
-            convertAndAdd(profile, attribute, CommonHelper.substringBetween(body, "<" + attribute + ">", "</" + attribute + ">"));
+            convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute,
+                    CommonHelper.substringBetween(body, "<" + attribute + ">", "</" + attribute + ">"));
         }
         return profile;
     }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/paypal/PayPalProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/paypal/PayPalProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 
 /**
@@ -45,7 +47,7 @@ public class PayPalProfileDefinition extends OAuth20ProfileDefinition<PayPalProf
             final String userId = (String) JsonHelper.getElement(json, "user_id");
             profile.setId(CommonHelper.substringAfter(userId, "/user/"));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/strava/StravaProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/strava/StravaProfileDefinition.java
@@ -10,6 +10,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -79,7 +81,7 @@ public class StravaProfileDefinition extends OAuth20ProfileDefinition<StravaProf
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, StravaProfileDefinition.ID)));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/twitter/TwitterProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/twitter/TwitterProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.oauth.config.OAuth10Configuration;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth10ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -86,7 +88,7 @@ public class TwitterProfileDefinition extends OAuth10ProfileDefinition<TwitterPr
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/vk/VkProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/vk/VkProfileDefinition.java
@@ -9,6 +9,8 @@ import org.pac4j.core.profile.converter.DateConverter;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 
 /**
@@ -75,7 +77,7 @@ public class VkProfileDefinition extends OAuth20ProfileDefinition<VkProfile, VkC
             JsonNode userNode = array.get(0);
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(userNode, "uid")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(userNode, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(userNode, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/windowslive/WindowsLiveProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/windowslive/WindowsLiveProfileDefinition.java
@@ -8,6 +8,8 @@ import org.pac4j.oauth.config.OAuth20Configuration;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 
 /**
@@ -42,7 +44,7 @@ public class WindowsLiveProfileDefinition extends OAuth20ProfileDefinition<Windo
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wordpress/WordPressProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wordpress/WordPressProfileDefinition.java
@@ -2,6 +2,9 @@ package org.pac4j.oauth.profile.wordpress;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.converter.Converters;
@@ -44,12 +47,12 @@ public class WordPressProfileDefinition extends OAuth20ProfileDefinition<WordPre
         if (json != null) {
             profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "ID")));
             for (final String attribute : getPrimaryAttributes()) {
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
             json = json.get("meta");
             if (json != null) {
                 final String attribute = WordPressProfileDefinition.LINKS;
-                convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }
         }
         return profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/yahoo/YahooProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/yahoo/YahooProfileDefinition.java
@@ -11,6 +11,8 @@ import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth10ProfileDefinition;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,7 +80,7 @@ public class YahooProfileDefinition extends OAuth10ProfileDefinition<YahooProfil
             if (json != null) {
                 profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "guid")));
                 for (final String attribute : getPrimaryAttributes()) {
-                    convertAndAdd(profile, attribute, JsonHelper.getElement(json, attribute));
+                    convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
                 }
             }
         }

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/OAuthProfileTests.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/OAuthProfileTests.java
@@ -41,10 +41,10 @@ public final class OAuthProfileTests implements TestsConstants {
         final GitHubProfile profile = new GitHubProfile();
         profile.setId(ID);
         final GitHubProfile profile2 =
-            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes());
+            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes(), null);
         assertEquals(ID, profile2.getId());
         final GitHubProfile profile3 =
-            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes());
+            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes(), null);
         assertEquals(ID, profile3.getId());
     }
 
@@ -54,13 +54,13 @@ public final class OAuthProfileTests implements TestsConstants {
         profile.setId(ID);
         profile.addAttribute(NAME, VALUE);
         final GitHubProfile profile2 =
-            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes());
+            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes(), null);
         assertEquals(ID, profile2.getId());
         final Map<String, Object> attributes = profile2.getAttributes();
         assertEquals(1, attributes.size());
         assertEquals(VALUE, attributes.get(NAME));
         final GitHubProfile profile3 =
-            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes());
+            (GitHubProfile) ProfileHelper.restoreOrBuildProfile(null, profile.getTypedId(), profile.getAttributes(), null);
         assertEquals(ID, profile3.getId());
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -35,6 +35,7 @@ import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Map;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
 /**
@@ -160,7 +161,7 @@ public class OidcProfileCreator<U extends OidcProfile> extends ProfileDefinition
                     } else {
                         userInfoClaimsSet = userInfoSuccessResponse.getUserInfoJWT().getJWTClaimsSet();
                     }
-                    getProfileDefinition().convertAndAdd(profile, userInfoClaimsSet.getClaims());
+                    getProfileDefinition().convertAndAdd(profile, userInfoClaimsSet.getClaims(), null);
                 }
             }
 
@@ -170,7 +171,7 @@ public class OidcProfileCreator<U extends OidcProfile> extends ProfileDefinition
                 final Object value = entry.getValue();
                 // it's not the subject and this attribute does not already exist, add it
                 if (!JwtClaims.SUBJECT.equals(key) && profile.getAttribute(key) == null) {
-                    getProfileDefinition().convertAndAdd(profile, key, value);
+                    getProfileDefinition().convertAndAdd(profile, PROFILE_ATTRIBUTE, key, value);
                 }
             }
 

--- a/pac4j-openid/src/main/java/org/pac4j/openid/credentials/authenticator/YahooAuthenticator.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/credentials/authenticator/YahooAuthenticator.java
@@ -1,5 +1,7 @@
 package org.pac4j.openid.credentials.authenticator;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import org.openid4java.OpenIDException;
 import org.openid4java.consumer.VerificationResult;
 import org.openid4java.discovery.DiscoveryInformation;
@@ -78,7 +80,7 @@ public class YahooAuthenticator implements Authenticator<OpenIdCredentials> {
         if (authSuccess.hasExtension(AxMessage.OPENID_NS_AX)) {
             final FetchResponse fetchResp = (FetchResponse) authSuccess.getExtension(AxMessage.OPENID_NS_AX);
             for (final String name : PROFILE_DEFINITION.getPrimaryAttributes()) {
-                PROFILE_DEFINITION.convertAndAdd(profile, name, fetchResp.getAttributeValue(name));
+                PROFILE_DEFINITION.convertAndAdd(profile, PROFILE_ATTRIBUTE, name, fetchResp.getAttributeValue(name));
             }
         }
         return profile;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -76,9 +78,9 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
             }
 
             if (!values.isEmpty()) {
-                getProfileDefinition().convertAndAdd(profile, name, values);
+                getProfileDefinition().convertAndAdd(profile, PROFILE_ATTRIBUTE, name, values);
                 if (CommonHelper.isNotBlank(friendlyName)) {
-                    getProfileDefinition().convertAndAdd(profile, friendlyName, values);
+                    getProfileDefinition().convertAndAdd(profile, PROFILE_ATTRIBUTE, friendlyName, values);
                 }
             } else {
                 logger.debug("No attribute values found for {}", name);


### PR DESCRIPTION
This is a pull request to solve issue #1103 for the master branch - port of changes from branch 2.2.x.
I have enhanced the ProfileHelper and the ProfileDefinition with a few new methods that support authentication attributes.
Existing methods, deprecated in 2.2.x and 2.3.x, were removed from 3.0.x. Calls from clients and unit tests were adapted.