### PR TITLE
Add option for SAML2 acceptedSkew

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -141,6 +141,7 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
                 this.decrypter,
                 this.configuration.getMaximumAuthenticationLifetime(),
                 this.configuration.isWantsAssertionsSigned());
+        this.responseValidator.setAcceptedSkew(this.configuration.getAcceptedSkew());
     }
 
     protected void initSignatureTrustEngineProvider(final MetadataResolver metadataManager) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2ClientConfiguration.java
@@ -87,7 +87,9 @@ public class SAML2ClientConfiguration extends InitializableObject {
 
     private String serviceProviderEntityId;
 
-    private int maximumAuthenticationLifetime;
+    private int maximumAuthenticationLifetime = 3600;
+
+    private int acceptedSkew = 300;
 
     private boolean forceAuth = false;
     private boolean passive = false;
@@ -265,6 +267,14 @@ public class SAML2ClientConfiguration extends InitializableObject {
         } else {
             return new FileSystemResource(path);
         }
+    }
+
+    public int getAcceptedSkew() {
+        return acceptedSkew;
+    }
+
+    public void setAcceptedSkew(final int acceptedSkew) {
+        this.acceptedSkew = acceptedSkew;
     }
 
     public Resource getIdentityProviderMetadataResource() {
@@ -500,7 +510,7 @@ public class SAML2ClientConfiguration extends InitializableObject {
         return this.wantsAssertionsSigned;
     }
 
-    public void setWantsAssertionsSigned(boolean wantsAssertionsSigned) {
+    public void setWantsAssertionsSigned(final boolean wantsAssertionsSigned) {
         this.wantsAssertionsSigned = wantsAssertionsSigned;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/SAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/SAML2ResponseValidator.java
@@ -11,6 +11,12 @@ import org.pac4j.saml.context.SAML2MessageContext;
  */
 public interface SAML2ResponseValidator {
 
+    /**
+     * Validates the SAML protocol response and the SAML SSO response.
+     * The method decrypt encrypted assertions if any.
+     *
+     * @param context the context
+     */
     Credentials validate(SAML2MessageContext context);
 
     void setMaximumAuthenticationLifetime(int maximumAuthenticationLifetime);


### PR DESCRIPTION
- Expose a new setting for `acceptedSkew`
- Do not override the `maximumAuthenticationLifetime` setting, if set to `0` in settings.