### PR TITLE
[master] Fix Google Plus API deprecated issue

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -14,9 +14,11 @@ title: Release notes&#58;
 - By default, the CSRF check applies on the PUT, PATCH and DELETE requests in addition to the POST requests
 - "csrf,securityheaders" is the default authorizers definition
 - Renamed the `SAMLMessageStorage*` classes as `SAMLMessageStore*` (based on `Store`)
+- For `Google2Client`, change profile url from `https://www.googleapis.com/plus/v1/people/me` to `https://www.googleapis.com/oauth2/v3/userinfo`. This change is to prepare for the shutdown of Google plus API. This change will remove the `birthday` and `emails` attribute for `Google2Client`.
 
 **v3.6.0**:
 - Multiple authn context class refs can be set in the SAML protocol support
+- For `Google2Client`, change profile url from `https://www.googleapis.com/plus/v1/people/me` to `https://www.googleapis.com/oauth2/v3/userinfo`. This change is to prepare for the shutdown of Google plus API. This change will make the `birthday` attribute return `null` and `emails` attribute resolve a single email from `email` attribute for `Google2Client`.
 
 **v3.5.0**:
 

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2Profile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2Profile.java
@@ -20,12 +20,7 @@ public class Google2Profile extends OAuth20Profile {
 
     @Override
     public String getEmail() {
-        final List<Google2Email> list = getEmails();
-        if (list != null && !list.isEmpty()) {
-            return list.get(0).getEmail();
-        } else {
-            return null;
-        }
+        return (String) getAttribute(Google2ProfileDefinition.EMAIL);
     }
 
     @Override
@@ -56,14 +51,5 @@ public class Google2Profile extends OAuth20Profile {
     @Override
     public URI getProfileUrl() {
         return (URI) getAttribute(Google2ProfileDefinition.URL);
-    }
-
-    public Date getBirthday() {
-        return (Date) getAttribute(Google2ProfileDefinition.BIRTHDAY);
-    }
-
-    @SuppressWarnings("unchecked")
-    public List<Google2Email> getEmails() {
-        return (List<Google2Email>) getAttribute(Google2ProfileDefinition.EMAILS);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2Profile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2Profile.java
@@ -1,8 +1,6 @@
 package org.pac4j.oauth.profile.google2;
 
 import java.net.URI;
-import java.util.Date;
-import java.util.List;
 import java.util.Locale;
 
 import org.pac4j.oauth.profile.OAuth20Profile;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
@@ -1,6 +1,5 @@
 package org.pac4j.oauth.profile.google2;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import org.pac4j.core.profile.ProfileHelper;
@@ -8,12 +7,10 @@ import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.converter.DateConverter;
 import org.pac4j.oauth.config.OAuth20Configuration;
 import org.pac4j.oauth.profile.JsonHelper;
-import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
 import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 
-import java.util.List;
 
 /**
  * This class is the Google profile definition (using OAuth 2.0 protocol).
@@ -29,8 +26,7 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
     public static final String URL = "url";
     public static final String PICTURE = "image.url";
     public static final String LANGUAGE = "language";
-    public static final String BIRTHDAY = "birthday";
-    public static final String EMAILS = "emails";
+    public static final String EMAIL = "email";
 
     public Google2ProfileDefinition() {
         super(x -> new Google2Profile());
@@ -40,13 +36,12 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
         primary(URL, Converters.URL);
         primary(PICTURE, Converters.URL);
         primary(LANGUAGE, Converters.LOCALE);
-        primary(BIRTHDAY, new DateConverter("yyyy-MM-dd"));
-        primary(EMAILS, new JsonConverter(List.class, new TypeReference<List<Google2Email>>() {}));
+        primary(EMAIL, Converters.STRING);
     }
 
     @Override
     public String getProfileUrl(final OAuth2AccessToken accessToken, final OAuth20Configuration configuration) {
-        return "https://www.googleapis.com/plus/v1/people/me";
+        return "https://www.googleapis.com/oauth2/v3/userinfo";
     }
 
     @Override
@@ -54,7 +49,7 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
         final Google2Profile profile = newProfile();
         final JsonNode json = JsonHelper.getFirstNode(body);
         if (json != null) {
-            profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
+            profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "sub")));
             for (final String attribute : getPrimaryAttributes()) {
                 convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import org.pac4j.core.profile.ProfileHelper;
 import org.pac4j.core.profile.converter.Converters;
-import org.pac4j.core.profile.converter.DateConverter;
 import org.pac4j.oauth.config.OAuth20Configuration;
 import org.pac4j.oauth.profile.JsonHelper;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGoogle2Client.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGoogle2Client.java
@@ -55,15 +55,13 @@ public final class RunGoogle2Client extends RunClient {
         final Google2Profile profile = (Google2Profile) userProfile;
         assertEquals("113675986756217860428", profile.getId());
         assertEquals(Google2Profile.class.getName() + CommonProfile.SEPARATOR + "113675986756217860428",
-                profile.getTypedId());
+            profile.getTypedId());
         assertTrue(ProfileHelper.isTypedIdOf(profile.getTypedId(), Google2Profile.class));
         assertTrue(CommonHelper.isNotBlank(profile.getAccessToken()));
         assertCommonProfile(userProfile, "testscribeup@gmail.com", "Jérôme", "ScribeUP", "Jérôme ScribeUP", null,
-                Gender.MALE, Locale.ENGLISH,
-                "https://lh4.googleusercontent.com/-fFUNeYqT6bk/AAAAAAAAAAI/AAAAAAAAAAA/5gBL6csVWio/photo.jpg",
-                "https://plus.google.com/113675986756217860428", null);
-        assertNull(profile.getBirthday());
-        assertTrue(profile.getEmails() != null && profile.getEmails().size() == 1);
-        assertEquals(9, profile.getAttributes().size());
+            Gender.MALE, Locale.ENGLISH,
+            "https://lh4.googleusercontent.com/-fFUNeYqT6bk/AAAAAAAAAAI/AAAAAAAAAAA/5gBL6csVWio/photo.jpg",
+            "https://plus.google.com/113675986756217860428", null);
+        assertEquals(7, profile.getAttributes().size());
     }
 }


### PR DESCRIPTION
Related Issue: #1228 
Related Google Group discussion: https://groups.google.com/forum/?fromgroups#!topic/pac4j-users/xlFNWXEMEog

## What is changed
What this PR does, is changing the url from `https://www.googleapis.com/plus/v1/people/me` to `https://www.googleapis.com/oauth2/v3/userinfo`, with minor changes to make the test case and properties compatible again.

## What will break from this PR
This PR will break the following:
- `birthday` is removed
- `emails` is removed (Note: `email` without an `s` will still be retained)

Other then that, everything else should still be working as before.

------------------------------------
P.s. I am aware that someone else is also researching the fix, if they come up with a better fix / my fix is not compatible. I will be glad to delete / change this PR, cheers!