### PR TITLE
[3.6.x] Fix Google Plus API deprecated issue

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2Profile.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2Profile.java
@@ -1,6 +1,7 @@
 package org.pac4j.oauth.profile.google2;
 
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -19,14 +20,7 @@ public class Google2Profile extends OAuth20Profile {
     private static final long serialVersionUID = -7486869356444327783L;
 
     @Override
-    public String getEmail() {
-        final List<Google2Email> list = getEmails();
-        if (list != null && !list.isEmpty()) {
-            return list.get(0).getEmail();
-        } else {
-            return null;
-        }
-    }
+    public String getEmail() { return (String) getAttribute(Google2ProfileDefinition.EMAIL); }
 
     @Override
     public String getFirstName() {
@@ -58,12 +52,12 @@ public class Google2Profile extends OAuth20Profile {
         return (URI) getAttribute(Google2ProfileDefinition.URL);
     }
 
-    public Date getBirthday() {
-        return (Date) getAttribute(Google2ProfileDefinition.BIRTHDAY);
-    }
+    public Date getBirthday() { return null; }
 
     @SuppressWarnings("unchecked")
     public List<Google2Email> getEmails() {
-        return (List<Google2Email>) getAttribute(Google2ProfileDefinition.EMAILS);
+        Google2Email email = new Google2Email();
+        email.setEmail(getEmail());
+        return Arrays.asList(email);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/google2/Google2ProfileDefinition.java
@@ -1,6 +1,5 @@
 package org.pac4j.oauth.profile.google2;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.scribejava.core.model.OAuth2AccessToken;
 import org.pac4j.core.profile.ProfileHelper;
@@ -8,12 +7,9 @@ import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.converter.DateConverter;
 import org.pac4j.oauth.config.OAuth20Configuration;
 import org.pac4j.oauth.profile.JsonHelper;
-import org.pac4j.oauth.profile.converter.JsonConverter;
 import org.pac4j.oauth.profile.definition.OAuth20ProfileDefinition;
 
 import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
-
-import java.util.List;
 
 /**
  * This class is the Google profile definition (using OAuth 2.0 protocol).
@@ -30,6 +26,7 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
     public static final String PICTURE = "image.url";
     public static final String LANGUAGE = "language";
     public static final String BIRTHDAY = "birthday";
+    public static final String EMAIL = "email";
     public static final String EMAILS = "emails";
 
     public Google2ProfileDefinition() {
@@ -41,12 +38,12 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
         primary(PICTURE, Converters.URL);
         primary(LANGUAGE, Converters.LOCALE);
         primary(BIRTHDAY, new DateConverter("yyyy-MM-dd"));
-        primary(EMAILS, new JsonConverter(List.class, new TypeReference<List<Google2Email>>() {}));
+        primary(EMAIL, Converters.STRING);
     }
 
     @Override
     public String getProfileUrl(final OAuth2AccessToken accessToken, final OAuth20Configuration configuration) {
-        return "https://www.googleapis.com/plus/v1/people/me";
+        return "https://www.googleapis.com/oauth2/v3/userinfo";
     }
 
     @Override
@@ -54,7 +51,7 @@ public class Google2ProfileDefinition extends OAuth20ProfileDefinition<Google2Pr
         final Google2Profile profile = newProfile();
         final JsonNode json = JsonHelper.getFirstNode(body);
         if (json != null) {
-            profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "id")));
+            profile.setId(ProfileHelper.sanitizeIdentifier(profile, JsonHelper.getElement(json, "sub")));
             for (final String attribute : getPrimaryAttributes()) {
                 convertAndAdd(profile, PROFILE_ATTRIBUTE, attribute, JsonHelper.getElement(json, attribute));
             }

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGoogle2Client.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/run/RunGoogle2Client.java
@@ -62,8 +62,7 @@ public final class RunGoogle2Client extends RunClient {
                 Gender.MALE, Locale.ENGLISH,
                 "https://lh4.googleusercontent.com/-fFUNeYqT6bk/AAAAAAAAAAI/AAAAAAAAAAA/5gBL6csVWio/photo.jpg",
                 "https://plus.google.com/113675986756217860428", null);
-        assertNull(profile.getBirthday());
         assertTrue(profile.getEmails() != null && profile.getEmails().size() == 1);
-        assertEquals(9, profile.getAttributes().size());
+        assertEquals(7, profile.getAttributes().size());
     }
 }


### PR DESCRIPTION
Same fix as #1249, with the following differences:
- Keep the attributes `emails` and `birthday` for backward compatibility
- For `birthday`, return null
- For `emails`, get the email information from the attribute `email` instead. 
  - I did this so that API which only use `emails` can still get the email attribute, see if the team agree with this. I can change it to return empty list if if deemed appropriate.
 