### PR TITLE
Add direct support for RFC 6750 bearer authentication tokens.

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BearerAuthExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BearerAuthExtractor.java
@@ -1,0 +1,29 @@
+package org.pac4j.core.credentials.extractor;
+
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.TokenCredentials;
+
+/**
+ * To extract an RFC 6750 bearer auth header.
+ *
+ * @author Graham Leggett
+ * @since 4.0.1
+ */
+public class BearerAuthExtractor implements CredentialsExtractor<TokenCredentials> {
+
+    private final HeaderExtractor extractor;
+
+    public BearerAuthExtractor() {
+        this(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.BEARER_HEADER_PREFIX);
+    }
+
+    public BearerAuthExtractor(final String headerName, final String prefixHeader) {
+        this.extractor = new HeaderExtractor(headerName, prefixHeader);
+    }
+
+    @Override
+    public TokenCredentials extract(WebContext context) {
+        return this.extractor.extract(context);
+    }
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BearerAuthExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BearerAuthExtractor.java
@@ -8,7 +8,7 @@ import org.pac4j.core.credentials.TokenCredentials;
  * To extract an RFC 6750 bearer auth header.
  *
  * @author Graham Leggett
- * @since 4.0.1
+ * @since 3.5.0
  */
 public class BearerAuthExtractor implements CredentialsExtractor<TokenCredentials> {
 

--- a/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectBearerAuthClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectBearerAuthClient.java
@@ -1,0 +1,67 @@
+package org.pac4j.http.client.direct;
+
+import static org.pac4j.core.util.CommonHelper.assertNotBlank;
+import static org.pac4j.core.util.CommonHelper.toNiceString;
+
+import org.pac4j.core.client.DirectClient;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.Pac4jConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.credentials.TokenCredentials;
+import org.pac4j.core.credentials.authenticator.Authenticator;
+import org.pac4j.core.credentials.extractor.BearerAuthExtractor;
+import org.pac4j.core.profile.creator.ProfileCreator;
+
+/**
+ * <p>This class is the client to authenticate users directly through RFC 6750 HTTP bearer authentication.</p>
+ *
+ * @author Graham Leggett
+ * @since 4.0.1
+ */
+public class DirectBearerAuthClient extends DirectClient<TokenCredentials> {
+
+    private String realmName = Pac4jConstants.DEFAULT_REALM_NAME;
+
+    public DirectBearerAuthClient() {
+    }
+
+    public DirectBearerAuthClient(final Authenticator tokenAuthenticator) {
+        defaultAuthenticator(tokenAuthenticator);
+    }
+
+    public DirectBearerAuthClient(final Authenticator tokenAuthenticator,
+                                 final ProfileCreator profileCreator) {
+        defaultAuthenticator(tokenAuthenticator);
+        defaultProfileCreator(profileCreator);
+    }
+
+    @Override
+    protected void clientInit() {
+        assertNotBlank("realmName", this.realmName);
+
+        defaultCredentialsExtractor(new BearerAuthExtractor());
+    }
+
+    @Override
+    protected TokenCredentials retrieveCredentials(final WebContext context) {
+        // set the www-authenticate in case of error
+        context.setResponseHeader(HttpConstants.AUTHENTICATE_HEADER, "Bearer realm=\"" + realmName + "\"");
+
+        return super.retrieveCredentials(context);
+    }
+
+    public String getRealmName() {
+        return realmName;
+    }
+
+    public void setRealmName(final String realmName) {
+        this.realmName = realmName;
+    }
+
+    @Override
+    public String toString() {
+        return toNiceString(this.getClass(), "name", getName(), "credentialsExtractor", getCredentialsExtractor(),
+            "authenticator", getAuthenticator(), "profileCreator", getProfileCreator(),
+            "authorizationGenerators", getAuthorizationGenerators(), "realmName", this.realmName);
+    }
+}

--- a/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectBearerAuthClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/direct/DirectBearerAuthClient.java
@@ -16,7 +16,7 @@ import org.pac4j.core.profile.creator.ProfileCreator;
  * <p>This class is the client to authenticate users directly through RFC 6750 HTTP bearer authentication.</p>
  *
  * @author Graham Leggett
- * @since 4.0.1
+ * @since 3.5.0
  */
 public class DirectBearerAuthClient extends DirectClient<TokenCredentials> {
 

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBearerAuthClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBearerAuthClientTests.java
@@ -1,0 +1,54 @@
+package org.pac4j.http.client.direct;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.credentials.TokenCredentials;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.core.util.TestsHelper;
+import org.pac4j.http.credentials.authenticator.test.SimpleTestTokenAuthenticator;
+
+/**
+ * This class tests the {@link DirectBearerAuthClient} class.
+ *
+ * @author Graham Leggett
+ * @since 4.0.1
+ */
+public final class DirectBearerAuthClientTests implements TestsConstants {
+
+    @Test
+    public void testMissingTokenAuthenticator() {
+        final DirectBearerAuthClient bearerAuthClient = new DirectBearerAuthClient(null);
+        TestsHelper.expectException(() -> bearerAuthClient.getCredentials(MockWebContext.create()), TechnicalException.class,
+            "authenticator cannot be null");
+    }
+
+    @Test
+    public void testMissingProfileCreator() {
+        final DirectBearerAuthClient bearerAuthClient = new DirectBearerAuthClient(new SimpleTestTokenAuthenticator(), null);
+        TestsHelper.expectException(() -> bearerAuthClient.getUserProfile(new TokenCredentials(TOKEN),
+            MockWebContext.create()), TechnicalException.class, "profileCreator cannot be null");
+    }
+
+    @Test
+    public void testHasDefaultProfileCreator() {
+        final DirectBearerAuthClient bearerAuthClient = new DirectBearerAuthClient(new SimpleTestTokenAuthenticator());
+        bearerAuthClient.init();
+    }
+
+    @Test
+    public void testAuthentication() {
+        final DirectBearerAuthClient client = new DirectBearerAuthClient(new SimpleTestTokenAuthenticator());
+        final MockWebContext context = MockWebContext.create();
+        context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
+            "Bearer " + TOKEN);
+        final TokenCredentials credentials = client.getCredentials(context);
+        final CommonProfile profile = (CommonProfile) client.getUserProfile(credentials, context);
+        assertEquals(TOKEN, profile.getId());
+    }
+
+}

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBearerAuthClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBearerAuthClientTests.java
@@ -16,7 +16,7 @@ import org.pac4j.http.credentials.authenticator.test.SimpleTestTokenAuthenticato
  * This class tests the {@link DirectBearerAuthClient} class.
  *
  * @author Graham Leggett
- * @since 4.0.1
+ * @since 3.5.0
  */
 public final class DirectBearerAuthClientTests implements TestsConstants {
 
@@ -45,7 +45,7 @@ public final class DirectBearerAuthClientTests implements TestsConstants {
         final DirectBearerAuthClient client = new DirectBearerAuthClient(new SimpleTestTokenAuthenticator());
         final MockWebContext context = MockWebContext.create();
         context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
-            "Bearer " + TOKEN);
+                HttpConstants.BEARER_HEADER_PREFIX + TOKEN);
         final TokenCredentials credentials = client.getCredentials(context);
         final CommonProfile profile = (CommonProfile) client.getUserProfile(credentials, context);
         assertEquals(TOKEN, profile.getId());


### PR DESCRIPTION
This patch adds formal support for RFC 6750 bearer authentication tokens, carried in the Authorization header.

https://tools.ietf.org/html/rfc6750