### PR TITLE
Support for European e-identification (merging with master)

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -110,7 +110,7 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
             final SAML2Credentials credentials = (SAML2Credentials) this.profileHandler.receive(samlContext);
             return credentials;
         });
-        defaultAuthenticator(new SAML2Authenticator());
+        defaultAuthenticator(new SAML2Authenticator(this.configuration.getAttributeAsId()));
         defaultLogoutActionBuilder(new SAML2LogoutActionBuilder<>(this));
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -162,12 +162,27 @@ public class SAML2ClientConfiguration extends InitializableObject {
             }
         }
 
-        final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap.buildDefaultSignatureSigningConfiguration();
-        this.blackListedSignatureSigningAlgorithms = new ArrayList<>(config.getBlacklistedAlgorithms());
-        this.signatureAlgorithms = new ArrayList<>(config.getSignatureAlgorithms());
-        this.signatureReferenceDigestMethods = new ArrayList<>(config.getSignatureReferenceDigestMethods());
-        this.signatureReferenceDigestMethods.remove("http://www.w3.org/2001/04/xmlenc#sha512");
-        this.signatureCanonicalizationAlgorithm = config.getSignatureCanonicalizationAlgorithm();
+		// Bootstrap signature signing configuration if not manually set
+		final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap
+				.buildDefaultSignatureSigningConfiguration();
+		if (this.blackListedSignatureSigningAlgorithms == null) {
+			this.blackListedSignatureSigningAlgorithms = new ArrayList<>(
+					config.getBlacklistedAlgorithms());
+		}
+		if (this.signatureAlgorithms == null) {
+			this.signatureAlgorithms = new ArrayList<>(
+					config.getSignatureAlgorithms());
+		}
+		if (this.signatureReferenceDigestMethods == null) {
+			this.signatureReferenceDigestMethods = new ArrayList<>(
+					config.getSignatureReferenceDigestMethods());
+			this.signatureReferenceDigestMethods
+					.remove("http://www.w3.org/2001/04/xmlenc#sha512");
+		}
+		if (this.signatureCanonicalizationAlgorithm == null) {
+			this.signatureCanonicalizationAlgorithm = config
+					.getSignatureCanonicalizationAlgorithm();
+		}
     }
 
     public void setIdentityProviderMetadataResource(final Resource identityProviderMetadataResource) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -118,6 +118,8 @@ public class SAML2ClientConfiguration extends InitializableObject {
 
     private Supplier<List<XSAny>> authnRequestExtensions;
 
+    private String attributeAsId;
+
     public SAML2ClientConfiguration() {
     }
 
@@ -125,14 +127,14 @@ public class SAML2ClientConfiguration extends InitializableObject {
                                     final String identityProviderMetadataPath) {
         this(null, null, mapPathToResource(keystorePath), keystorePassword, privateKeyPassword,
             mapPathToResource(identityProviderMetadataPath), null, null,
-            DEFAULT_PROVIDER_NAME, null);
+            DEFAULT_PROVIDER_NAME, null, null);
     }
 
     public SAML2ClientConfiguration(final Resource keystoreResource, final String keystorePassword, final String privateKeyPassword,
                                     final Resource identityProviderMetadataResource) {
         this(null, null, keystoreResource, keystorePassword, privateKeyPassword,
             identityProviderMetadataResource, null, null,
-            DEFAULT_PROVIDER_NAME, null);
+            DEFAULT_PROVIDER_NAME, null, null);
     }
 
     public SAML2ClientConfiguration(final Resource keystoreResource, final String keyStoreAlias,
@@ -140,14 +142,15 @@ public class SAML2ClientConfiguration extends InitializableObject {
                                     final Resource identityProviderMetadataResource) {
         this(keyStoreAlias, keyStoreType, keystoreResource, keystorePassword,
             privateKeyPassword, identityProviderMetadataResource, null,
-            null, DEFAULT_PROVIDER_NAME, null);
+            null, DEFAULT_PROVIDER_NAME, null, null);
     }
 
     private SAML2ClientConfiguration(final String keyStoreAlias, final String keyStoreType,
                                      final Resource keystoreResource, final String keystorePassword,
                                      final String privateKeyPassword, final Resource identityProviderMetadataResource,
                                      final String identityProviderEntityId, final String serviceProviderEntityId,
-                                     final String providerName, final Supplier<List<XSAny>> authnRequestExtensions) {
+                                     final String providerName, final Supplier<List<XSAny>> authnRequestExtensions,
+                                     final String attributeAsId) {
         this.keyStoreAlias = keyStoreAlias;
         this.keyStoreType = keyStoreType;
         this.keystoreResource = keystoreResource;
@@ -158,6 +161,7 @@ public class SAML2ClientConfiguration extends InitializableObject {
         this.serviceProviderEntityId = serviceProviderEntityId;
         this.providerName = providerName;
         this.authnRequestExtensions = authnRequestExtensions;
+        this.attributeAsId = attributeAsId;
     }
 
     @Override
@@ -493,6 +497,14 @@ public class SAML2ClientConfiguration extends InitializableObject {
 
     public void setAuthnRequestExtensions(Supplier<List<XSAny>> authnRequestExtensions) {
         this.authnRequestExtensions = authnRequestExtensions;
+    }
+
+    public String getAttributeAsId() {
+        return attributeAsId;
+    }
+
+    public void setAttributeAsId(String attributeAsId) {
+        this.attributeAsId = attributeAsId;
     }
 
     /**

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -180,31 +180,7 @@ public class SAML2ClientConfiguration extends InitializableObject {
             }
         }
 
-        // Bootstrap signature signing configuration if not manually set
-        final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap
-            .buildDefaultSignatureSigningConfiguration();
-        if (this.blackListedSignatureSigningAlgorithms == null) {
-            this.blackListedSignatureSigningAlgorithms = new ArrayList<>(
-                config.getBlacklistedAlgorithms());
-            LOGGER.info("Bootstrapped Blacklisted Algorithms");
-        }
-        if (this.signatureAlgorithms == null) {
-            this.signatureAlgorithms = new ArrayList<>(
-                config.getSignatureAlgorithms());
-            LOGGER.info("Bootstrapped Signature Algorithms");
-        }
-        if (this.signatureReferenceDigestMethods == null) {
-            this.signatureReferenceDigestMethods = new ArrayList<>(
-                config.getSignatureReferenceDigestMethods());
-            this.signatureReferenceDigestMethods
-                .remove("http://www.w3.org/2001/04/xmlenc#sha512");
-            LOGGER.info("Bootstrapped Signature Reference Digest Methods");
-        }
-        if (this.signatureCanonicalizationAlgorithm == null) {
-            this.signatureCanonicalizationAlgorithm = config
-                .getSignatureCanonicalizationAlgorithm();
-            LOGGER.info("Bootstrapped Canonicalization Algorithm");
-        }
+        initSignatureSigningConfiguration();
     }
 
     public void setIdentityProviderMetadataResource(final Resource identityProviderMetadataResource) {
@@ -608,6 +584,34 @@ public class SAML2ClientConfiguration extends InitializableObject {
                 ks.aliases().nextElement());
         } catch (final Exception e) {
             throw new SAMLException("Could not create keystore", e);
+        }
+    }
+
+    private void initSignatureSigningConfiguration() {
+        // Bootstrap signature signing configuration if not manually set
+        final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap
+            .buildDefaultSignatureSigningConfiguration();
+        if (this.blackListedSignatureSigningAlgorithms == null) {
+            this.blackListedSignatureSigningAlgorithms = new ArrayList<>(
+                config.getBlacklistedAlgorithms());
+            LOGGER.info("Bootstrapped Blacklisted Algorithms");
+        }
+        if (this.signatureAlgorithms == null) {
+            this.signatureAlgorithms = new ArrayList<>(
+                config.getSignatureAlgorithms());
+            LOGGER.info("Bootstrapped Signature Algorithms");
+        }
+        if (this.signatureReferenceDigestMethods == null) {
+            this.signatureReferenceDigestMethods = new ArrayList<>(
+                config.getSignatureReferenceDigestMethods());
+            this.signatureReferenceDigestMethods
+                .remove("http://www.w3.org/2001/04/xmlenc#sha512");
+            LOGGER.info("Bootstrapped Signature Reference Digest Methods");
+        }
+        if (this.signatureCanonicalizationAlgorithm == null) {
+            this.signatureCanonicalizationAlgorithm = config
+                .getSignatureCanonicalizationAlgorithm();
+            LOGGER.info("Bootstrapped Canonicalization Algorithm");
         }
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -18,6 +18,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Encoding;
@@ -32,6 +33,7 @@ import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x509.TBSCertificate;
 import org.bouncycastle.asn1.x509.Time;
 import org.bouncycastle.asn1.x509.V3TBSCertificateGenerator;
+import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
@@ -63,6 +65,7 @@ public class SAML2ClientConfiguration extends InitializableObject {
     protected static final String RESOURCE_PREFIX = "resource:";
     protected static final String CLASSPATH_PREFIX = "classpath:";
     protected static final String FILE_PREFIX = "file:";
+    protected static final String DEFAULT_PROVIDER_NAME = "pac4j-saml";
 
     private Resource keystoreResource;
 
@@ -111,31 +114,40 @@ public class SAML2ClientConfiguration extends InitializableObject {
 
     private int attributeConsumingServiceIndex = -1;
 
-    public SAML2ClientConfiguration() {}
+    private String providerName;
+
+    private Supplier<List<XSAny>> authnRequestExtensions;
+
+    public SAML2ClientConfiguration() {
+    }
 
     public SAML2ClientConfiguration(final String keystorePath, final String keystorePassword, final String privateKeyPassword,
                                     final String identityProviderMetadataPath) {
         this(null, null, mapPathToResource(keystorePath), keystorePassword, privateKeyPassword,
-                mapPathToResource(identityProviderMetadataPath), null, null);
+            mapPathToResource(identityProviderMetadataPath), null, null,
+            DEFAULT_PROVIDER_NAME, null);
     }
 
     public SAML2ClientConfiguration(final Resource keystoreResource, final String keystorePassword, final String privateKeyPassword,
                                     final Resource identityProviderMetadataResource) {
         this(null, null, keystoreResource, keystorePassword, privateKeyPassword,
-                identityProviderMetadataResource, null, null);
+            identityProviderMetadataResource, null, null,
+            DEFAULT_PROVIDER_NAME, null);
     }
 
     public SAML2ClientConfiguration(final Resource keystoreResource, final String keyStoreAlias,
                                     final String keyStoreType, final String keystorePassword, final String privateKeyPassword,
                                     final Resource identityProviderMetadataResource) {
-        this(keyStoreAlias, keyStoreType, keystoreResource, keystorePassword, privateKeyPassword,
-                identityProviderMetadataResource, null, null);
+        this(keyStoreAlias, keyStoreType, keystoreResource, keystorePassword,
+            privateKeyPassword, identityProviderMetadataResource, null,
+            null, DEFAULT_PROVIDER_NAME, null);
     }
 
     private SAML2ClientConfiguration(final String keyStoreAlias, final String keyStoreType,
                                      final Resource keystoreResource, final String keystorePassword,
                                      final String privateKeyPassword, final Resource identityProviderMetadataResource,
-                                     final String identityProviderEntityId, final String serviceProviderEntityId) {
+                                     final String identityProviderEntityId, final String serviceProviderEntityId,
+                                     final String providerName, final Supplier<List<XSAny>> authnRequestExtensions) {
         this.keyStoreAlias = keyStoreAlias;
         this.keyStoreType = keyStoreType;
         this.keystoreResource = keystoreResource;
@@ -144,6 +156,8 @@ public class SAML2ClientConfiguration extends InitializableObject {
         this.identityProviderMetadataResource = identityProviderMetadataResource;
         this.identityProviderEntityId = identityProviderEntityId;
         this.serviceProviderEntityId = serviceProviderEntityId;
+        this.providerName = providerName;
+        this.authnRequestExtensions = authnRequestExtensions;
     }
 
     @Override
@@ -162,27 +176,31 @@ public class SAML2ClientConfiguration extends InitializableObject {
             }
         }
 
-		// Bootstrap signature signing configuration if not manually set
-		final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap
-				.buildDefaultSignatureSigningConfiguration();
-		if (this.blackListedSignatureSigningAlgorithms == null) {
-			this.blackListedSignatureSigningAlgorithms = new ArrayList<>(
-					config.getBlacklistedAlgorithms());
-		}
-		if (this.signatureAlgorithms == null) {
-			this.signatureAlgorithms = new ArrayList<>(
-					config.getSignatureAlgorithms());
-		}
-		if (this.signatureReferenceDigestMethods == null) {
-			this.signatureReferenceDigestMethods = new ArrayList<>(
-					config.getSignatureReferenceDigestMethods());
-			this.signatureReferenceDigestMethods
-					.remove("http://www.w3.org/2001/04/xmlenc#sha512");
-		}
-		if (this.signatureCanonicalizationAlgorithm == null) {
-			this.signatureCanonicalizationAlgorithm = config
-					.getSignatureCanonicalizationAlgorithm();
-		}
+        // Bootstrap signature signing configuration if not manually set
+        final BasicSignatureSigningConfiguration config = DefaultSecurityConfigurationBootstrap
+            .buildDefaultSignatureSigningConfiguration();
+        if (this.blackListedSignatureSigningAlgorithms == null) {
+            this.blackListedSignatureSigningAlgorithms = new ArrayList<>(
+                config.getBlacklistedAlgorithms());
+            LOGGER.info("Bootstrapped Blacklisted Algorithms");
+        }
+        if (this.signatureAlgorithms == null) {
+            this.signatureAlgorithms = new ArrayList<>(
+                config.getSignatureAlgorithms());
+            LOGGER.info("Bootstrapped Signature Algorithms");
+        }
+        if (this.signatureReferenceDigestMethods == null) {
+            this.signatureReferenceDigestMethods = new ArrayList<>(
+                config.getSignatureReferenceDigestMethods());
+            this.signatureReferenceDigestMethods
+                .remove("http://www.w3.org/2001/04/xmlenc#sha512");
+            LOGGER.info("Bootstrapped Signature Reference Digest Methods");
+        }
+        if (this.signatureCanonicalizationAlgorithm == null) {
+            this.signatureCanonicalizationAlgorithm = config
+                .getSignatureCanonicalizationAlgorithm();
+            LOGGER.info("Bootstrapped Canonicalization Algorithm");
+        }
     }
 
     public void setIdentityProviderMetadataResource(final Resource identityProviderMetadataResource) {
@@ -461,6 +479,22 @@ public class SAML2ClientConfiguration extends InitializableObject {
         this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
     }
 
+    public String getProviderName() {
+        return providerName;
+    }
+
+    public void setProviderName(String providerName) {
+        this.providerName = providerName;
+    }
+
+    public Supplier<List<XSAny>> getAuthnRequestExtensions() {
+        return authnRequestExtensions;
+    }
+
+    public void setAuthnRequestExtensions(Supplier<List<XSAny>> authnRequestExtensions) {
+        this.authnRequestExtensions = authnRequestExtensions;
+    }
+
     /**
      * Initializes the configuration for a particular client.
      *
@@ -558,8 +592,8 @@ public class SAML2ClientConfiguration extends InitializableObject {
             }
 
             LOGGER.info("Created keystore {} with key alias {} ",
-                    keystoreResource.getFile().getCanonicalPath(),
-                    ks.aliases().nextElement());
+                keystoreResource.getFile().getCanonicalPath(),
+                ks.aliases().nextElement());
         } catch (final Exception e) {
             throw new SAMLException("Could not create keystore", e);
         }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.credentials.authenticator;
 
+import org.apache.commons.lang.StringUtils;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Conditions;
@@ -40,6 +41,13 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
+    private final String attributeAsId;
+
+    public SAML2Authenticator(String attributeAsId) {
+
+        this.attributeAsId = attributeAsId;
+    }
+
     @Override
     protected void internalInit() {
         defaultProfileDefinition(new CommonProfileDefinition<>(x -> new SAML2Profile()));
@@ -70,7 +78,7 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
                 if (attributeValueElement != null) {
                     final String value = attributeValueElement.getTextContent();
                     logger.debug("Adding attribute value {} for attribute {} / {}", value,
-                            name, friendlyName);
+                        name, friendlyName);
                     values.add(value);
                 } else {
                     logger.warn("Attribute value DOM element is null for {}", attribute);
@@ -78,6 +86,13 @@ public class SAML2Authenticator extends ProfileDefinitionAware<SAML2Profile> imp
             }
 
             if (!values.isEmpty()) {
+                if (StringUtils.isNotBlank(attributeAsId) && attributeAsId.equals(name)) {
+                    if (values.size() == 1) {
+                        profile.setId(values.get(0));
+                    } else {
+                        logger.warn("Will not add {} as id because it has multiple values: {}", attributeAsId, values);
+                    }
+                }
                 getProfileDefinition().convertAndAdd(profile, PROFILE_ATTRIBUTE, name, values);
                 if (CommonHelper.isNotBlank(friendlyName)) {
                     getProfileDefinition().convertAndAdd(profile, PROFILE_ATTRIBUTE, friendlyName, values);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -1,10 +1,14 @@
 
 package org.pac4j.saml.sso.impl;
 
+import java.util.List;
+import java.util.function.Supplier;
+
 import org.apache.commons.lang.RandomStringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
+import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.common.SAMLObjectBuilder;
 import org.opensaml.saml.common.SAMLVersion;
@@ -13,6 +17,7 @@ import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.Extensions;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.NameIDPolicy;
 import org.opensaml.saml.saml2.core.RequestedAuthnContext;
@@ -52,6 +57,10 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
 
     private final int assertionConsumerServiceIndex;
 
+    private final String providerName;
+
+    private final Supplier<List<XSAny>> extensions;
+
     private final XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
 
     /**
@@ -68,6 +77,8 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         this.passive = cfg.isPassive();
         this.attributeConsumingServiceIndex = cfg.getAttributeConsumingServiceIndex();
         this.assertionConsumerServiceIndex = cfg.getAssertionConsumerServiceIndex();
+        this.providerName = cfg.getProviderName();
+        this.extensions = cfg.getAuthnRequestExtensions();
     }
 
     @Override
@@ -106,7 +117,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         request.setVersion(SAMLVersion.VERSION_20);
         request.setIsPassive(this.passive);
         request.setForceAuthn(this.forceAuth);
-        request.setProviderName("pac4j-saml");
+        request.setProviderName(this.providerName);
 
         if (nameIdPolicyFormat != null) {
             final NameIDPolicy nameIdPolicy = new NameIDPolicyBuilder().buildObject();
@@ -126,6 +137,15 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         if (attributeConsumingServiceIndex >= 0) {
             request.setAttributeConsumingServiceIndex(attributeConsumingServiceIndex);
         }
+
+        // Setting extensions if they are defined
+        if (extensions != null) {
+            Extensions extensionsElem = ((SAMLObjectBuilder<Extensions>) this.builderFactory
+                .getBuilder(Extensions.DEFAULT_ELEMENT_NAME)).buildObject();
+            extensionsElem.getUnknownXMLObjects().addAll(extensions.get());
+            request.setExtensions(extensionsElem);
+        }
+
         return request;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidator.java
@@ -166,7 +166,9 @@ public class SAML2DefaultResponseValidator implements SAML2ResponseValidator {
         List<AuthnStatement> authnStatements = subjectAssertion.getAuthnStatements();
         List<String> authnContexts = new ArrayList<String>();
         for (AuthnStatement authnStatement : authnStatements) {
-            authnContexts.add(authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef());
+            if(authnStatement.getAuthnContext().getAuthnContextClassRef() != null) {
+                authnContexts.add(authnStatement.getAuthnContext().getAuthnContextClassRef().getAuthnContextClassRef());
+            }
         }
 
 


### PR DESCRIPTION
Integration with the [European eId](https://ec.europa.eu/digital-single-market/en/e-identification), specifically with [Portuguese implementation](https://www.autenticacao.gov.pt/) that use the  SAML2 protocol

Changes include:
- [x] Allow to restrict signing algorithms to rsa-sha1 and sha1 (bug)
- [x] Support configuring the ProviderName (previously hardcoded to 'pac4j-saml')
- [x] Support defining AuthnRequest extensions (used to request specific attributes on each authentication request)
- [x] Guarding against a NPE when AuthContext is defined AuthContextClassRef child is not (this element is not mandatory on the SAML specification, and does not appear in the use case)
- [x] Adding support for setting a SAML attribute as the principal Id: this is necessary as the eId specification defines that the SAML NameId is not used to convey the user identification, an attribute is used instead (to note that many possible user identifications may be on the attributes, as the fiscal number or the social security number)