### PR TITLE
Ensure tenant is set for AzureAdOidcConfiguration in the ctor

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAdOidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAdOidcConfiguration.java
@@ -17,7 +17,7 @@ public class AzureAdOidcConfiguration extends OidcConfiguration {
     public AzureAdOidcConfiguration() {
     }
 
-    public AzureAdOidcConfiguration(OidcConfiguration oidcConfiguration) {
+    public AzureAdOidcConfiguration(final OidcConfiguration oidcConfiguration) {
         this.setProviderMetadata(oidcConfiguration.getProviderMetadata());
         this.setClientId(oidcConfiguration.getClientId());
         this.setSecret(oidcConfiguration.getSecret());
@@ -34,6 +34,11 @@ public class AzureAdOidcConfiguration extends OidcConfiguration {
         this.setResponseType(oidcConfiguration.getResponseType());
         this.setResponseMode(oidcConfiguration.getResponseMode());
         this.setLogoutUrl(oidcConfiguration.getLogoutUrl());
+
+        if (oidcConfiguration instanceof AzureAdOidcConfiguration) {
+            final AzureAdOidcConfiguration azureConfig = AzureAdOidcConfiguration.class.cast(oidcConfiguration);
+            this.setTenant(azureConfig.getTenant());
+        }
     }
 
     @Override


### PR DESCRIPTION
The current constructor does not fully initialize the configuration of azure, where it misses out on setting the tenant. The developer is expected to do that separately and this PR makes that task unnecessary.

Related to https://github.com/apereo/cas/pull/3449