### PR TITLE
Selection of PrivateKey alias from keystore returning non-PrivateKey aliases

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
@@ -138,7 +138,11 @@ public class KeyStoreCredentialProvider implements CredentialProvider {
             final Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
                 final String currentAlias = aliases.nextElement();
-                if (keyStoreAlias == null || currentAlias.equalsIgnoreCase(keyStoreAlias)) {
+                if (keyStoreAlias != null) {
+                    if (currentAlias.equalsIgnoreCase(keyStoreAlias)) {
+                        return currentAlias;
+                    }
+                } else if (keyStore.entryInstanceOf(currentAlias, KeyStore.PrivateKeyEntry.class)) {
                     return currentAlias;
                 }
             }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
@@ -138,11 +138,8 @@ public class KeyStoreCredentialProvider implements CredentialProvider {
             final Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
                 final String currentAlias = aliases.nextElement();
-                if (keyStoreAlias != null) {
-                    if (currentAlias.equalsIgnoreCase(keyStoreAlias)) {
-                        return currentAlias;
-                    }
-                } else if (keyStore.entryInstanceOf(currentAlias, KeyStore.PrivateKeyEntry.class)) {
+                if (currentAlias.equalsIgnoreCase(keyStoreAlias)
+                    || keyStore.entryInstanceOf(currentAlias, KeyStore.PrivateKeyEntry.class)) {
                     return currentAlias;
                 }
             }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
@@ -138,8 +138,11 @@ public class KeyStoreCredentialProvider implements CredentialProvider {
             final Enumeration<String> aliases = keyStore.aliases();
             while (aliases.hasMoreElements()) {
                 final String currentAlias = aliases.nextElement();
-                if (currentAlias.equalsIgnoreCase(keyStoreAlias)
-                    || keyStore.entryInstanceOf(currentAlias, KeyStore.PrivateKeyEntry.class)) {
+                if (keyStoreAlias != null) {
+                    if (currentAlias.equalsIgnoreCase(keyStoreAlias)) {
+                        return currentAlias;
+                    }
+                } else if (keyStore.entryInstanceOf(currentAlias, KeyStore.PrivateKeyEntry.class)) {
                     return currentAlias;
                 }
             }


### PR DESCRIPTION
Selector was simply choosing the first alias it was given in the case where an explicit alias was not specified. In the case of keystores with entities other than PrivateKeys, this could/would possibly return a certificate or password entry, which would cause an exception when attempting to use it as a PrivateKey.