### PR TITLE
Allow oidc configuration to indicate state predefined

### DIFF
--- a/documentation/docs/clients/openid-connect.md
+++ b/documentation/docs/clients/openid-connect.md
@@ -106,3 +106,10 @@ config.addCustomParam("display", "popup");
 // select prompt mode: none, consent, select_account
 config.addCustomParam("prompt", "none");
 ```
+
+Custom `state` values may be defined in the configuration using the below method
+
+```java
+config.setWithState(true);
+config.setStateData("custom-state-value");
+```

--- a/documentation/docs/clients/openid-connect.md
+++ b/documentation/docs/clients/openid-connect.md
@@ -107,7 +107,7 @@ config.addCustomParam("display", "popup");
 config.addCustomParam("prompt", "none");
 ```
 
-Custom `state` values may be defined in the configuration using the below method
+Custom `state` values may be defined in the configuration using the below method:
 
 ```java
 config.setWithState(true);

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -91,6 +91,10 @@ public class OidcConfiguration extends InitializableObject {
 
     private int readTimeout = HttpConstants.DEFAULT_READ_TIMEOUT;
 
+    private boolean withState;
+
+    private String stateData;
+
     @Override
     protected void internalInit() {
         // checks
@@ -293,6 +297,22 @@ public class OidcConfiguration extends InitializableObject {
         this.logoutUrl = logoutUrl;
     }
 
+    public boolean isWithState() {
+        return withState;
+    }
+
+    public void setWithState(final boolean withState) {
+        this.withState = withState;
+    }
+
+    public String getStateData() {
+        return stateData;
+    }
+
+    public void setStateData(final String stateData) {
+        this.stateData = stateData;
+    }
+    
     @Override
     public String toString() {
         return CommonHelper.toNiceString(this.getClass(), "clientId", clientId, "secret", "[protected]",
@@ -300,6 +320,7 @@ public class OidcConfiguration extends InitializableObject {
             "clientAuthenticationMethod", clientAuthenticationMethod, "useNonce", useNonce,
             "preferredJwsAlgorithm", preferredJwsAlgorithm, "maxAge", maxAge, "maxClockSkew", maxClockSkew,
             "connectTimeout", connectTimeout, "readTimeout", readTimeout, "resourceRetriever", resourceRetriever,
-            "responseType", responseType, "responseMode", responseMode, "logoutUrl", logoutUrl);
+            "responseType", responseType, "responseMode", responseMode, "logoutUrl", logoutUrl,
+            "withState", withState, "stateData", stateData);
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectActionBuilder.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectActionBuilder.java
@@ -85,12 +85,18 @@ public class OidcRedirectActionBuilder implements RedirectActionBuilder {
 
     protected void addStateAndNonceParameters(final WebContext context, final Map<String, String> params) {
         // Init state for CSRF mitigation
-        State state = new State();
-        params.put(OidcConfiguration.STATE, state.getValue());
-        context.getSessionStore().set(context, OidcConfiguration.STATE_SESSION_ATTRIBUTE, state);
+        final String stateData;
+        if (configuration.isWithState()) {
+            stateData = configuration.getStateData();
+        } else {
+            final State state = new State();
+            stateData = state.getValue();
+        }
+        params.put(OidcConfiguration.STATE, stateData);
+        context.getSessionStore().set(context, OidcConfiguration.STATE_SESSION_ATTRIBUTE, stateData);
         // Init nonce for replay attack mitigation
         if (configuration.isUseNonce()) {
-            Nonce nonce = new Nonce();
+            final Nonce nonce = new Nonce();
             params.put(OidcConfiguration.NONCE, nonce.getValue());
             context.getSessionStore().set(context, OidcConfiguration.NONCE_SESSION_ATTRIBUTE, nonce.getValue());
         }


### PR DESCRIPTION
Similar to the OAuth20Configuration, building the redirection url for OIDC client should have the ability to specify state where needed.