### PR TITLE
3.6.x allow HttpAction, RedirectAction to be extended

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/exception/HttpAction.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/exception/HttpAction.java
@@ -16,7 +16,7 @@ public class HttpAction extends TechnicalException {
 
     protected int code;
 
-    private HttpAction(final int code) {
+    protected HttpAction(final int code) {
         super("Performing a " + code + " HTTP action");
         this.code = code;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectAction.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectAction.java
@@ -30,7 +30,7 @@ public class RedirectAction {
 
     private String content;
 
-    private RedirectAction() {}
+    protected RedirectAction() {}
 
     public static RedirectAction redirect(final String location) {
         RedirectAction action = new RedirectAction();
@@ -95,6 +95,18 @@ public class RedirectAction {
 
     public String getContent() {
         return this.content;
+    }
+
+    protected void setType( RedirectType type ) {
+        this.type = type;
+    }
+
+    protected void setLocation( String loc ) {
+        this.location = loc;
+    }
+
+    protected void setContent( String content ) {
+        this.content = content;
     }
 
     @Override

--- a/pac4j-core/src/test/java/org/pac4j/core/redirect/RedirectActionTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/redirect/RedirectActionTests.java
@@ -36,4 +36,20 @@ public final class RedirectActionTests implements TestsConstants {
                 "<script type='text/javascript'>document.forms['f'].submit();</script>\n" +
                 "</body>\n</html>\n", s);
     }
+
+    @Test
+    public void testSetters() {
+        RedirectAction action = new RedirectAction();
+        RedirectAction.RedirectType type = RedirectAction.RedirectType.SUCCESS;
+        String location = "some other place";
+        String content = "short content string";
+
+        action.setType( type );
+        action.setLocation( location );
+        action.setContent( content );
+
+        assertEquals( action.getType(), type );
+        assertEquals( action.getLocation(), location );
+        assertEquals( action.getContent(), content );
+    }
 }


### PR DESCRIPTION
So that both Httpaction and RedirectAction may be extended, the visibility of the constructors need to be changed from private to protected.
