### PR TITLE
Add twitter include_email support

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/TwitterClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/TwitterClient.java
@@ -13,6 +13,8 @@ import org.pac4j.oauth.profile.twitter.TwitterProfileDefinition;
  * <p>This class is the OAuth client to authenticate users in Twitter.</p>
  * <p>You can define if a screen should always been displayed for authorization confirmation by using the
  * {@link #setAlwaysConfirmAuthorization(boolean)} method (<code>false</code> by default).</p>
+ * <p>If your twitter oauth app allows requests for email addresses you can enable requesting an email
+ * address by using the {@link #setIncludeEmail(boolean)} method (<code>false</code> by default).</p>
  * <p>It returns a {@link org.pac4j.oauth.profile.twitter.TwitterProfile}.</p>
  * <p>More information at https://dev.twitter.com/docs/api/1/get/account/verify_credentials</p>
  *
@@ -23,17 +25,24 @@ public class TwitterClient extends OAuth10Client<TwitterProfile> {
 
     private boolean alwaysConfirmAuthorization = false;
 
+    private boolean includeEmail = false;
+
     public TwitterClient() {}
 
     public TwitterClient(final String key, final String secret) {
+        this(key, secret, false);
+    }
+
+    public TwitterClient(final String key, final String secret, boolean includeEmail) {
         setKey(key);
         setSecret(secret);
+        this.includeEmail = includeEmail;
     }
 
     @Override
     protected void clientInit() {
         configuration.setApi(getApi());
-        configuration.setProfileDefinition(new TwitterProfileDefinition());
+        configuration.setProfileDefinition(new TwitterProfileDefinition(includeEmail));
         configuration.setHasBeenCancelledFactory(ctx -> {
             final String denied = ctx.getRequestParameter("denied");
             if (CommonHelper.isNotBlank(denied)) {
@@ -63,5 +72,13 @@ public class TwitterClient extends OAuth10Client<TwitterProfile> {
 
     public void setAlwaysConfirmAuthorization(final boolean alwaysConfirmAuthorization) {
         this.alwaysConfirmAuthorization = alwaysConfirmAuthorization;
+    }
+
+    public boolean isIncludeEmail() {
+        return includeEmail;
+    }
+
+    public void setIncludeEmail(final boolean includeEmail) {
+        this.includeEmail = includeEmail;
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/twitter/TwitterProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/twitter/TwitterProfileDefinition.java
@@ -27,6 +27,7 @@ public class TwitterProfileDefinition extends OAuth10ProfileDefinition<TwitterPr
     public static final String DEFAULT_PROFILE = "default_profile";
     public static final String DEFAULT_PROFILE_IMAGE = "default_profile_image";
     public static final String DESCRIPTION = "description";
+    public static final String EMAIL = "email";
     public static final String FAVOURITES_COUNT = "favourites_count";
     public static final String FOLLOW_REQUEST_SENT = "follow_request_sent";
     public static final String FOLLOWERS_COUNT = "followers_count";
@@ -58,9 +59,17 @@ public class TwitterProfileDefinition extends OAuth10ProfileDefinition<TwitterPr
     public static final String UTC_OFFSET = "utc_offset";
     public static final String VERIFIED = "verified";
 
+    private static final String VERIFY_CREDENTIALS_URL = "https://api.twitter.com/1.1/account/verify_credentials.json";
+
+    private final boolean includeEmail;
+
     public TwitterProfileDefinition() {
+        this(false);
+    }
+
+    public TwitterProfileDefinition(boolean includeEmail) {
         super(x -> new TwitterProfile());
-        Arrays.stream(new String[] {DESCRIPTION, NAME, SCREEN_NAME, TIME_ZONE})
+        Arrays.stream(new String[] {DESCRIPTION, EMAIL, NAME, SCREEN_NAME, TIME_ZONE})
                 .forEach(a -> primary(a, Converters.STRING));
         Arrays.stream(new String[] {CONTRIBUTORS_ENABLED, DEFAULT_PROFILE, DEFAULT_PROFILE_IMAGE, FOLLOW_REQUEST_SENT, FOLLOWING,
                 GEO_ENABLED, IS_TRANSLATOR, NOTIFICATIONS, PROFILE_USE_BACKGROUND_IMAGE, PROTECTED, SHOW_ALL_INLINE_MEDIA,
@@ -74,11 +83,17 @@ public class TwitterProfileDefinition extends OAuth10ProfileDefinition<TwitterPr
                 PROFILE_SIDEBAR_FILL_COLOR, PROFILE_TEXT_COLOR}).forEach(a -> primary(a, Converters.COLOR));
         primary(LANG, Converters.LOCALE);
         primary(CREATED_AT, new DateConverter("EEE MMM dd HH:mm:ss Z yyyy", Locale.US));
+
+        this.includeEmail = includeEmail;
     }
 
     @Override
     public String getProfileUrl(final OAuth1Token accessToken, final OAuth10Configuration configuration) {
-        return "https://api.twitter.com/1.1/account/verify_credentials.json";
+        if (includeEmail) {
+            // https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
+            return VERIFY_CREDENTIALS_URL + "?include_email=true";
+        }
+        return VERIFY_CREDENTIALS_URL;
     }
 
     @Override


### PR DESCRIPTION
Support the twitter include_email parameter documented here: https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials