### PR TITLE
Added a configurable way of removing setNameQualifier on Issuer. Usef…

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -91,6 +91,8 @@ public class SAML2ClientConfiguration extends InitializableObject {
     private String authnContextClassRef = null;
 
     private String nameIdPolicyFormat = null;
+    
+    private boolean useNameQualifier = true;
 
     private WritableResource serviceProviderMetadataResource;
 
@@ -614,4 +616,12 @@ public class SAML2ClientConfiguration extends InitializableObject {
             LOGGER.info("Bootstrapped Canonicalization Algorithm");
         }
     }
+
+	public boolean isUseNameQualifier() {
+		return useNameQualifier;
+	}
+
+	public void setUseNameQualifier(boolean useNameQualifier) {
+		this.useNameQualifier = useNameQualifier;
+	}
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -484,6 +484,14 @@ public class SAML2ClientConfiguration extends InitializableObject {
     public void setAttributeAsId(String attributeAsId) {
         this.attributeAsId = attributeAsId;
     }
+    
+    public boolean isUseNameQualifier() {
+        return useNameQualifier;
+    }
+
+    public void setUseNameQualifier(boolean useNameQualifier) {
+        this.useNameQualifier = useNameQualifier;
+    }
 
     /**
      * Initializes the configuration for a particular client.
@@ -616,12 +624,4 @@ public class SAML2ClientConfiguration extends InitializableObject {
             LOGGER.info("Bootstrapped Canonicalization Algorithm");
         }
     }
-
-	public boolean isUseNameQualifier() {
-		return useNameQualifier;
-	}
-
-	public void setUseNameQualifier(boolean useNameQualifier) {
-		this.useNameQualifier = useNameQualifier;
-	}
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -50,6 +50,8 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
     private String authnContextClassRef = null;
 
     private String nameIdPolicyFormat = null;
+    
+    private boolean useNameQualifier = true;
 
     private int issueInstantSkewSeconds = 0;
 
@@ -79,6 +81,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         this.assertionConsumerServiceIndex = cfg.getAssertionConsumerServiceIndex();
         this.providerName = cfg.getProviderName();
         this.extensions = cfg.getAuthnRequestExtensions();
+        this.useNameQualifier = cfg.isUseNameQualifier();
     }
 
     @Override
@@ -156,7 +159,9 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         final Issuer issuer = issuerBuilder.buildObject();
         issuer.setValue(spEntityId);
         issuer.setFormat(Issuer.ENTITY);
-        issuer.setNameQualifier(spEntityId);
+        if(this.useNameQualifier) {
+        	issuer.setNameQualifier(spEntityId);
+        }
         return issuer;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -160,7 +160,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         issuer.setValue(spEntityId);
         issuer.setFormat(Issuer.ENTITY);
         if (this.useNameQualifier) {
-           issuer.setNameQualifier(spEntityId);
+            issuer.setNameQualifier(spEntityId);
         }
         return issuer;
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -159,8 +159,8 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         final Issuer issuer = issuerBuilder.buildObject();
         issuer.setValue(spEntityId);
         issuer.setFormat(Issuer.ENTITY);
-        if(this.useNameQualifier) {
-        	issuer.setNameQualifier(spEntityId);
+        if (this.useNameQualifier) {
+           issuer.setNameQualifier(spEntityId);
         }
         return issuer;
     }


### PR DESCRIPTION
Added a configurable way of removing setNameQualifier on Issuer. Useful when using ADFS 3.0 that does not accept NameQualifier when using urn:oasis:names:tc:SAML:2.0:nameid-format:entity.

In SAML2ClientConfiguration you can use setUseNameQualifier to disable the NameQualifier from SAML Request. The flag default is true, in this way it will continue to work as before is Name Qualifier is required.

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html