### PR TITLE
Callback save in session default value (2.x)

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultCallbackLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultCallbackLogic.java
@@ -35,7 +35,7 @@ public class DefaultCallbackLogic<R, C extends WebContext> extends ProfileManage
 
     protected Logger logger = LoggerFactory.getLogger(getClass());
 
-    private boolean saveInSession = true;
+    private Boolean saveInSession;
 
     public Boolean getSaveInSession() {
         return saveInSession;
@@ -108,7 +108,15 @@ public class DefaultCallbackLogic<R, C extends WebContext> extends ProfileManage
                                    final boolean multiProfile, final boolean renewSession) {
         final ProfileManager manager = getProfileManager(context, config);
         if (profile != null) {
-            manager.save(this.saveInSession, profile, multiProfile);
+
+            final boolean saveInSession;
+            if (this.saveInSession == null) {
+                saveInSession = true;
+            } else {
+                saveInSession = this.saveInSession;
+            }
+
+            manager.save(saveInSession, profile, multiProfile);
             if (renewSession) {
                 renewSession(context, config);
             }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -84,8 +84,8 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
 
                 while (it.hasNext()) {
                     final EntityDescriptor entityDescriptor = it.next();
-                    if (SAML2IdentityProviderMetadataResolver.this.idpEntityId == null) {
-                        SAML2IdentityProviderMetadataResolver.this.idpEntityId = entityDescriptor.getEntityID();
+                    if (this.idpEntityId == null) {
+                        this.idpEntityId = entityDescriptor.getEntityID();
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.3</version>
+				<version>3.0.5</version>
 				<configuration>
 					<effort>Low</effort> <!-- Max -->
 					<threshold>Max</threshold> <!-- Medium Low -->
@@ -376,7 +376,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.6</version>
+				<version>3.8</version>
 				<configuration>
 					<includeTests>true</includeTests>
 					<printFailingErrors>true</printFailingErrors>


### PR DESCRIPTION
Hi,

I noticed a discrepancy in the way defaults where handled for the `saveInSession` parameter of `CallbackLogic`.

The way it was before this PR is that a NPE would be emitted if `null` was called as the parameter of `setSaveInSession` and thus it wasn't possible to set the default value like this.

I also updated pmd and findbugs dependencies because they are not working with latest versions of eclipse (I already made a PR that was merged for the master branch in the past).