### PR TITLE
Generalizes OIDC session expiration when token expires

### DIFF
--- a/documentation/docs/clients/openid-connect.md
+++ b/documentation/docs/clients/openid-connect.md
@@ -113,3 +113,10 @@ Custom `state` values may be defined in the configuration using the below method
 config.setWithState(true);
 config.setStateData("custom-state-value");
 ```
+
+Additionally, it is possible to establish a behavior according to which, the local session expires when the access token does. In order to do this, just enable `ExpireSessionWithToken` in configuration. This behavior is disabled by default. The additional param `TokenExpirationAdvance` allows to set the time in seconds, previous to the token expiration, in which the session expiration is advanced. By default it is `0` seconds.
+
+```java
+config.setExpireSessionWithToken(true);
+config.setTokenExpirationAdvance(10);
+```

--- a/pac4j-oidc/pom.xml
+++ b/pac4j-oidc/pom.xml
@@ -48,6 +48,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.pac4j</groupId>
+            <artifactId>pac4j-jwt</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -47,6 +47,9 @@ public class OidcConfiguration extends InitializableObject {
     /* default max clock skew */
     public static final int DEFAULT_MAX_CLOCK_SKEW = 30;
 
+    /* default time period advance (in seconds) for considering an access token expired */
+    public static final int DEFAULT_TOKEN_EXPIRATION_ADVANCE = 0;
+
     /* OpenID client identifier */
     private String clientId;
 
@@ -94,6 +97,12 @@ public class OidcConfiguration extends InitializableObject {
     private boolean withState;
 
     private String stateData;
+
+    /* checks if sessions expire with token expiration (see also `tokenExpirationAdvance`) */
+    private boolean expireSessionWithToken = false;
+
+    /** time period advance (in seconds) for considering an access token expired */
+    private int tokenExpirationAdvance = DEFAULT_TOKEN_EXPIRATION_ADVANCE;
 
     @Override
     protected void internalInit() {
@@ -312,7 +321,23 @@ public class OidcConfiguration extends InitializableObject {
     public void setStateData(final String stateData) {
         this.stateData = stateData;
     }
-    
+
+    public boolean isExpireSessionWithToken() {
+        return expireSessionWithToken;
+    }
+
+    public void setExpireSessionWithToken(boolean expireSessionWithToken) {
+        this.expireSessionWithToken = expireSessionWithToken;
+    }
+
+    public int getTokenExpirationAdvance() {
+        return isExpireSessionWithToken() ? tokenExpirationAdvance : -1;
+    }
+
+    public void setTokenExpirationAdvance(int tokenExpirationAdvance) {
+        this.tokenExpirationAdvance = tokenExpirationAdvance;
+    }
+
     @Override
     public String toString() {
         return CommonHelper.toNiceString(this.getClass(), "clientId", clientId, "secret", "[protected]",

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -140,7 +140,8 @@ public class OidcProfile extends AbstractJwtProfile {
     }
 
     public int getTokenExpirationAdvance() {
-        return (int) getAttribute(OidcProfileDefinition.TOKEN_EXPIRATION_ADVANCE);
+        Object tokenExpirationAdvance = getAttribute(OidcProfileDefinition.TOKEN_EXPIRATION_ADVANCE);
+        return tokenExpirationAdvance != null ? (int) tokenExpirationAdvance : -1;
     }
 
     public void setTokenExpirationAdvance(int tokenExpirationAdvance) {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -1,6 +1,7 @@
 package org.pac4j.oidc.profile;
 
 import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
@@ -136,5 +137,33 @@ public class OidcProfile extends AbstractJwtProfile {
         removeAttribute(OidcProfileDefinition.ACCESS_TOKEN);
         removeAttribute(OidcProfileDefinition.ID_TOKEN);
         removeAttribute(OidcProfileDefinition.REFRESH_TOKEN);
+    }
+
+    public int getTokenExpirationAdvance() {
+        return (int) getAttribute(OidcProfileDefinition.TOKEN_EXPIRATION_ADVANCE);
+    }
+
+    public void setTokenExpirationAdvance(int tokenExpirationAdvance) {
+        addAttribute(OidcProfileDefinition.TOKEN_EXPIRATION_ADVANCE, tokenExpirationAdvance);
+    }
+
+    @Override
+    public boolean isExpired() {
+        if (getTokenExpirationAdvance() < 0)
+            return false;
+        else {
+            try {
+                JWT jwt = this.getIdToken();
+                JWTClaimsSet claims = jwt.getJWTClaimsSet();
+                Date expiresOn = claims.getExpirationTime();
+
+                Calendar now = Calendar.getInstance();
+                now.add( Calendar.SECOND, getTokenExpirationAdvance() );
+
+                return expiresOn.before(now.getTime());
+            } catch (ParseException e) {
+                throw new TechnicalException(e);
+            }
+        }
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfileDefinition.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfileDefinition.java
@@ -20,29 +20,32 @@ import java.util.function.Function;
  */
 public class OidcProfileDefinition<P extends OidcProfile> extends CommonProfileDefinition<P> {
 
-    public static final String NAME = "name";
-    public static final String GIVEN_NAME = "given_name";
-    public static final String MIDDLE_NAME = "middle_name";
-    public static final String NICKNAME = "nickname";
-    public static final String PREFERRED_USERNAME = "preferred_username";
-    public static final String PROFILE = "profile";
-    public static final String PICTURE = "picture";
-    public static final String WEBSITE = "website";
-    public static final String EMAIL_VERIFIED = "email_verified";
-    public static final String BIRTHDATE = "birthdate";
-    public static final String ZONEINFO = "zoneinfo";
-    public static final String PHONE_NUMBER = "phone_number";
-    public static final String PHONE_NUMBER_VERIFIED = "phone_number_verified";
-    public static final String ADDRESS = "address";
-    public static final String UPDATED_AT = "updated_at";
-    public static final String ACCESS_TOKEN = "access_token";
-    public static final String ID_TOKEN = "id_token";
-    public static final String REFRESH_TOKEN = "refresh_token";
-    public static final String AUTH_TIME       = "auth_time";
-    public static final String NONCE           = "nonce";
-    public static final String ACR             = "acr";
-    public static final String AMR             = "amr";
-    public static final String AZP             = "azp";
+    public static final String NAME                     = "name";
+    public static final String GIVEN_NAME               = "given_name";
+    public static final String MIDDLE_NAME              = "middle_name";
+    public static final String NICKNAME                 = "nickname";
+    public static final String PREFERRED_USERNAME       = "preferred_username";
+    public static final String PROFILE                  = "profile";
+    public static final String PICTURE                  = "picture";
+    public static final String WEBSITE                  = "website";
+    public static final String EMAIL_VERIFIED           = "email_verified";
+    public static final String BIRTHDATE                = "birthdate";
+    public static final String ZONEINFO                 = "zoneinfo";
+    public static final String PHONE_NUMBER             = "phone_number";
+    public static final String PHONE_NUMBER_VERIFIED    = "phone_number_verified";
+    public static final String ADDRESS                  = "address";
+    public static final String UPDATED_AT               = "updated_at";
+    public static final String ACCESS_TOKEN             = "access_token";
+    public static final String ID_TOKEN                 = "id_token";
+    public static final String REFRESH_TOKEN            = "refresh_token";
+    public static final String AUTH_TIME                = "auth_time";
+    public static final String NONCE                    = "nonce";
+    public static final String ACR                      = "acr";
+    public static final String AMR                      = "amr";
+    public static final String AZP                      = "azp";
+
+    // Custom secondary attributes
+    public static final String TOKEN_EXPIRATION_ADVANCE = "token_expiration_advance";
 
     public OidcProfileDefinition() {
         super(x -> (P) new OidcProfile());
@@ -74,6 +77,9 @@ public class OidcProfileDefinition<P extends OidcProfile> extends CommonProfileD
         Arrays.stream(new String[] {JwtClaims.EXPIRATION_TIME, JwtClaims.ISSUED_AT, JwtClaims.NOT_BEFORE})
             .forEach(a -> primary(a, Converters.DATE_TZ_GENERAL));
         primary(AUTH_TIME, new OidcLongTimeConverter());
+
+        // custom attributes
+        secondary(TOKEN_EXPIRATION_ADVANCE, Converters.INTEGER);
     }
 
     public OidcProfileDefinition(final Function<Object[], P> profileFactory) {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfile.java
@@ -1,13 +1,5 @@
 package org.pac4j.oidc.profile.azuread;
 
-import java.text.ParseException;
-import java.util.Calendar;
-import java.util.Date;
-
-import com.nimbusds.jwt.JWT;
-import com.nimbusds.jwt.JWTClaimsSet;
-
-import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.profile.OidcProfile;
 
 /**
@@ -20,16 +12,6 @@ import org.pac4j.oidc.profile.OidcProfile;
 public class AzureAdProfile extends OidcProfile {
 
     private static final long serialVersionUID = -8659029290353954198L;
-
-    private int idTokenExpireAdvance;
-
-    public AzureAdProfile() {
-        this.idTokenExpireAdvance = 10;
-    }
-
-    public AzureAdProfile(int idTokenExpireAdvance) {
-        this.idTokenExpireAdvance = idTokenExpireAdvance;
-    }
 
     public String getIdp() {
         return (String) getAttribute(AzureAdProfileDefinition.IDP);
@@ -62,25 +44,5 @@ public class AzureAdProfile extends OidcProfile {
     @Override
     public String getUsername() {
         return (String) getAttribute(AzureAdProfileDefinition.UPN);
-    }
-
-    @Override
-    public boolean isExpired() {
-        try {
-            JWT jwt = this.getIdToken();
-            JWTClaimsSet claims = jwt.getJWTClaimsSet();
-            Date expiresOn = claims.getExpirationTime();
-
-            Calendar now = Calendar.getInstance();
-            now.add( Calendar.SECOND, idTokenExpireAdvance );
-
-            if (expiresOn.before(now.getTime())) {
-                return true;
-            }
-        } catch (ParseException e) {
-            throw new TechnicalException(e);
-        }
-
-        return false;
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileCreator.java
@@ -21,7 +21,7 @@ public class AzureAdProfileCreator extends OidcProfileCreator<AzureAdProfile> {
 
     @Override
     protected void internalInit() {
-        defaultProfileDefinition(new AzureAdProfileDefinition(10));
+        defaultProfileDefinition(new AzureAdProfileDefinition());
         super.internalInit();
     }
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileDefinition.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileDefinition.java
@@ -21,9 +21,9 @@ public class AzureAdProfileDefinition extends OidcProfileDefinition<AzureAdProfi
     public static final String IPADDR = "ipaddr";
     public static final String UPN = "upn";
 
-    public AzureAdProfileDefinition(int idTokenExpireAdvance) {
+    public AzureAdProfileDefinition() {
         super();
         Arrays.stream(new String[] {IDP, OID, TID, VER, UNQIUE_NAME, IPADDR, UPN}).forEach(a -> primary(a, Converters.STRING));
-        setProfileFactory(x -> new AzureAdProfile(idTokenExpireAdvance));
+        setProfileFactory(x -> new AzureAdProfile());
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -175,6 +175,9 @@ public class OidcProfileCreator<U extends OidcProfile> extends ProfileDefinition
                 }
             }
 
+            // session expiration with token behavior
+            profile.setTokenExpirationAdvance(configuration.getTokenExpirationAdvance());
+
             return profile;
 
         } catch (final IOException | ParseException | JOSEException | BadJOSEException | java.text.ParseException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.pac4j</groupId>
+                <artifactId>pac4j-jwt</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.version}</version>


### PR DESCRIPTION
Currently, this behavior is only available for the Azure OIDC client. This PR generalizes this making it configurable through two new secondary attributes: `ExpireSessionWithToken` and `TokenExpirationAdvance`.

Azure OIDC client users must take into account that this behavior is now optional in contrast with before that it wasn't.