### PR TITLE
add config building of oauth2

### DIFF
--- a/pac4j-config/src/main/java/org/pac4j/config/builder/OAuthBuilder.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/builder/OAuthBuilder.java
@@ -121,4 +121,15 @@ public class OAuthBuilder extends AbstractBuilder {
             clients.add(twitterClient);
         }
     }
+
+    public void tryCreateOauth2Client(final List<Client> clients) {
+        final String key = getProperty(OAUTH2_KEY);
+        final String secret = getProperty(OAUTH2_SECRET);
+        if (isNotBlank(key) && isNotBlank(secret)) {
+            final OAuth20Client oAuth20Client = new OAuth20Client();
+            oAuth20Client.setKey(key);
+            oAuth20Client.setSecret(secret);
+            clients.add(oAuth20Client);
+        }
+    }
 }

--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConfigFactory.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConfigFactory.java
@@ -72,6 +72,7 @@ public class PropertiesConfigFactory extends AbstractBuilder implements ConfigFa
             oAuthBuilder.tryCreateFoursquareClient(clients);
             oAuthBuilder.tryCreateWindowsLiveClient(clients);
             oAuthBuilder.tryCreateLinkedInClient(clients);
+            oAuthBuilder.tryCreateOauth2Client(clients);
         }
         // pac4j-saml dependency required
         if (hasSaml2Clients()) {
@@ -171,6 +172,9 @@ public class PropertiesConfigFactory extends AbstractBuilder implements ConfigFa
             return true;
         }
         if (isNotBlank(getProperty(TWITTER_ID)) && isNotBlank(getProperty(TWITTER_SECRET))) {
+            return true;
+        }
+        if (isNotBlank(getProperty(OAUTH2_KEY)) && isNotBlank(getProperty(OAUTH2_SECRET))) {
             return true;
         }
         return false;

--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
@@ -40,6 +40,9 @@ public interface PropertiesConstants {
     String GOOGLE_SECRET = "google.secret";
     String GOOGLE_SCOPE = "google.scope";
 
+    String OAUTH2_KEY = "oauth2.key";
+    String OAUTH2_SECRET = "oauth2.secret";
+
     String AUTHENTICATOR_TEST_TOKEN = "testToken";
     String AUTHENTICATOR_TEST_USERNAME_PASSWORD = "testUsernamePassword";
 


### PR DESCRIPTION
currently, there is not a way to have `PropertiesConfigFactory` to build an Oauth2Client via a configuration.

This PR aims to add the ability to specify parameters to build an Oauth2Client.