### PR TITLE
Add case-insensitive header name comparison in HeaderExtractor

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/HeaderExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/HeaderExtractor.java
@@ -57,12 +57,15 @@ public class HeaderExtractor implements CredentialsExtractor<TokenCredentials> {
         CommonHelper.assertNotBlank("headerName", this.headerName);
         CommonHelper.assertNotNull("prefixHeader", this.prefixHeader);
 
-        final String header = context.getRequestHeader(this.headerName);
+        String header = context.getRequestHeader(this.headerName);
         if (header == null) {
-            return null;
+            header = context.getRequestHeader(this.headerName.toLowerCase());
+            if (header == null) {
+                return null;
+            }
         }
 
-        if  (!header.startsWith(this.prefixHeader)) {
+        if (!header.startsWith(this.prefixHeader)) {
             throw new CredentialsException("Wrong prefix for header: " + this.headerName);
         }
 

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBasicAuthClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBasicAuthClientTests.java
@@ -34,7 +34,7 @@ public final class DirectBasicAuthClientTests implements TestsConstants {
     public void testMissingProfileCreator() {
         final DirectBasicAuthClient basicAuthClient = new DirectBasicAuthClient(new SimpleTestUsernamePasswordAuthenticator(), null);
         TestsHelper.expectException(() -> basicAuthClient.getUserProfile(new UsernamePasswordCredentials(USERNAME, PASSWORD),
-                MockWebContext.create()), TechnicalException.class, "profileCreator cannot be null");
+            MockWebContext.create()), TechnicalException.class, "profileCreator cannot be null");
     }
 
     @Test
@@ -49,6 +49,18 @@ public final class DirectBasicAuthClientTests implements TestsConstants {
         final MockWebContext context = MockWebContext.create();
         final String header = USERNAME + ":" + USERNAME;
         context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
+            "Basic " + Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8)));
+        final UsernamePasswordCredentials credentials = client.getCredentials(context);
+        final CommonProfile profile = client.getUserProfile(credentials, context);
+        assertEquals(USERNAME, profile.getId());
+    }
+
+    @Test
+    public void testAuthenticationLowercase() {
+        final DirectBasicAuthClient client = new DirectBasicAuthClient(new SimpleTestUsernamePasswordAuthenticator());
+        final MockWebContext context = MockWebContext.create();
+        final String header = USERNAME + ":" + USERNAME;
+        context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER.toLowerCase(),
             "Basic " + Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8)));
         final UsernamePasswordCredentials credentials = client.getCredentials(context);
         final CommonProfile profile = client.getUserProfile(credentials, context);


### PR DESCRIPTION
Headers are sent with lower case names by Google Chrome since version 60 [1].
This change seems to be a conformity to the rfc7320 spec, where header fields
are described as 'case-insensitive'. [2]

Unfortunately, this renders client authentication via DirectBasicAuthClient unusable.

This patch extends the header look up in HeaderExtractor by implementing a fall back
mechanism to look for a lowercase named header name.

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=749086
[2] https://tools.ietf.org/html/rfc7230#section-3.2