### PR TITLE
Add support for BaseClient custom properties

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
@@ -2,7 +2,9 @@ package org.pac4j.core.client;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.pac4j.core.authorization.generator.AuthorizationGenerator;
 import org.pac4j.core.context.WebContext;
@@ -49,6 +51,8 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
     private Authenticator<C> authenticator;
 
     private ProfileCreator<C, U> profileCreator = AuthenticatorProfileCreator.INSTANCE;
+
+    private Map<String, Object> customProperties = new LinkedHashMap<>();
 
     /**
      * Retrieve the credentials.
@@ -102,7 +106,7 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
      * Retrieve a user userprofile.
      *
      * @param credentials the credentials
-     * @param context the web context
+     * @param context     the web context
      * @return the user profile
      */
     protected final U retrieveUserProfile(final C credentials, final WebContext context) {
@@ -127,9 +131,10 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
      * Notify of the web session renewal.
      *
      * @param oldSessionId the old session identifier
-     * @param context the web context
+     * @param context      the web context
      */
-    public void notifySessionRenewal(final String oldSessionId, final WebContext context) { }
+    public void notifySessionRenewal(final String oldSessionId, final WebContext context) {
+    }
 
     public List<AuthorizationGenerator<U>> getAuthorizationGenerators() {
         return this.authorizationGenerators;
@@ -206,10 +211,18 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
         this.profileCreator = profileCreator;
     }
 
+    public Map<String, Object> getCustomProperties() {
+        return customProperties;
+    }
+
+    public void setCustomProperties(final Map<String, Object> customProperties) {
+        this.customProperties = customProperties;
+    }
+
     @Override
     public String toString() {
         return CommonHelper.toNiceString(this.getClass(), "name", getName(), "credentialsExtractor", this.credentialsExtractor,
-                "authenticator", this.authenticator, "profileCreator", this.profileCreator,
-                "authorizationGenerators", authorizationGenerators);
+            "authenticator", this.authenticator, "profileCreator", this.profileCreator,
+            "authorizationGenerators", authorizationGenerators, "customProperties", customProperties);
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
@@ -216,7 +216,8 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
     }
 
     public void setCustomProperties(final Map<String, Object> customProperties) {
-        this.customProperties = customProperties;
+        CommonHelper.assertNotNull("customProperties", customProperties);
+        this.customProperties =  customProperties;
     }
 
     @Override


### PR DESCRIPTION
During the bootstrapping and construction of a client, it would be useful to provide a "bag of properties" that one can use to attach settings to the client in order to determine behavior elsewhere. An example would be: *This client should automatically redirect to the provider when the view layer begins processing things, etc*
