### PR TITLE
Support for European e-identification (merging with 2.2.0)

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -112,7 +112,7 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
             credentials.setClientName(getName());
             return credentials;
         });
-        defaultAuthenticator(new SAML2Authenticator());
+        defaultAuthenticator(new SAML2Authenticator(this.configuration.getAttributeAsId()));
         defaultLogoutActionBuilder(new SAML2LogoutActionBuilder<>(this));
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -105,6 +105,8 @@ public class SAML2ClientConfiguration extends InitializableObject {
 
     private Supplier<List<XSAny>> authnRequestExtensions;
 
+    private String attributeAsId;
+
     public SAML2ClientConfiguration() {
     }
 
@@ -112,14 +114,14 @@ public class SAML2ClientConfiguration extends InitializableObject {
                                     final String identityProviderMetadataPath) {
         this(null, null, mapPathToResource(keystorePath), keystorePassword, privateKeyPassword,
             mapPathToResource(identityProviderMetadataPath), null, null,
-            DEFAULT_PROVIDER_NAME, null);
+            DEFAULT_PROVIDER_NAME, null, null);
     }
 
     public SAML2ClientConfiguration(final Resource keystoreResource, final String keystorePassword, final String privateKeyPassword,
                                     final Resource identityProviderMetadataResource) {
         this(null, null, keystoreResource, keystorePassword, privateKeyPassword,
             identityProviderMetadataResource, null, null,
-            DEFAULT_PROVIDER_NAME, null);
+            DEFAULT_PROVIDER_NAME, null, null);
     }
 
     public SAML2ClientConfiguration(final Resource keystoreResource, final String keyStoreAlias,
@@ -127,14 +129,15 @@ public class SAML2ClientConfiguration extends InitializableObject {
                                     final Resource identityProviderMetadataResource) {
         this(keyStoreAlias, keyStoreType, keystoreResource, keystorePassword,
             privateKeyPassword, identityProviderMetadataResource, null,
-            null, DEFAULT_PROVIDER_NAME, null);
+            null, DEFAULT_PROVIDER_NAME, null, null);
     }
 
     private SAML2ClientConfiguration(final String keyStoreAlias, final String keyStoreType,
                                      final Resource keystoreResource, final String keystorePassword,
                                      final String privateKeyPassword, final Resource identityProviderMetadataResource,
                                      final String identityProviderEntityId, final String serviceProviderEntityId,
-                                     final String providerName, final Supplier<List<XSAny>> authnRequestExtensions) {
+                                     final String providerName, final Supplier<List<XSAny>> authnRequestExtensions,
+                                     final String attributeAsId) {
         this.keyStoreAlias = keyStoreAlias;
         this.keyStoreType = keyStoreType;
         this.keystoreResource = keystoreResource;
@@ -145,6 +148,7 @@ public class SAML2ClientConfiguration extends InitializableObject {
         this.serviceProviderEntityId = serviceProviderEntityId;
         this.providerName = providerName;
         this.authnRequestExtensions = authnRequestExtensions;
+        this.attributeAsId = attributeAsId;
     }
 
     @Override
@@ -484,6 +488,14 @@ public class SAML2ClientConfiguration extends InitializableObject {
 
     public void setAuthnRequestExtensions(Supplier<List<XSAny>> authnRequestExtensions) {
         this.authnRequestExtensions = authnRequestExtensions;
+    }
+
+    public String getAttributeAsId() {
+        return attributeAsId;
+    }
+
+    public void setAttributeAsId(String attributeAsId) {
+        this.attributeAsId = attributeAsId;
     }
 
     /**

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -149,12 +149,27 @@ public class SAML2ClientConfiguration extends InitializableObject {
             }
         }
 
-        final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap.buildDefaultSignatureSigningConfiguration();
-        this.blackListedSignatureSigningAlgorithms = new ArrayList<>(config.getBlacklistedAlgorithms());
-        this.signatureAlgorithms = new ArrayList<>(config.getSignatureAlgorithms());
-        this.signatureReferenceDigestMethods = new ArrayList<>(config.getSignatureReferenceDigestMethods());
-        this.signatureReferenceDigestMethods.remove("http://www.w3.org/2001/04/xmlenc#sha512");
-        this.signatureCanonicalizationAlgorithm = config.getSignatureCanonicalizationAlgorithm();
+		// Bootstrap signature signing configuration if not manually set
+		final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap
+				.buildDefaultSignatureSigningConfiguration();
+		if (this.blackListedSignatureSigningAlgorithms == null) {
+			this.blackListedSignatureSigningAlgorithms = new ArrayList<>(
+					config.getBlacklistedAlgorithms());
+		}
+		if (this.signatureAlgorithms == null) {
+			this.signatureAlgorithms = new ArrayList<>(
+					config.getSignatureAlgorithms());
+		}
+		if (this.signatureReferenceDigestMethods == null) {
+			this.signatureReferenceDigestMethods = new ArrayList<>(
+					config.getSignatureReferenceDigestMethods());
+			this.signatureReferenceDigestMethods
+					.remove("http://www.w3.org/2001/04/xmlenc#sha512");
+		}
+		if (this.signatureCanonicalizationAlgorithm == null) {
+			this.signatureCanonicalizationAlgorithm = config
+					.getSignatureCanonicalizationAlgorithm();
+		}
     }
 
     public void setIdentityProviderMetadataResource(final Resource identityProviderMetadataResource) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.credentials.authenticator;
 
+import org.apache.commons.lang.StringUtils;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Conditions;
@@ -40,6 +41,13 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
+    private final String attributeAsId;
+
+    public SAML2Authenticator(String attributeAsId) {
+
+        this.attributeAsId = attributeAsId;
+    }
+
     protected void internalInit(final WebContext context) {
         defaultProfileDefinition(new CommonProfileDefinition<>(x -> new SAML2Profile()));
     }
@@ -69,7 +77,7 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
                 if (attributeValueElement != null) {
                     final String value = attributeValueElement.getTextContent();
                     logger.debug("Adding attribute value {} for attribute {} / {}", value,
-                            name, friendlyName);
+                        name, friendlyName);
                     values.add(value);
                 } else {
                     logger.warn("Attribute value DOM element is null for {}", attribute);
@@ -77,6 +85,15 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
             }
 
             if (!values.isEmpty()) {
+                if (StringUtils.isNotBlank(attributeAsId) && attributeAsId.equals(name)) {
+                    if (values.size() == 1) {
+                        profile.setId(values.get(0));
+                    } else {
+                        logger.warn("Will not add {} as id because it has multiple values: {}", attributeAsId, values);
+                    }
+                }
+
+
                 getProfileDefinition().convertAndAdd(profile, name, values);
                 if (CommonHelper.isNotBlank(friendlyName)) {
                     getProfileDefinition().convertAndAdd(profile, friendlyName, values);


### PR DESCRIPTION
Integration with the [European eId](https://ec.europa.eu/digital-single-market/en/e-identification), specifically with [Portuguese implementation](https://www.autenticacao.gov.pt/) that use the  SAML2 protocol

Changes include:
- [x] Allow to restrict signing algorithms to rsa-sha1 and sha1 (bug)
- [x] Support configuring the ProviderName (previously hardcoded to 'pac4j-saml')
- [x] Support defining AuthnRequest extensions (used to request specific attributes on each authentication request)
- [x] Guarding against a NPE when AuthContext is defined AuthContextClassRef child is not (this element is not mandatory on the SAML specification, and does not appear in the use case)
- [x] Adding support for setting a SAML attribute as the principal Id: this is necessary as the eId specification defines that the SAML NameId is not used to convey the user identification, an attribute is used instead (to note that many possible user identifications may be on the attributes, as the fiscal number or the social security number)