### PR TITLE
Upgrade nimbusds dependencies for JWT and OIDC

### DIFF
--- a/pac4j-config/pom.xml
+++ b/pac4j-config/pom.xml
@@ -13,6 +13,7 @@
     <name>pac4j configuration</name>
 
     <properties>
+        <commonslang3.version>3.8.1</commonslang3.version>
         <hikaricp.version>2.7.6</hikaricp.version>
     </properties>
 
@@ -55,6 +56,11 @@
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>${hikaricp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commonslang3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.pac4j</groupId>

--- a/pac4j-oidc/pom.xml
+++ b/pac4j-oidc/pom.xml
@@ -13,7 +13,7 @@
     <name>pac4j for OpenID Connect protocol</name>
 
     <properties>
-        <oauth-oidc-sdk.version>5.45</oauth-oidc-sdk.version>
+        <oauth-oidc-sdk.version>6.5</oauth-oidc-sdk.version>
     </properties>
 
     <dependencies>

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
@@ -18,8 +18,10 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Extract the authorization code on the callback.
@@ -48,7 +50,9 @@ public class OidcExtractor implements CredentialsExtractor<OidcCredentials> {
         final Map<String, String> parameters = retrieveParameters(context);
         AuthenticationResponse response;
         try {
-            response = AuthenticationResponseParser.parse(new URI(computedCallbackUrl), parameters);
+            response = AuthenticationResponseParser.parse(new URI(computedCallbackUrl),
+                    parameters.entrySet().stream().collect(
+                            Collectors.toMap(Map.Entry::getKey, e -> Collections.singletonList(e.getValue()))));
         } catch (final URISyntaxException | ParseException e) {
             throw new TechnicalException(e);
         }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectActionBuilder.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectActionBuilder.java
@@ -13,8 +13,10 @@ import org.pac4j.oidc.config.OidcConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Redirect to the OpenID Connect provider.
@@ -105,7 +107,8 @@ public class OidcRedirectActionBuilder implements RedirectActionBuilder {
         // Build authentication request query string
         final String queryString;
         try {
-            queryString = AuthenticationRequest.parse(params).toQueryString();
+            queryString = AuthenticationRequest.parse(params.entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, e -> Collections.singletonList(e.getValue())))).toQueryString();
         } catch (Exception e) {
             throw new TechnicalException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<commons-codec.version>1.11</commons-codec.version>
 		<commons-io.version>2.6</commons-io.version>
 		<guava.version>23.6-jre</guava.version>
-		<nimbus-jose-jwt.version>5.4</nimbus-jose-jwt.version>
+		<nimbus-jose-jwt.version>6.5</nimbus-jose-jwt.version>
 		<spring.version>5.0.2.RELEASE</spring.version>
 		<spring.security.version>5.0.0.RELEASE</spring.security.version>
 		<shiro.version>1.4.0</shiro.version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<commons-codec.version>1.11</commons-codec.version>
 		<commons-io.version>2.6</commons-io.version>
 		<guava.version>23.6-jre</guava.version>
-		<nimbus-jose-jwt.version>6.5</nimbus-jose-jwt.version>
+		<nimbus-jose-jwt.version>6.0.2</nimbus-jose-jwt.version>
 		<spring.version>5.0.2.RELEASE</spring.version>
 		<spring.security.version>5.0.0.RELEASE</spring.security.version>
 		<shiro.version>1.4.0</shiro.version>


### PR DESCRIPTION
This PR upgrades both NimbusDS dependencies to the latest version without changing the Pac4j API. It also adds a commons-lang3 dependency to pac4j-config, because that module depends on that lib, which is no longer provided via nimbus-jose-jwt.