### PR TITLE
Allow CasClient to use custom parameters when building callback urls

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/client/CasClient.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/client/CasClient.java
@@ -4,12 +4,13 @@ import org.pac4j.cas.authorization.DefaultCasAuthorizationGenerator;
 import org.pac4j.cas.config.CasConfiguration;
 import org.pac4j.cas.credentials.authenticator.CasAuthenticator;
 import org.pac4j.cas.credentials.extractor.TicketAndLogoutRequestExtractor;
-import org.pac4j.core.logout.CasLogoutActionBuilder;
 import org.pac4j.cas.logout.CasLogoutHandler;
 import org.pac4j.cas.redirect.CasRedirectActionBuilder;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.TokenCredentials;
+import org.pac4j.core.http.callback.QueryParameterCallbackUrlResolver;
+import org.pac4j.core.logout.CasLogoutActionBuilder;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.util.CommonHelper;
 
@@ -44,6 +45,7 @@ public class CasClient extends IndirectClient<TokenCredentials, CommonProfile> {
     protected void clientInit() {
         CommonHelper.assertNotNull("configuration", configuration);
         configuration.setUrlResolver(this.getUrlResolver());
+        setCallbackUrlResolver(new QueryParameterCallbackUrlResolver(configuration.getCustomParams()));
 
         defaultRedirectActionBuilder(new CasRedirectActionBuilder(configuration, this));
         defaultCredentialsExtractor(new TicketAndLogoutRequestExtractor(configuration));

--- a/pac4j-cas/src/main/java/org/pac4j/cas/config/CasConfiguration.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/config/CasConfiguration.java
@@ -13,6 +13,8 @@ import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.InitializableObject;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * CAS configuration.
@@ -61,6 +63,9 @@ public class CasConfiguration extends InitializableObject {
     private UrlResolver urlResolver;
 
     private String postLogoutUrlParameter = SERVICE_PARAMETER;
+
+    /* Map containing user defined parameters */
+    private Map<String, String> customParams = new HashMap<>();
 
     public CasConfiguration() {}
 
@@ -237,6 +242,14 @@ public class CasConfiguration extends InitializableObject {
         this.prefixUrl = prefixUrl;
     }
 
+    public Map<String, String> getCustomParams() {
+        return customParams;
+    }
+
+    public void setCustomParams(final Map<String, String> customParams) {
+        this.customParams = customParams;
+    }
+    
     public long getTimeTolerance() {
         return timeTolerance;
     }
@@ -345,6 +358,10 @@ public class CasConfiguration extends InitializableObject {
         this.urlResolver = urlResolver;
     }
 
+    public void addCustomParam(final String name, final String value) {
+        this.customParams.put(name, value);
+    }
+    
     @Override
     public String toString() {
         return CommonHelper.toNiceString(this.getClass(), "loginUrl", this.loginUrl, "prefixUrl", this.prefixUrl, "restUrl", this.restUrl,

--- a/pac4j-core/src/main/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolver.java
@@ -5,6 +5,9 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.util.CommonHelper;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * The client name is added as a query parameter to the callback URL.
  *
@@ -12,14 +15,25 @@ import org.pac4j.core.util.CommonHelper;
  * @since 3.0.0
  */
 public class QueryParameterCallbackUrlResolver implements CallbackUrlResolver {
-
     private String clientNameParameter = Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER;
+
+    private Map<String, String> customParams = new HashMap<>();
+
+    public QueryParameterCallbackUrlResolver() {
+    }
+
+    public QueryParameterCallbackUrlResolver(final Map<String, String> customParams) {
+        this.customParams = customParams;
+    }
 
     @Override
     public String compute(final UrlResolver urlResolver, final String url, final String clientName, final WebContext context) {
         String newUrl = urlResolver.compute(url, context);
-        if (newUrl != null && !newUrl.contains(this.clientNameParameter + "=")) {
+        if (newUrl != null && !newUrl.contains(this.clientNameParameter + '=')) {
             newUrl = CommonHelper.addParameter(newUrl, this.clientNameParameter, clientName);
+        }
+        for (final Map.Entry<String, String> entry : this.customParams.entrySet()) {
+            newUrl = CommonHelper.addParameter(newUrl, entry.getKey(), entry.getValue());
         }
         return newUrl;
     }

--- a/pac4j-core/src/test/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolverTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolverTests.java
@@ -1,5 +1,6 @@
 package org.pac4j.core.http.callback;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.Pac4jConstants;
@@ -19,9 +20,16 @@ public final class QueryParameterCallbackUrlResolverTests implements TestsConsta
     private static final QueryParameterCallbackUrlResolver resolver = new QueryParameterCallbackUrlResolver();
 
     @Test
+    public void testParams() {
+        final String url = new QueryParameterCallbackUrlResolver(ImmutableMap.of("param1", "value", "param2", "value2"))
+            .compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());
+        assertEquals(CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER
+            + '=' + CLIENT_NAME + "&param1=value&param2=value2", url);
+    }
+    @Test
     public void testCompute() {
         final String url = resolver.compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());
-        assertEquals(CALLBACK_URL + "?" + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER + "=" + CLIENT_NAME, url);
+        assertEquals(CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER + '=' + CLIENT_NAME, url);
     }
 
     @Test
@@ -29,12 +37,12 @@ public final class QueryParameterCallbackUrlResolverTests implements TestsConsta
         final QueryParameterCallbackUrlResolver resolver = new QueryParameterCallbackUrlResolver();
         resolver.setClientNameParameter(KEY);
         final String url = resolver.compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());
-        assertEquals(CALLBACK_URL + "?" + KEY + "=" + CLIENT_NAME, url);
+        assertEquals(CALLBACK_URL +'?' + KEY + '=' + CLIENT_NAME, url);
     }
 
     @Test
     public void testComputeCallbackUrlAlreadyDefined() {
-        final String callbackUrl = CALLBACK_URL + "?" + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER + "=cn";
+        final String callbackUrl = CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER + "=cn";
         final String url = resolver.compute(new DefaultUrlResolver(), callbackUrl, CLIENT_NAME, MockWebContext.create());
         assertEquals(callbackUrl, url);
     }


### PR DESCRIPTION
Callback urls for CAS need to be customized in certain cases to include additional parameters that might convey "state" like values. Rather than building a new custom resolver, this PR allows the existing resolver to support custom parameters.