### PR TITLE
Introduce specific saml exceptions - add UTC to date comparisons

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMAssertionSubjectException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMAssertionSubjectException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMAssertionSubjectException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMAssertionSubjectException extends SAMLException {
+    public SAMAssertionSubjectException(final String message) {
+        super(message);
+    }
+
+    public SAMAssertionSubjectException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMAssertionSubjectException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMAssertionSubjectException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMAssertionSubjectException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMAssertionSubjectException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMAssertionSubjectException extends SAMLException {
     public SAMAssertionSubjectException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionAudienceException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionAudienceException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLAssertionAudienceException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLAssertionAudienceException extends SAMLException {
+    public SAMLAssertionAudienceException(final String message) {
+        super(message);
+    }
+
+    public SAMLAssertionAudienceException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLAssertionAudienceException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionAudienceException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionAudienceException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLAssertionAudienceException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLAssertionAudienceException extends SAMLException {
     public SAMLAssertionAudienceException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionConditionException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionConditionException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLAssertionConditionException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLAssertionConditionException extends SAMLException {
+    public SAMLAssertionConditionException(final String message) {
+        super(message);
+    }
+
+    public SAMLAssertionConditionException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLAssertionConditionException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionConditionException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAssertionConditionException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLAssertionConditionException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLAssertionConditionException extends SAMLException {
     public SAMLAssertionConditionException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnInstantException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnInstantException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLAuthnInstantException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLAuthnInstantException extends SAMLException {
     public SAMLAuthnInstantException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnInstantException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnInstantException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLAuthnInstantException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLAuthnInstantException extends SAMLException {
+    public SAMLAuthnInstantException(final String message) {
+        super(message);
+    }
+
+    public SAMLAuthnInstantException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLAuthnInstantException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnSessionCriteriaException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnSessionCriteriaException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLAuthnSessionCriteriaException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLAuthnSessionCriteriaException extends SAMLException {
+    public SAMLAuthnSessionCriteriaException(final String message) {
+        super(message);
+    }
+
+    public SAMLAuthnSessionCriteriaException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLAuthnSessionCriteriaException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnSessionCriteriaException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnSessionCriteriaException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLAuthnSessionCriteriaException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLAuthnSessionCriteriaException extends SAMLException {
     public SAMLAuthnSessionCriteriaException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLEndpointMismatchException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLEndpointMismatchException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLEndpointMismatchException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLEndpointMismatchException extends SAMLException {
     public SAMLEndpointMismatchException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLEndpointMismatchException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLEndpointMismatchException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLEndpointMismatchException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLEndpointMismatchException extends SAMLException {
+    public SAMLEndpointMismatchException(final String message) {
+        super(message);
+    }
+
+    public SAMLEndpointMismatchException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLEndpointMismatchException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLInResponseToMismatchException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLInResponseToMismatchException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLInResponseToMismatchException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLInResponseToMismatchException extends SAMLException {
+    public SAMLInResponseToMismatchException(final String message) {
+        super(message);
+    }
+
+    public SAMLInResponseToMismatchException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLInResponseToMismatchException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLInResponseToMismatchException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLInResponseToMismatchException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLInResponseToMismatchException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLInResponseToMismatchException extends SAMLException {
     public SAMLInResponseToMismatchException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssueInstantException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssueInstantException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLIssueInstantException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLIssueInstantException extends SAMLException {
     public SAMLIssueInstantException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssueInstantException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssueInstantException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLIssueInstantException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLIssueInstantException extends SAMLException {
+    public SAMLIssueInstantException(final String message) {
+        super(message);
+    }
+
+    public SAMLIssueInstantException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLIssueInstantException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssuerException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssuerException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLIssuerException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLIssuerException extends SAMLException {
     public SAMLIssuerException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssuerException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLIssuerException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLIssuerException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLIssuerException extends SAMLException {
+    public SAMLIssuerException(final String message) {
+        super(message);
+    }
+
+    public SAMLIssuerException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLIssuerException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLNameIdDecryptionException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLNameIdDecryptionException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLNameIdDecryptionException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLNameIdDecryptionException extends SAMLException {
+    public SAMLNameIdDecryptionException(final String message) {
+        super(message);
+    }
+
+    public SAMLNameIdDecryptionException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLNameIdDecryptionException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLNameIdDecryptionException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLNameIdDecryptionException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLNameIdDecryptionException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLNameIdDecryptionException extends SAMLException {
     public SAMLNameIdDecryptionException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureRequiredException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureRequiredException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLSignatureRequiredException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLSignatureRequiredException extends SAMLException {
     public SAMLSignatureRequiredException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureRequiredException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureRequiredException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLSignatureRequiredException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLSignatureRequiredException extends SAMLException {
+    public SAMLSignatureRequiredException(final String message) {
+        super(message);
+    }
+
+    public SAMLSignatureRequiredException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLSignatureRequiredException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureValidationException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureValidationException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLSignatureValidationException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLSignatureValidationException extends SAMLException {
     public SAMLSignatureValidationException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureValidationException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSignatureValidationException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLSignatureValidationException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLSignatureValidationException extends SAMLException {
+    public SAMLSignatureValidationException(final String message) {
+        super(message);
+    }
+
+    public SAMLSignatureValidationException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLSignatureValidationException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSubjectConfirmationException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSubjectConfirmationException.java
@@ -1,0 +1,20 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLSubjectConfirmationException}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAMLSubjectConfirmationException extends SAMLException {
+    public SAMLSubjectConfirmationException(final String message) {
+        super(message);
+    }
+
+    public SAMLSubjectConfirmationException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLSubjectConfirmationException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSubjectConfirmationException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLSubjectConfirmationException.java
@@ -4,6 +4,7 @@ package org.pac4j.saml.exceptions;
  * This is {@link SAMLSubjectConfirmationException}.
  *
  * @author Misagh Moayyed
+ * @since 3.0.0
  */
 public class SAMLSubjectConfirmationException extends SAMLException {
     public SAMLSubjectConfirmationException(final String message) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.metadata;
 import net.shibboleth.utilities.java.support.xml.SerializeSupport;
 import org.apache.commons.lang.RandomStringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.core.xml.io.MarshallerFactory;
 import org.opensaml.saml.common.SAMLObjectBuilder;
@@ -96,7 +97,7 @@ public class SAML2MetadataGenerator implements SAMLMetadataGenerator {
 
         final EntityDescriptor descriptor = builder.buildObject();
         descriptor.setEntityID(this.entityId);
-        descriptor.setValidUntil(DateTime.now().plusYears(20));
+        descriptor.setValidUntil(DateTime.now(DateTimeZone.UTC).plusYears(20));
         descriptor.setID(generateEntityDescriptorId());
         descriptor.setExtensions(generateMetadataExtensions());
         descriptor.getRoleDescriptors().add(buildSPSSODescriptor());

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.sso.impl;
 
 import org.apache.commons.lang.RandomStringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.common.SAMLObjectBuilder;
@@ -101,7 +102,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
 
         request.setID(generateID());
         request.setIssuer(getIssuer(selfContext.getEntityId()));
-        request.setIssueInstant(DateTime.now().plusSeconds(this.issueInstantSkewSeconds));
+        request.setIssueInstant(DateTime.now(DateTimeZone.UTC).plusSeconds(this.issueInstantSkewSeconds));
         request.setVersion(SAMLVersion.VERSION_20);
         request.setIsPassive(this.passive);
         request.setForceAuthn(this.forceAuth);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -5,6 +5,7 @@ import net.shibboleth.utilities.java.support.net.BasicURLComparator;
 import net.shibboleth.utilities.java.support.net.URIComparator;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.common.SAMLObject;
@@ -49,7 +50,20 @@ import org.pac4j.core.credentials.Credentials;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.exceptions.SAMLAssertionAudienceException;
+import org.pac4j.saml.exceptions.SAMLAssertionConditionException;
+import org.pac4j.saml.exceptions.SAMLAuthnInstantException;
+import org.pac4j.saml.exceptions.SAMLAuthnSessionCriteriaException;
+import org.pac4j.saml.exceptions.SAMLEndpointMismatchException;
 import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.exceptions.SAMLInResponseToMismatchException;
+import org.pac4j.saml.exceptions.SAMLIssueInstantException;
+import org.pac4j.saml.exceptions.SAMLIssuerException;
+import org.pac4j.saml.exceptions.SAMLNameIdDecryptionException;
+import org.pac4j.saml.exceptions.SAMLSignatureRequiredException;
+import org.pac4j.saml.exceptions.SAMLSignatureValidationException;
+import org.pac4j.saml.exceptions.SAMAssertionSubjectException;
+import org.pac4j.saml.exceptions.SAMLSubjectConfirmationException;
 import org.pac4j.saml.sso.SAML2ResponseValidator;
 import org.pac4j.saml.storage.SAMLMessageStorage;
 import org.pac4j.saml.util.UriUtils;
@@ -70,11 +84,10 @@ import java.util.Set;
  *
  * @author Michael Remond
  * @since 1.5.0
- *
  */
 public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
-    private final static Logger logger = LoggerFactory.getLogger(SAML2DefaultResponseValidator.class);
+    private static final Logger logger = LoggerFactory.getLogger(SAML2DefaultResponseValidator.class);
 
     /**
      * The default maximum authentication lifetime, in seconds. Used for {@link #maximumAuthenticationLifetime} if a meaningless (&lt;=0)
@@ -152,7 +165,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         final String issuerEntityId = subjectAssertion.getIssuer().getValue();
         List<AuthnStatement> authnStatements = subjectAssertion.getAuthnStatements();
         List<String> authnContexts = new ArrayList<String>();
-        for(AuthnStatement authnStatement : authnStatements) {
+        for (AuthnStatement authnStatement : authnStatements) {
             authnContexts.add(authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef());
         }
 
@@ -198,14 +211,14 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
     /**
      * Validates the SAML protocol response:
-     *  - IssueInstant
-     *  - Issuer
-     *  - StatusCode
-     *  - Signature
+     * - IssueInstant
+     * - Issuer
+     * - StatusCode
+     * - Signature
      *
      * @param response the response
-     * @param context the context
-     * @param engine the engine
+     * @param context  the context
+     * @param engine   the engine
      */
     protected final void validateSamlProtocolResponse(final Response response, final SAML2MessageContext context,
                                                       final SignatureTrustEngine engine) {
@@ -225,7 +238,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         }
 
         if (!isIssueInstantValid(response.getIssueInstant())) {
-            throw new SAMLException("Response issue instant is too old or in the future");
+            throw new SAMLIssueInstantException("Response issue instant is too old or in the future");
         }
 
         AuthnRequest request = null;
@@ -233,12 +246,13 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         if (messageStorage != null && response.getInResponseTo() != null) {
             final XMLObject xmlObject = messageStorage.retrieveMessage(response.getInResponseTo());
             if (xmlObject == null) {
-                throw new SAMLException("InResponseToField of the Response doesn't correspond to sent message "
+                throw new SAMLInResponseToMismatchException("InResponseToField of the Response doesn't correspond to sent message "
                     + response.getInResponseTo());
             } else if (xmlObject instanceof AuthnRequest) {
                 request = (AuthnRequest) xmlObject;
             } else {
-                throw new SAMLException("Sent request was of different type than the expected AuthnRequest " + response.getInResponseTo());
+                throw new SAMLInResponseToMismatchException("Sent request was of different type than the expected AuthnRequest "
+                    + response.getInResponseTo());
             }
         }
 
@@ -271,12 +285,12 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
                 }
                 if (!requestedResponseURL.equals(responseLocation)) {
                     logger.warn("Response was received at a different endpoint URL {} than was requested {}",
-                            responseLocation, requestedResponseURL);
+                        responseLocation, requestedResponseURL);
                 }
             }
             if (requestedBinding != null && !requestedBinding.equals(context.getSAMLBindingContext().getBindingUri())) {
                 logger.warn("Response was received using a different binding {} than was requested {}",
-                        context.getSAMLBindingContext().getBindingUri(), requestedBinding);
+                    context.getSAMLBindingContext().getBindingUri(), requestedBinding);
             }
         }
     }
@@ -284,13 +298,13 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
     protected final void verifyEndpoint(final Endpoint endpoint, final String destination) {
         try {
             if (destination != null && !uriComparator.compare(destination, endpoint.getLocation())
-                    && !uriComparator.compare(destination, endpoint.getResponseLocation())) {
-                throw new SAMLException("Intended destination " + destination
-                        + " doesn't match any of the endpoint URLs on endpoint "
-                        + endpoint.getLocation());
+                && !uriComparator.compare(destination, endpoint.getResponseLocation())) {
+                throw new SAMLEndpointMismatchException("Intended destination " + destination
+                    + " doesn't match any of the endpoint URLs on endpoint "
+                    + endpoint.getLocation());
             }
         } catch (final Exception e) {
-            throw new SAMLException(e);
+            throw new SAMLEndpointMismatchException(e);
         }
     }
 
@@ -298,9 +312,9 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
      * Validates the SAML SSO response by finding a valid assertion with authn statements.
      * Populates the {@link SAML2MessageContext} with a subjectAssertion and a subjectNameIdentifier.
      *
-     * @param response the response
-     * @param context the context
-     * @param engine the engine
+     * @param response  the response
+     * @param context   the context
+     * @param engine    the engine
      * @param decrypter the decrypter
      */
     protected final void validateSamlSSOResponse(final Response response, final SAML2MessageContext context,
@@ -320,23 +334,23 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         }
 
         if (context.getSubjectAssertion() == null) {
-            throw new SAMLException("No valid subject assertion found in response");
+            throw new SAMAssertionSubjectException("No valid subject assertion found in response");
         }
 
         // We do not check EncryptedID here because it has been already decrypted and stored into NameID
         final List<SubjectConfirmation> subjectConfirmations = context.getSubjectConfirmations();
         final NameID nameIdentifier = (NameID) context.getSAMLSubjectNameIdentifierContext().getSubjectNameIdentifier();
         if ((nameIdentifier == null || nameIdentifier.getValue() == null) && context.getBaseID() == null
-                && (subjectConfirmations == null || subjectConfirmations.isEmpty())) {
+            && (subjectConfirmations == null || subjectConfirmations.isEmpty())) {
             throw new SAMLException(
-                    "Subject NameID, BaseID and EncryptedID cannot be all null at the same time if there are no Subject Confirmations.");
+                "Subject NameID, BaseID and EncryptedID cannot be all null at the same time if there are no Subject Confirmations.");
         }
     }
 
     /**
      * Decrypt encrypted assertions and add them to the assertions list of the response.
      *
-     * @param response the response
+     * @param response  the response
      * @param decrypter the decrypter
      */
     protected final void decryptEncryptedAssertions(final Response response, final Decrypter decrypter) {
@@ -355,39 +369,39 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
     /**
      * Validate issuer format and value.
      *
-     * @param issuer the issuer
+     * @param issuer  the issuer
      * @param context the context
      */
     protected final void validateIssuer(final Issuer issuer, final SAML2MessageContext context) {
         if (issuer.getFormat() != null && !issuer.getFormat().equals(NameIDType.ENTITY)) {
-            throw new SAMLException("Issuer type is not entity but " + issuer.getFormat());
+            throw new SAMLIssuerException("Issuer type is not entity but " + issuer.getFormat());
         }
 
         final String entityId = context.getSAMLPeerEntityContext().getEntityId();
         if (entityId == null || !entityId.equals(issuer.getValue())) {
-            throw new SAMLException("Issuer " + issuer.getValue() + " does not match idp entityId " + entityId);
+            throw new SAMLIssuerException("Issuer " + issuer.getValue() + " does not match idp entityId " + entityId);
         }
     }
 
     /**
      * Validate the given assertion:
-     *  - issueInstant
-     *  - issuer
-     *  - subject
-     *  - conditions
-     *  - authnStatements
-     *  - signature
+     * - issueInstant
+     * - issuer
+     * - subject
+     * - conditions
+     * - authnStatements
+     * - signature
      *
      * @param assertion the assertion
-     * @param context the context
-     * @param engine the engine
+     * @param context   the context
+     * @param engine    the engine
      * @param decrypter the decrypter
      */
     protected final void validateAssertion(final Assertion assertion, final SAML2MessageContext context,
                                            final SignatureTrustEngine engine, final Decrypter decrypter) {
 
         if (!isIssueInstantValid(assertion.getIssueInstant())) {
-            throw new SAMLException("Assertion issue instant is too old or in the future");
+            throw new SAMLIssueInstantException("Assertion issue instant is too old or in the future");
         }
 
         validateIssuer(assertion.getIssuer(), context);
@@ -395,7 +409,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         if (assertion.getSubject() != null) {
             validateSubject(assertion.getSubject(), context, decrypter);
         } else {
-            throw new SAMLException("Assertion subject cannot be null");
+            throw new SAMAssertionSubjectException("Assertion subject cannot be null");
         }
 
         validateAssertionConditions(assertion.getConditions(), context);
@@ -408,17 +422,14 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
     /**
      * Validate the given subject by finding a valid Bearer confirmation. If the subject is valid, put its nameID in the context.
-     *
+     * <p>
      * NameID / BaseID / EncryptedID is first looked up directly in the Subject. If not present there, then all relevant
      * SubjectConfirmations are parsed and the IDs are taken from them.
      *
-     * @param subject
-     *            The Subject from an assertion.
-     * @param context
-     *            SAML message context.
-     * @param decrypter
-     *            Decrypter used to decrypt some encrypted IDs, if they are present. May be {@code null}, no decryption will be possible
-     *            then.
+     * @param subject   The Subject from an assertion.
+     * @param context   SAML message context.
+     * @param decrypter Decrypter used to decrypt some encrypted IDs, if they are present.
+     *                  May be {@code null}, no decryption will be possible then.
      */
     @SuppressWarnings("unchecked")
     protected final void validateSubject(final Subject subject, final SAML2MessageContext context,
@@ -454,7 +465,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
                 // Encrypted ID can overwrite the non-encrypted one, if present
                 final NameID decryptedNameIdFromConfirmation = decryptEncryptedId(encryptedIDFromConfirmation,
-                        decrypter);
+                    decrypter);
                 if (decryptedNameIdFromConfirmation != null) {
                     nameIDFromConfirmation = decryptedNameIdFromConfirmation;
                 }
@@ -473,17 +484,15 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             }
         }
 
-        throw new SAMLException("Subject confirmation validation failed");
+        throw new SAMLSubjectConfirmationException("Subject confirmation validation failed");
     }
 
     /**
      * Decrypts an EncryptedID, using a decrypter.
      *
      * @param encryptedId The EncryptedID to be decrypted.
-     * @param decrypter The decrypter to use.
-     *
+     * @param decrypter   The decrypter to use.
      * @return Decrypted ID or {@code null} if any input is {@code null}.
-     *
      * @throws SAMLException If the input ID cannot be decrypted.
      */
     protected final NameID decryptEncryptedId(final EncryptedID encryptedId, final Decrypter decrypter) throws SAMLException {
@@ -499,17 +508,17 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             final NameID decryptedId = (NameID) decrypter.decrypt(encryptedId);
             return decryptedId;
         } catch (final DecryptionException e) {
-            throw new SAMLException("Decryption of an EncryptedID failed.", e);
+            throw new SAMLNameIdDecryptionException("Decryption of an EncryptedID failed.", e);
         }
     }
 
     /**
      * Validate Bearer subject confirmation data
-     *  - notBefore
-     *  - NotOnOrAfter
-     *  - recipient
+     * - notBefore
+     * - NotOnOrAfter
+     * - recipient
      *
-     * @param data the data
+     * @param data    the data
      * @param context the context
      * @return true if all Bearer subject checks are passing
      */
@@ -566,11 +575,11 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
 
     /**
      * Validate assertionConditions
-     *  - notBefore
-     *  - notOnOrAfter
+     * - notBefore
+     * - notOnOrAfter
      *
      * @param conditions the conditions
-     * @param context the context
+     * @param context    the context
      */
     protected final void validateAssertionConditions(final Conditions conditions, final SAML2MessageContext context) {
 
@@ -579,11 +588,11 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         }
 
         if (conditions.getNotBefore() != null && conditions.getNotBefore().minusSeconds(acceptedSkew).isAfterNow()) {
-            throw new SAMLException("Assertion condition notBefore is not valid");
+            throw new SAMLAssertionConditionException("Assertion condition notBefore is not valid");
         }
 
         if (conditions.getNotOnOrAfter() != null && conditions.getNotOnOrAfter().plusSeconds(acceptedSkew).isBeforeNow()) {
-            throw new SAMLException("Assertion condition notOnOrAfter is not valid");
+            throw new SAMLAssertionConditionException("Assertion condition notOnOrAfter is not valid");
         }
 
         final String entityId = context.getSAMLSelfEntityContext().getEntityId();
@@ -594,13 +603,13 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
      * Validate audience by matching the SP entityId.
      *
      * @param audienceRestrictions the audience restrictions
-     * @param spEntityId the sp entity id
+     * @param spEntityId           the sp entity id
      */
     protected final void validateAudienceRestrictions(final List<AudienceRestriction> audienceRestrictions,
                                                       final String spEntityId) {
 
         if (audienceRestrictions == null || audienceRestrictions.isEmpty()) {
-            throw new SAMLException("Audience restrictions cannot be null or empty");
+            throw new SAMLAssertionAudienceException("Audience restrictions cannot be null or empty");
         }
 
         final Set<String> audienceUris = new HashSet<String>();
@@ -612,28 +621,28 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             }
         }
         if (!audienceUris.contains(spEntityId)) {
-            throw new SAMLException("Assertion audience " + audienceUris + " does not match SP configuration "
-                    + spEntityId);
+            throw new SAMLAssertionAudienceException("Assertion audience " + audienceUris
+                + " does not match SP configuration " + spEntityId);
         }
     }
 
     /**
      * Validate the given authnStatements:
-     *  - authnInstant
-     *  - sessionNotOnOrAfter
+     * - authnInstant
+     * - sessionNotOnOrAfter
      *
      * @param authnStatements the authn statements
-     * @param context the context
+     * @param context         the context
      */
     protected final void validateAuthenticationStatements(final List<AuthnStatement> authnStatements,
                                                           final SAML2MessageContext context) {
 
         for (final AuthnStatement statement : authnStatements) {
             if (!isAuthnInstantValid(statement.getAuthnInstant())) {
-                throw new SAMLException("Authentication issue instant is too old or in the future");
+                throw new SAMLAuthnInstantException("Authentication issue instant is too old or in the future");
             }
             if (statement.getSessionNotOnOrAfter() != null && statement.getSessionNotOnOrAfter().isBeforeNow()) {
-                throw new SAMLException("Authentication session between IDP and subject has ended");
+                throw new SAMLAuthnSessionCriteriaException("Authentication session between IDP and subject has ended");
             }
             // TODO implement authnContext validation
         }
@@ -644,8 +653,8 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
      * the assertions to be signed, the validation fails.
      *
      * @param signature the signature
-     * @param context the context
-     * @param engine the engine
+     * @param context   the context
+     * @param engine    the engine
      */
     protected final void validateAssertionSignature(final Signature signature, final SAML2MessageContext context,
                                                     final SignatureTrustEngine engine) {
@@ -657,7 +666,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
             validateSignature(signature, entityId, engine);
         } else {
             if (wantsAssertionsSigned(context) && !peerContext.isAuthenticated()) {
-                throw new SAMLException("Assertion or response must be signed");
+                throw new SAMLSignatureRequiredException("Assertion or response must be signed");
             }
         }
     }
@@ -673,7 +682,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
     /**
      * Validate the given digital signature by checking its profile and value.
      *
-     * @param signature the signature
+     * @param signature   the signature
      * @param idpEntityId the idp entity id
      * @param trustEngine the trust engine
      */
@@ -684,7 +693,7 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         try {
             validator.validate(signature);
         } catch (final SignatureException e) {
-            throw new SAMLException("SAMLSignatureProfileValidator failed to validate signature", e);
+            throw new SAMLSignatureValidationException("SAMLSignatureProfileValidator failed to validate signature", e);
         }
 
         final CriteriaSet criteriaSet = new CriteriaSet();
@@ -696,20 +705,25 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         try {
             valid = trustEngine.validate(signature, criteriaSet);
         } catch (final SecurityException e) {
-            throw new SAMLException("An error occurred during signature validation", e);
+            throw new SAMLSignatureValidationException("An error occurred during signature validation", e);
         }
         if (!valid) {
-            throw new SAMLException("Signature is not trusted");
+            throw new SAMLSignatureValidationException("Signature is not trusted");
         }
     }
 
     private boolean isDateValid(final DateTime issueInstant, final int interval) {
-        final DateTime before =  DateTime.now().plusSeconds(acceptedSkew);
-        final DateTime after =  DateTime.now().minusSeconds(acceptedSkew + interval);
-        boolean isDateValid = issueInstant.isBefore(before) && issueInstant.isAfter(after);
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+
+        final DateTime before = now.plusSeconds(acceptedSkew);
+        final DateTime after = now.minusSeconds(acceptedSkew + interval);
+
+        final DateTime issueInstanceUtc = issueInstant.toDateTime(DateTimeZone.UTC);
+
+        final boolean isDateValid = issueInstanceUtc.isBefore(before) && issueInstanceUtc.isAfter(after);
         if (!isDateValid) {
-            logger.trace("interval={},before={},after={},issueInstant={}", interval, before.toDateTime(issueInstant.getZone()),
-                after.toDateTime(issueInstant.getZone()), issueInstant);
+            logger.trace("interval={},before={},after={},issueInstant={}", interval, before.toDateTime(issueInstanceUtc.getZone()),
+                after.toDateTime(issueInstanceUtc.getZone()), issueInstanceUtc);
         }
         return isDateValid;
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2LogoutRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2LogoutRequestBuilder.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.sso.impl;
 import java.util.Optional;
 import org.apache.commons.lang.RandomStringUtils;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.saml.common.SAMLObjectBuilder;
 import org.opensaml.saml.common.SAMLVersion;
@@ -66,7 +67,7 @@ public class SAML2LogoutRequestBuilder implements SAML2ObjectBuilder<LogoutReque
 
         request.setID(generateID());
         request.setIssuer(getIssuer(selfContext.getEntityId()));
-        request.setIssueInstant(DateTime.now().plusSeconds(this.issueInstantSkewSeconds));
+        request.setIssueInstant(DateTime.now(DateTimeZone.UTC).plusSeconds(this.issueInstantSkewSeconds));
         request.setVersion(SAMLVersion.VERSION_20);
         request.setDestination(ssoService.getLocation());
 


### PR DESCRIPTION
This pull requests:

- Tries to handle date comparisons based on a common timezone (UTC) when SAML responses are validated.
- Introduces specific exceptions for SAML validation events so that integrations can catch each event separately and re-act to it differently (UI, etc). 