### PR TITLE
Allow GenericOAuth20Client to specify profileId

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
@@ -30,6 +30,7 @@ public class GenericOAuth20Client extends OAuth20Client<OAuth20Profile> {
     private String tokenUrl;
     private String profileUrl;
     private String profilePath;
+    private String profileId;
     private Verb profileVerb;
     private Map<String, String> profileAttrs;
     private Map<String, String> customParams;
@@ -53,6 +54,9 @@ public class GenericOAuth20Client extends OAuth20Client<OAuth20Profile> {
         profileDefinition.setProfileVerb(profileVerb);
         profileDefinition.setProfileUrl(profileUrl);
 
+        if (profileId != null) {
+            profileDefinition.setProfileId(profileId);
+        }
         if (profileAttrs != null) {
             for (Map.Entry<String, String> entry : profileAttrs.entrySet()) {
                 String key = entry.getKey();
@@ -142,5 +146,9 @@ public class GenericOAuth20Client extends OAuth20Client<OAuth20Profile> {
 
     public void setCustomParams(final Map<String, String> customParamsMap) {
         this.customParams = customParamsMap;
+    }
+
+    public void setProfileId(String profileId) {
+        this.profileId = profileId;
     }
 }


### PR DESCRIPTION
https://github.com/apereo/cas/blob/5.3.x/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java#L394

Because GenericOAuth20Client can't specify profileid, causing cas-oauth error, so we should allow the specified profileid

The Issues is similar to #1056 