### PR TITLE
add wechat oauth2.0 login，support both QR code and Wechat embedded browser login

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WechatClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WechatClient.java
@@ -24,15 +24,15 @@ public class WechatClient extends OAuth20Client<WechatProfile> {
         /**
          * Only for WeChat QRCode login. Get the nickname, avatar, and gender of the logged in user.
          */
-        snsapi_login,
+        SNSAPI_LOGIN,
         /**
          * Exchange code for access_token, refresh_token, and authorized scope
          */
-        snsapi_base,
+        SNSAPI_BASE,
         /**
          * Get user personal information
          */
-        snsapi_userinfo
+        SNSAPI_USERINFO
     }
 
     protected List<WechatScope> scopes;
@@ -60,7 +60,7 @@ public class WechatClient extends OAuth20Client<WechatProfile> {
         StringBuilder builder = null;
         if (scopes == null || scopes.isEmpty()) {
             scopes = new ArrayList<>();
-            scopes.add(WechatScope.snsapi_base);
+            scopes.add(WechatScope.SNSAPI_BASE);
         }
         if (scopes != null) {
             for (WechatScope value : scopes) {
@@ -69,7 +69,7 @@ public class WechatClient extends OAuth20Client<WechatProfile> {
                 } else {
                     builder.append(",");
                 }
-                builder.append(value.toString());
+                builder.append(value.toString().toLowerCase());
             }
         }
         return builder == null ? null : builder.toString();

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WechatClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WechatClient.java
@@ -1,0 +1,91 @@
+package org.pac4j.oauth.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.pac4j.oauth.profile.wechat.WechatProfile;
+import org.pac4j.oauth.profile.wechat.WechatProfileCreator;
+import org.pac4j.oauth.profile.wechat.WechatProfileDefinition;
+import org.pac4j.scribe.builder.api.WechatApi20;
+
+/**
+ * <p>This class is the OAuth client to authenticate users in Tencent Wechat.</p>
+ * <p>It returns a {@link WechatProfile}.</p>
+ * <p>More info at: <a href=
+ * "https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN">
+ * WeChat login development guide</a></p>
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatClient extends OAuth20Client<WechatProfile> {
+
+    public enum WechatScope {
+        /**
+         * Only for WeChat QRCode login. Get the nickname, avatar, and gender of the logged in user.
+         */
+        snsapi_login,
+        /**
+         * Exchange code for access_token, refresh_token, and authorized scope
+         */
+        snsapi_base,
+        /**
+         * Get user personal information
+         */
+        snsapi_userinfo
+    }
+
+    protected List<WechatScope> scopes;
+
+
+    public WechatClient() {
+    }
+
+    public WechatClient(final String key, final String secret) {
+        setKey(key);
+        setSecret(secret);
+    }
+
+    @Override
+    protected void clientInit() {
+        configuration.setApi(new WechatApi20());
+        configuration.setScope(getOAuthScope());
+        configuration.setProfileDefinition(new WechatProfileDefinition());
+        configuration.setWithState(true);
+        defaultProfileCreator(new WechatProfileCreator(configuration, this));
+        super.clientInit();
+    }
+
+    protected String getOAuthScope() {
+        StringBuilder builder = null;
+        if (scopes == null || scopes.isEmpty()) {
+            scopes = new ArrayList<>();
+            scopes.add(WechatScope.snsapi_base);
+        }
+        if (scopes != null) {
+            for (WechatScope value : scopes) {
+                if (builder == null) {
+                    builder = new StringBuilder();
+                } else {
+                    builder.append(",");
+                }
+                builder.append(value.toString());
+            }
+        }
+        return builder == null ? null : builder.toString();
+    }
+
+    public List<WechatScope> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<WechatScope> scopes) {
+        this.scopes = scopes;
+    }
+
+    public void addScope(WechatScope scopes) {
+        if (this.scopes == null)
+            this.scopes = new ArrayList<>();
+        this.scopes.add(scopes);
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfile.java
@@ -1,0 +1,46 @@
+package org.pac4j.oauth.profile.wechat;
+
+import java.net.URI;
+
+import org.pac4j.core.profile.Gender;
+import org.pac4j.oauth.profile.OAuth20Profile;
+
+/**
+ * <p>This class is the user profile for Tencent Wechat with appropriate getters.</p>
+ * <p>It is returned by the {@link org.pac4j.oauth.client.WechatClient}.</p>
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatProfile extends OAuth20Profile {
+
+    private static final long serialVersionUID = 2576512203937798654L;
+
+    @Override
+    public String getDisplayName() {
+        return (String) getAttribute(WechatProfileDefinition.nickname);
+    }
+
+    @Override
+    public String getUsername() {
+        return (String) getAttribute(WechatProfileDefinition.nickname);
+    }
+
+    @Override
+    public Gender getGender() {
+        return (Gender) getAttribute(WechatProfileDefinition.sex);
+    }
+
+    @Override
+    public String getLocation() {
+        final String location = getAttribute(WechatProfileDefinition.city) + ","
+            + getAttribute(WechatProfileDefinition.province) + ","
+            + getAttribute(WechatProfileDefinition.country);
+        return location;
+    }
+
+    @Override
+    public URI getPictureUrl() {
+        return (URI) getAttribute(WechatProfileDefinition.headimgurl);
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfile.java
@@ -18,29 +18,29 @@ public class WechatProfile extends OAuth20Profile {
 
     @Override
     public String getDisplayName() {
-        return (String) getAttribute(WechatProfileDefinition.nickname);
+        return (String) getAttribute(WechatProfileDefinition.NICKNAME);
     }
 
     @Override
     public String getUsername() {
-        return (String) getAttribute(WechatProfileDefinition.nickname);
+        return (String) getAttribute(WechatProfileDefinition.NICKNAME);
     }
 
     @Override
     public Gender getGender() {
-        return (Gender) getAttribute(WechatProfileDefinition.sex);
+        return (Gender) getAttribute(WechatProfileDefinition.SEX);
     }
 
     @Override
     public String getLocation() {
-        final String location = getAttribute(WechatProfileDefinition.city) + ","
-            + getAttribute(WechatProfileDefinition.province) + ","
-            + getAttribute(WechatProfileDefinition.country);
+        final String location = getAttribute(WechatProfileDefinition.CITY) + ","
+            + getAttribute(WechatProfileDefinition.PROVINCE) + ","
+            + getAttribute(WechatProfileDefinition.COUNTRY);
         return location;
     }
 
     @Override
     public URI getPictureUrl() {
-        return (URI) getAttribute(WechatProfileDefinition.headimgurl);
+        return (URI) getAttribute(WechatProfileDefinition.HEADIMGURL);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileCreator.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileCreator.java
@@ -12,7 +12,7 @@ import com.github.scribejava.core.model.OAuth2AccessToken;
  * Specific profile creator for Wechat.
  *
  * @author zhangzhenli
- * @since 2.0.0
+ * @since 3.1.0
  */
 public class WechatProfileCreator extends OAuth20ProfileCreator<WechatProfile> {
     public WechatProfileCreator(OAuth20Configuration configuration,

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileCreator.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileCreator.java
@@ -1,0 +1,31 @@
+package org.pac4j.oauth.profile.wechat;
+
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.oauth.config.OAuth20Configuration;
+import org.pac4j.oauth.profile.creator.OAuth20ProfileCreator;
+import org.pac4j.scribe.model.WechatToken;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+
+/**
+ * Specific profile creator for Wechat.
+ *
+ * @author zhangzhenli
+ * @since 2.0.0
+ */
+public class WechatProfileCreator extends OAuth20ProfileCreator<WechatProfile> {
+    public WechatProfileCreator(OAuth20Configuration configuration,
+                                IndirectClient client) {
+        super(configuration, client);
+    }
+
+    @Override
+    protected WechatProfile retrieveUserProfileFromToken(WebContext context,
+                                                         OAuth2AccessToken accessToken) {
+        WechatToken token = (WechatToken) accessToken;
+        WechatProfile profile = super.retrieveUserProfileFromToken(context, token);
+        profile.setId(token.getOpenid());
+        return profile;
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileDefinition.java
@@ -27,47 +27,47 @@ import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
  */
 public class WechatProfileDefinition extends OAuth20ProfileDefinition<WechatProfile, OAuth20Configuration> {
 
-    public static final String openid = "openid";
+    public static final String OPENID = "openid";
 
-    public static final String nickname = "nickname";
+    public static final String NICKNAME = "nickname";
     /**
      * Gender, 1 male and 2 female
      */
-    public static final String sex = "sex";
+    public static final String SEX = "sex";
 
-    public static final String province = "province";
+    public static final String PROVINCE = "province";
 
-    public static final String city = "city";
+    public static final String CITY = "city";
     /**
      * country, For example, China is CN
      */
-    public static final String country = "country";
+    public static final String COUNTRY = "country";
     /**
      * User avatar, the last value represents the size of the square avatar (0, 46, 64, 96, 132 values are optional, 0 is 640 * 640
      * square avatar), the item is empty when the user has no avatar
      */
-    public static final String headimgurl = "headimgurl";
+    public static final String HEADIMGURL = "headimgurl";
     /**
      * User privilege information, json array, such as WeChat Waka users (chinaunicom)
      */
-    public static final String privilege = "privilege ";
+    public static final String PRIVILEGE = "privilege ";
     /**
      * User union identity. For an application under the WeChat open platform account, the unionid of the same user is unique.
      */
-    public static final String unionid = "unionid";
+    public static final String UNIONID = "unionid";
 
     public WechatProfileDefinition() {
         Arrays.stream(new String[]{
-            openid,
-            nickname,
-            province,
-            city,
-            country,
-            privilege,
-            unionid
+            OPENID,
+            NICKNAME,
+            PROVINCE,
+            CITY,
+            COUNTRY,
+            PRIVILEGE,
+            UNIONID
         }).forEach(a -> primary(a, Converters.STRING));
-        primary(sex, new GenderConverter("1", "2"));
-        primary(headimgurl, Converters.URL);
+        primary(SEX, new GenderConverter("1", "2"));
+        primary(HEADIMGURL, Converters.URL);
     }
 
 
@@ -76,7 +76,7 @@ public class WechatProfileDefinition extends OAuth20ProfileDefinition<WechatProf
         if (accessToken instanceof WechatToken) {
             WechatToken token = (WechatToken) accessToken;
             String profileUrl;
-            if (WechatClient.WechatScope.snsapi_base.name().equals(token.getScope())) {
+            if (WechatClient.WechatScope.SNSAPI_BASE.toString().toLowerCase().equals(token.getScope())) {
                 profileUrl = "https://api.weixin.qq.com/sns/auth?openid=" + token.getOpenid();
             } else {
                 profileUrl = "https://api.weixin.qq.com/sns/userinfo?openid=" + token.getOpenid();

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileDefinition.java
@@ -1,0 +1,108 @@
+package org.pac4j.oauth.profile.wechat;
+
+import java.util.Arrays;
+
+import org.pac4j.core.profile.converter.Converters;
+import org.pac4j.core.profile.converter.GenderConverter;
+import org.pac4j.oauth.client.WechatClient;
+import org.pac4j.oauth.config.OAuth20Configuration;
+import org.pac4j.oauth.profile.JsonHelper;
+import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
+import org.pac4j.scribe.model.WechatToken;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.scribejava.core.exceptions.OAuthException;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+
+import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
+
+/**
+ * This class defines the attributes of the Wechat profile.
+ * <p>More info at: <a href=
+ * "https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316518&token=&lang=zh_CN">
+ * https://api.weixin.qq.com/sns/userinfo</a></p>
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatProfileDefinition extends OAuth20ProfileDefinition<WechatProfile, OAuth20Configuration> {
+
+    public static final String openid = "openid";
+
+    public static final String nickname = "nickname";
+    /**
+     * Gender, 1 male and 2 female
+     */
+    public static final String sex = "sex";
+
+    public static final String province = "province";
+
+    public static final String city = "city";
+    /**
+     * country, For example, China is CN
+     */
+    public static final String country = "country";
+    /**
+     * User avatar, the last value represents the size of the square avatar (0, 46, 64, 96, 132 values are optional, 0 is 640 * 640
+     * square avatar), the item is empty when the user has no avatar
+     */
+    public static final String headimgurl = "headimgurl";
+    /**
+     * User privilege information, json array, such as WeChat Waka users (chinaunicom)
+     */
+    public static final String privilege = "privilege ";
+    /**
+     * User union identity. For an application under the WeChat open platform account, the unionid of the same user is unique.
+     */
+    public static final String unionid = "unionid";
+
+    public WechatProfileDefinition() {
+        Arrays.stream(new String[]{
+            openid,
+            nickname,
+            province,
+            city,
+            country,
+            privilege,
+            unionid
+        }).forEach(a -> primary(a, Converters.STRING));
+        primary(sex, new GenderConverter("1", "2"));
+        primary(headimgurl, Converters.URL);
+    }
+
+
+    @Override
+    public String getProfileUrl(OAuth2AccessToken accessToken, OAuth20Configuration configuration) {
+        if (accessToken instanceof WechatToken) {
+            WechatToken token = (WechatToken) accessToken;
+            String profileUrl;
+            if (WechatClient.WechatScope.snsapi_base.name().equals(token.getScope())) {
+                profileUrl = "https://api.weixin.qq.com/sns/auth?openid=" + token.getOpenid();
+            } else {
+                profileUrl = "https://api.weixin.qq.com/sns/userinfo?openid=" + token.getOpenid();
+            }
+            return profileUrl;
+        } else {
+            throw new OAuthException("Token in getProfileUrl is not an WechatToken");
+        }
+    }
+
+    @Override
+    public WechatProfile extractUserProfile(String body) {
+        final WechatProfile profile = new WechatProfile();
+        final JsonNode json = JsonHelper.getFirstNode(body);
+        if (json != null) {
+            Integer errcode = (Integer) JsonHelper.getElement(json, "errcode");
+            if (errcode != null && errcode > 0) {
+                Object errmsg = JsonHelper.getElement(json, "errmsg");
+                throw new OAuthException(
+                    errmsg != null ? errmsg.toString() : "error code " + errcode);
+            }
+            for (final String attribute : getPrimaryAttributes()) {
+                convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute,
+                    JsonHelper.getElement(json, attribute));
+            }
+        }
+        return profile;
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/wechat/WechatProfileDefinition.java
@@ -76,7 +76,7 @@ public class WechatProfileDefinition extends OAuth20ProfileDefinition<WechatProf
         if (accessToken instanceof WechatToken) {
             WechatToken token = (WechatToken) accessToken;
             String profileUrl;
-            if (WechatClient.WechatScope.SNSAPI_BASE.toString().toLowerCase().equals(token.getScope())) {
+            if (WechatClient.WechatScope.SNSAPI_BASE.toString().equalsIgnoreCase(token.getScope())) {
                 profileUrl = "https://api.weixin.qq.com/sns/auth?openid=" + token.getOpenid();
             } else {
                 profileUrl = "https://api.weixin.qq.com/sns/userinfo?openid=" + token.getOpenid();

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/WechatApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/WechatApi20.java
@@ -1,0 +1,114 @@
+package org.pac4j.scribe.builder.api;
+
+import java.util.Map;
+
+import org.pac4j.oauth.client.WechatClient;
+import org.pac4j.scribe.extractors.WechatJsonExtractor;
+import org.pac4j.scribe.service.WechatService;
+
+import com.github.scribejava.core.builder.api.ClientAuthenticationType;
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.builder.api.OAuth2SignatureType;
+import com.github.scribejava.core.extractors.TokenExtractor;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthConfig;
+import com.github.scribejava.core.model.OAuthConstants;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth20Service;
+
+
+/**
+ * This class represents the OAuth API implementation for Tencent Wechat using OAuth protocol version 2.
+ * It could be part of the Scribe library.
+ * <p>More info at: <a href=
+ * "https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN"
+ * >OAuth2.0</a></p>
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatApi20 extends DefaultApi20 {
+
+    public static final String APPID = "appid";
+    public static final String SECRET = "secret";
+    //WeChat QR code login
+    public static final String AUTHORIZE_ENDPOINT_URL_1 = "https://open.weixin.qq.com/connect/qrconnect";
+    //WeChat embedded browser,, call native login.
+    public static final String AUTHORIZE_ENDPOINT_URL_2 = "https://open.weixin.qq.com/connect/oauth2/authorize";
+
+    public static final String TOKEN_ENDPOINT_URL = "https://api.weixin.qq.com/sns/oauth2/access_token";
+
+
+    private static class InstanceHolder {
+        private static final WechatApi20 INSTANCE = new WechatApi20();
+    }
+
+    public static WechatApi20 instance() {
+        return WechatApi20.InstanceHolder.INSTANCE;
+    }
+
+    @Override
+    public String getAccessTokenEndpoint() {
+        return TOKEN_ENDPOINT_URL + "?grant_type=authorization_code";
+    }
+
+    @Override
+    public String getAuthorizationUrl(OAuthConfig config, Map<String, String> additionalParams) {
+        String authorizationUrl = super.getAuthorizationUrl(config, additionalParams);
+        authorizationUrl = authorizationUrl.replace(OAuthConstants.CLIENT_ID, APPID);
+        if (config.getScope() != null && config.getScope().contains(
+            WechatClient.WechatScope.snsapi_login.name())) {
+            authorizationUrl = AUTHORIZE_ENDPOINT_URL_1 + authorizationUrl;
+        } else {
+            authorizationUrl = AUTHORIZE_ENDPOINT_URL_2 + authorizationUrl;
+        }
+        return authorizationUrl;
+    }
+
+    @Override
+    protected String getAuthorizationBaseUrl() {
+        return "";
+    }
+
+    @Override
+    public Verb getAccessTokenVerb() {
+        return Verb.GET;
+    }
+
+    @Override
+    public OAuth2SignatureType getSignatureType() {
+        return OAuth2SignatureType.BEARER_URI_QUERY_PARAMETER;
+    }
+
+    @Override
+    public TokenExtractor<OAuth2AccessToken> getAccessTokenExtractor() {
+        return WechatJsonExtractor.instance();
+    }
+
+    @Override
+    public ClientAuthenticationType getClientAuthenticationType() {
+        return ClientAuthenticationType.REQUEST_BODY;
+    }
+
+    @Override
+    public OAuth20Service createService(OAuthConfig config) {
+        return new WechatService(this, config);
+    }
+/*
+    @Override
+    public ClientAuthenticationType getClientAuthenticationType() {
+        return new ClientAuthenticationType() {
+
+            @Override
+            public void addClientAuthentication(OAuthRequest request, String apiKey,
+                                                String apiSecret) {
+                request.addParameter(APPID, apiKey);
+                if (apiSecret != null) {
+                    request.addParameter(SECRET, apiSecret);
+                }
+            }
+        };
+    }
+*/
+}
+

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/WechatApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/WechatApi20.java
@@ -94,21 +94,6 @@ public class WechatApi20 extends DefaultApi20 {
     public OAuth20Service createService(OAuthConfig config) {
         return new WechatService(this, config);
     }
-/*
-    @Override
-    public ClientAuthenticationType getClientAuthenticationType() {
-        return new ClientAuthenticationType() {
-
-            @Override
-            public void addClientAuthentication(OAuthRequest request, String apiKey,
-                                                String apiSecret) {
-                request.addParameter(APPID, apiKey);
-                if (apiSecret != null) {
-                    request.addParameter(SECRET, apiSecret);
-                }
-            }
-        };
-    }
-*/
 }
+
 

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/WechatApi20.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/builder/api/WechatApi20.java
@@ -57,7 +57,7 @@ public class WechatApi20 extends DefaultApi20 {
         String authorizationUrl = super.getAuthorizationUrl(config, additionalParams);
         authorizationUrl = authorizationUrl.replace(OAuthConstants.CLIENT_ID, APPID);
         if (config.getScope() != null && config.getScope().contains(
-            WechatClient.WechatScope.snsapi_login.name())) {
+            WechatClient.WechatScope.SNSAPI_LOGIN.toString().toLowerCase())) {
             authorizationUrl = AUTHORIZE_ENDPOINT_URL_1 + authorizationUrl;
         } else {
             authorizationUrl = AUTHORIZE_ENDPOINT_URL_2 + authorizationUrl;

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/extractors/WechatJsonExtractor.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/extractors/WechatJsonExtractor.java
@@ -1,0 +1,45 @@
+package org.pac4j.scribe.extractors;
+
+import java.util.regex.Pattern;
+
+import org.pac4j.scribe.model.WechatToken;
+
+import com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+
+/**
+ * This class represents a specific JSON extractor for Wechat Connect using OAuth protocol version 2.
+ * It could be part of the Scribe library.
+ * <p>More info at: <a href=
+ * "https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316505&token=&lang=zh_CN">
+ * WeChat login development guide</a></p>
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatJsonExtractor extends OAuth2AccessTokenJsonExtractor {
+
+    public static final Pattern OPENID_REGEX = Pattern.compile("\"openid\"\\s*:\\s*\"(\\S*?)\"");
+    public static final Pattern UNION_ID_REGEX = Pattern.compile("\"unionid\"\\s*:\\s*\"(\\S*?)\"");
+
+    protected WechatJsonExtractor() {
+    }
+
+    private static class InstanceHolder {
+
+        private static final WechatJsonExtractor INSTANCE = new WechatJsonExtractor();
+    }
+
+    public static WechatJsonExtractor instance() {
+        return WechatJsonExtractor.InstanceHolder.INSTANCE;
+    }
+
+    @Override
+    protected OAuth2AccessToken createToken(String accessToken, String tokenType, Integer expiresIn,
+                                            String refreshToken, String scope, String response) {
+        String openid = extractParameter(response, OPENID_REGEX, true);
+        String unionid = extractParameter(response, UNION_ID_REGEX, false);
+        WechatToken token = new WechatToken(accessToken, tokenType, expiresIn, refreshToken, scope, response, openid, unionid);
+        return token;
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/model/WechatToken.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/model/WechatToken.java
@@ -1,5 +1,7 @@
 package org.pac4j.scribe.model;
 
+import org.pac4j.core.util.CommonHelper;
+
 import com.github.scribejava.core.model.OAuth2AccessToken;
 
 /**
@@ -62,9 +64,7 @@ public class WechatToken extends OAuth2AccessToken {
 
     @Override
     public String toString() {
-        return "WechatToken{" + super.toString() + " " +
-            "openid='" + openid + '\'' +
-            ", unionid='" + unionid + '\'' +
-            '}';
+        return CommonHelper.toNiceString(WechatToken.class, "accessToken", getAccessToken(),
+            "openid", openid, "unionid", unionid);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/model/WechatToken.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/model/WechatToken.java
@@ -1,0 +1,70 @@
+package org.pac4j.scribe.model;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+
+/**
+ * Wechat token extra.
+ * <p>More info at: <a href=
+ * "https://open.weixin.qq.com/cgi-bin/showdocument?action=dir_list&t=resource/res_list&verify=1&id=open1419316518&token=&lang=zh_CN">
+ * access_token</a></p>
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatToken extends OAuth2AccessToken {
+
+    private String openid;
+    private String unionid;
+
+    public WechatToken(String accessToken, String tokenType, Integer expiresIn,
+                       String refreshToken, String scope, String rawResponse,
+                       String openid, String unionid) {
+        super(accessToken, tokenType, expiresIn, refreshToken, scope, rawResponse);
+        this.openid = openid;
+        this.unionid = unionid;
+    }
+
+    public String getOpenid() {
+        return openid;
+    }
+
+    public void setOpenid(String openid) {
+        this.openid = openid;
+    }
+
+    public String getUnionid() {
+        return unionid;
+    }
+
+    public void setUnionid(String unionid) {
+        this.unionid = unionid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        WechatToken that = (WechatToken) o;
+
+        if (openid != null ? !openid.equals(that.openid) : that.openid != null) return false;
+        return unionid != null ? unionid.equals(that.unionid) : that.unionid == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (openid != null ? openid.hashCode() : 0);
+        result = 31 * result + (unionid != null ? unionid.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "WechatToken{" + super.toString() + " " +
+            "openid='" + openid + '\'' +
+            ", unionid='" + unionid + '\'' +
+            '}';
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/service/WechatService.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/service/WechatService.java
@@ -39,15 +39,15 @@ public class WechatService extends OAuth20Service {
     @Override
     public <R> Future<R> execute(OAuthRequest request, OAuthAsyncRequestCallback<R> callback,
                                  OAuthRequest.ResponseConverter<R> converter) {
-        request = addClientAuthentication(request);
-        return super.execute(request, callback, converter);
+        OAuthRequest authRequest = addClientAuthentication(request);
+        return super.execute(authRequest, callback, converter);
     }
 
     @Override
     public Response execute(OAuthRequest request)
         throws InterruptedException, ExecutionException, IOException {
-        request = addClientAuthentication(request);
-        return super.execute(request);
+        OAuthRequest authRequest = addClientAuthentication(request);
+        return super.execute(authRequest);
     }
 
     private OAuthRequest addClientAuthentication(OAuthRequest request) {

--- a/pac4j-oauth/src/main/java/org/pac4j/scribe/service/WechatService.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/scribe/service/WechatService.java
@@ -1,0 +1,58 @@
+package org.pac4j.scribe.service;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.pac4j.scribe.builder.api.WechatApi20;
+
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import com.github.scribejava.core.model.OAuthAsyncRequestCallback;
+import com.github.scribejava.core.model.OAuthConfig;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.oauth.OAuth20Service;
+
+/**
+ * As of scribejava 5.3, the enumeration class ClientAuthenticationType does not support inheritance,
+ * and can not complete the client authentication of wechat.
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public class WechatService extends OAuth20Service {
+
+    private OAuthConfig config;
+
+    /**
+     * Default constructor
+     *
+     * @param api    OAuth2.0 api information
+     * @param config OAuth 2.0 configuration param object
+     */
+    public WechatService(DefaultApi20 api,
+                         OAuthConfig config) {
+        super(api, config);
+        this.config = config;
+    }
+
+    @Override
+    public <R> Future<R> execute(OAuthRequest request, OAuthAsyncRequestCallback<R> callback,
+                                 OAuthRequest.ResponseConverter<R> converter) {
+        request = addClientAuthentication(request);
+        return super.execute(request, callback, converter);
+    }
+
+    @Override
+    public Response execute(OAuthRequest request)
+        throws InterruptedException, ExecutionException, IOException {
+        request = addClientAuthentication(request);
+        return super.execute(request);
+    }
+
+    private OAuthRequest addClientAuthentication(OAuthRequest request) {
+        request.addParameter(WechatApi20.APPID, config.getApiKey());
+        request.addParameter(WechatApi20.SECRET, config.getApiSecret());
+        return request;
+    }
+}

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunWechatClient.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunWechatClient.java
@@ -1,0 +1,110 @@
+package org.pac4j.oauth.run;
+
+import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.Gender;
+import org.pac4j.core.profile.ProfileHelper;
+import org.pac4j.core.run.RunClient;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.oauth.client.WechatClient;
+import org.pac4j.oauth.profile.wechat.WechatProfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Run manually a test for the {@link WechatClient}.
+ *
+ * @author zhangzhenli
+ * @since 3.1.0
+ */
+public final class RunWechatClient extends RunClient {
+
+    public static final boolean QRCODE = true;
+
+    public static void main(String[] args) throws Exception {
+//        System.setProperty("http.proxyHost", "127.0.0.1");
+//        System.setProperty("https.proxyHost", "127.0.0.1");
+//        System.setProperty("http.proxyPort", "8888");
+//        System.setProperty("https.proxyPort", "8888");
+//        System.setProperty("javax.net.ssl.trustStore", "C:\\Users\\Administrator\\cacerts");
+//        System.setProperty("javax.net.ssl.trustStorePassword", "changeit");
+//        System.setProperty("sun.security.ssl.allowUnsafeRenegotiation", "true");
+        final RunWechatClient runWechatClient = new RunWechatClient();
+        runWechatClient.run();
+    }
+
+    @Override
+    protected String getLogin() {
+        return "zhangzawn";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "";
+    }
+
+    @Override
+    protected IndirectClient getClient() {
+        final WechatClient wechatClient = new WechatClient();
+        final String apiKey;
+        final String apiSecret;
+        final String callbackUrl;
+        final WechatClient.WechatScope scope;
+        if (QRCODE) {
+//          Only for WeChat QRCode login.
+            apiKey = "wx87e3d5b7290aa255";
+            apiSecret = "3f70550b81198131429b408cc1c8b091";
+            callbackUrl = "http://www.yomoer.cn/ThirdpartyLogin/afterWeixinLogin";
+            scope = WechatClient.WechatScope.snsapi_login;
+        } else {
+//            WeChat embedded browser, call native login.
+            apiKey = "wxade4323a74dcb897";
+            apiSecret = "43854fe4325282609ace1da9df0cbf32";
+            callbackUrl = "http://192.168.10.20/callback";
+            scope = WechatClient.WechatScope.snsapi_userinfo;
+        }
+
+        wechatClient.setKey(apiKey);
+        wechatClient.setSecret(apiSecret);
+        wechatClient.setCallbackUrl(callbackUrl);
+        wechatClient.addScope(scope);
+        return wechatClient;
+    }
+
+    @Override
+    protected boolean canCancel() {
+        return true;
+    }
+
+    @Override
+    protected void verifyProfile(CommonProfile userProfile) {
+        final WechatProfile profile = (WechatProfile) userProfile;
+        String openid;
+        // Note: different apiKey get the same user's uid differently, headimgurl may also be different.
+        if (QRCODE) {
+            openid = "ofrPB1XEft_igz1Ms-QeOcev-SZQ";
+        } else {
+            openid = "oLQIp0oBRhtxJGMIh9Gs7qiCCAcI";
+        }
+        assertEquals(openid, profile.getId());
+        assertEquals(WechatProfile.class.getName() + CommonProfile.SEPARATOR + openid,
+            profile.getTypedId());
+        assertTrue(ProfileHelper.isTypedIdOf(profile.getTypedId(), WechatProfile.class));
+        assertTrue(CommonHelper.isNotBlank(profile.getAccessToken()));
+        String pictureUrl;
+        if (QRCODE)
+            pictureUrl = "http://thirdwx.qlogo.cn/mmopen/vi_32/" +
+                "Q0j4TwGTfTIeoXSyFb6PBH1zZ9rqFxRj2Y4nCrfBs3VociatoRttyDTVGkT60xh1JDnYsR84ywqJk3h5RO4YxIw/132";
+        else {
+            pictureUrl = "http://thirdwx.qlogo.cn/mmopen/vi_32/" +
+                "Q0j4TwGTfTJCNYUsTpmibmVImWFDrNbibWnkR2z2f8XOa3dhgnyrp1icyRvpic1ZDxkuVO8pcd1CaHbCbkicCzJoPibg/132";
+        }
+        assertCommonProfile(userProfile, null, null, null, "张", "张",
+            Gender.MALE, null,
+            pictureUrl,
+            null, "Nanjing,Jiangsu,CN");
+
+        assertTrue(8 <= profile.getAttributes().size());
+    }
+}

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunWechatClient.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunWechatClient.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
  */
 public final class RunWechatClient extends RunClient {
 
-    public static final boolean QRCODE = true;
+    public static final boolean QRCODE = false;
 
     public static void main(String[] args) throws Exception {
 //        System.setProperty("http.proxyHost", "127.0.0.1");
@@ -56,13 +56,13 @@ public final class RunWechatClient extends RunClient {
             apiKey = "wx87e3d5b7290aa255";
             apiSecret = "3f70550b81198131429b408cc1c8b091";
             callbackUrl = "http://www.yomoer.cn/ThirdpartyLogin/afterWeixinLogin";
-            scope = WechatClient.WechatScope.snsapi_login;
+            scope = WechatClient.WechatScope.SNSAPI_LOGIN;
         } else {
 //            WeChat embedded browser, call native login.
             apiKey = "wxade4323a74dcb897";
             apiSecret = "43854fe4325282609ace1da9df0cbf32";
             callbackUrl = "http://192.168.10.20/callback";
-            scope = WechatClient.WechatScope.snsapi_userinfo;
+            scope = WechatClient.WechatScope.SNSAPI_USERINFO;
         }
 
         wechatClient.setKey(apiKey);


### PR DESCRIPTION
add wechat oauth2.0 login，support both QR code and Wechat embedded browser login.

Wechat uses different scopes and authorization endpoints in normal browsers and WeChat embedded browsers.The current implementation determines which one to use the authorization endpoint based on the scope passed in by the client.

Scope
    snsapi_login：For web pages, a QR code will be displayed when the user opens the web page. user can use the  WeChat App to scan the QR code to confirm.

   snsapi_base，snsapi_userinfo：For WeChat embedded web pages，This authorization endpoint url needs to be opened inside WeChat。snsapi_base does not require user secondary confirmation, but only gets openid.

https://open.wechat.com/cgi-bin/newreadtemplate?t=overseas_open/docs/web/login/login#login_login