### PR TITLE
Refactoring GenderConverter with regular expressions。

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/converter/GenderConverter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/converter/GenderConverter.java
@@ -1,41 +1,41 @@
 package org.pac4j.core.profile.converter;
 
+import java.util.regex.Pattern;
+
 import org.pac4j.core.profile.Gender;
 
 /**
  * This class converts a String to a Gender.
- * 
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
 public final class GenderConverter extends AbstractAttributeConverter<Gender> {
 
+    private final Pattern maleText;
+    private final Pattern femaleText;
+
     public GenderConverter() {
         super(Gender.class);
+        this.maleText = Pattern.compile("(^m$)|(^male$)");
+        this.femaleText = Pattern.compile("(^f$)|(^female$)");
+    }
+
+    public GenderConverter(final String maleText, final String femaleText) {
+        super(Gender.class);
+        this.maleText = Pattern.compile(maleText);
+        this.femaleText = Pattern.compile(femaleText);
     }
 
     @Override
     protected Gender internalConvert(final Object attribute) {
-        if (attribute instanceof String) {
-            final String s = ((String) attribute).toLowerCase();
-            if ("m".equals(s) || "male".equals(s)) {
-                return Gender.MALE;
-            } else if ("f".equals(s) || "female".equals(s)) {
-                return Gender.FEMALE;
-            } else {
-                return Gender.UNSPECIFIED;
-            }
-            // for Vk:
-        } else if (attribute instanceof Integer) {
-            Integer value = (Integer) attribute;
-            if (value == 2) {
-                return Gender.MALE;
-            } else if (value == 1) {
-                return Gender.FEMALE;
-            } else {
-                return Gender.UNSPECIFIED;
-            }
+        final String s = attribute.toString().toLowerCase();
+        if (maleText.matcher(s).matches()) {
+            return Gender.MALE;
+        } else if (femaleText.matcher(s).matches()) {
+            return Gender.FEMALE;
+        } else {
+            return Gender.UNSPECIFIED;
         }
-        return null;
     }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/converter/GenderConverterTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/converter/GenderConverterTests.java
@@ -1,19 +1,26 @@
 package org.pac4j.core.profile.converter;
 
+import java.util.regex.Pattern;
+
 import org.junit.Test;
 import org.pac4j.core.profile.Gender;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This class tests the {@link GenderConverter} class.
- * 
+ *
  * @author Jerome Leleu
  * @since 1.0.0
  */
 public final class GenderConverterTests {
 
     private final GenderConverter converter = new GenderConverter();
+    private final GenderConverter converterNumber = new GenderConverter("2", "1");
+    private final GenderConverter converterChinese = new GenderConverter("男", "女");
 
     @Test
     public void testNull() {
@@ -22,7 +29,7 @@ public final class GenderConverterTests {
 
     @Test
     public void testNotAString() {
-        assertNull(this.converter.convert(Boolean.TRUE));
+        assertEquals(Gender.UNSPECIFIED, this.converter.convert(Boolean.TRUE));
     }
 
     @Test
@@ -37,12 +44,12 @@ public final class GenderConverterTests {
 
     @Test
     public void testMaleNumber() {
-        assertEquals(Gender.MALE, this.converter.convert(2));
+        assertEquals(Gender.MALE, this.converterNumber.convert(2));
     }
 
     @Test
     public void testFemaleNumber() {
-        assertEquals(Gender.FEMALE, this.converter.convert(1));
+        assertEquals(Gender.FEMALE, this.converterNumber.convert(1));
     }
 
     @Test
@@ -63,5 +70,20 @@ public final class GenderConverterTests {
     @Test
     public void testUnspecifiedEnum() {
         assertEquals(Gender.UNSPECIFIED, this.converter.convert(Gender.UNSPECIFIED.toString()));
+    }
+
+    @Test
+    public void testMaleChinese() {
+        assertEquals(Gender.MALE, this.converterChinese.convert("男"));
+    }
+
+    @Test
+    public void testFemaleChinese() {
+        assertEquals(Gender.FEMALE, this.converterChinese.convert("女"));
+    }
+
+    @Test
+    public void testUnspecifiedChinese() {
+        assertEquals(Gender.UNSPECIFIED, this.converterChinese.convert("其他"));
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/vk/VkProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/vk/VkProfileDefinition.java
@@ -6,6 +6,7 @@ import com.github.scribejava.core.model.OAuth2AccessToken;
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.converter.DateConverter;
+import org.pac4j.core.profile.converter.GenderConverter;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
@@ -60,7 +61,7 @@ public class VkProfileDefinition extends OAuth20ProfileDefinition<VkProfile, VkC
             CAN_WRITE_PRIVATE_MESSAGE})
             .forEach(a -> primary(a, Converters.BOOLEAN));
         primary(BIRTH_DATE, new DateConverter("dd.MM.yyyy"));
-        primary(SEX, Converters.GENDER);
+        primary(SEX, new GenderConverter("2", "1"));
     }
 
     @Override


### PR DESCRIPTION
#749 this pull requst refactored the GenderConverter, This refactoring weakens the functionality of the GenderConverter ，Although the pr #749 has successfully merged the functionality of the GenderIntegerConverter, but the implementation has special code for VkProfileDefinition。we can't continue to use new GenderConverter("男", "女") or new GenderConverter("2", "1") to create an GenderConverter instance。

Currently I use regular expressions to better implement this feature and be more flexible.
 And we need to use on WeChat （new GenderConverter("男", "女") ）