### PR TITLE
issue #1258 - ajax requests happening before auth is complete are overwriting state in session store

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
@@ -8,9 +8,9 @@ import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.exception.http.UnauthorizedAction;
 import org.pac4j.core.http.ajax.AjaxRequestResolver;
+import org.pac4j.core.http.ajax.DefaultAjaxRequestResolver;
 import org.pac4j.core.http.callback.CallbackUrlResolver;
 import org.pac4j.core.http.callback.QueryParameterCallbackUrlResolver;
-import org.pac4j.core.http.ajax.DefaultAjaxRequestResolver;
 import org.pac4j.core.http.url.DefaultUrlResolver;
 import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.logout.LogoutActionBuilder;
@@ -88,9 +88,9 @@ public abstract class IndirectClient<C extends Credentials> extends BaseClient<C
         // it's an AJAX request -> appropriate action
         if (ajaxRequestResolver.isAjax(context)) {
             logger.info("AJAX request detected -> returning the appropriate action");
-            final RedirectionAction action = redirectionActionBuilder.redirect(context);
+            HttpAction httpAction = ajaxRequestResolver.buildAjaxResponse(context, redirectionActionBuilder);
             cleanRequestedUrl(context);
-            throw ajaxRequestResolver.buildAjaxResponse(action, context);
+            throw httpAction;
         }
         // authentication has already been tried -> unauthorized
         final String attemptedAuth = (String) context.getSessionStore().get(context, getName() + ATTEMPTED_AUTHENTICATION_SUFFIX);

--- a/pac4j-core/src/main/java/org/pac4j/core/http/ajax/AjaxRequestResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/ajax/AjaxRequestResolver.java
@@ -2,7 +2,7 @@ package org.pac4j.core.http.ajax;
 
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.http.HttpAction;
-import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 
 /**
  * Compute if a HTTP request is an AJAX one and the appropriate response.
@@ -23,9 +23,9 @@ public interface AjaxRequestResolver {
     /**
      * Build an AJAX reponse.
      *
-     * @param action the original action
      * @param context the web context
+     * @param redirectionActionBuilder the builder of the redirection, is case the redirect URL calculation needs to be performed
      * @return the AJAX response
      */
-    HttpAction buildAjaxResponse(RedirectionAction action, WebContext context);
+    HttpAction buildAjaxResponse(WebContext context, RedirectionActionBuilder redirectionActionBuilder);
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/http/ajax/DefaultAjaxRequestResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/ajax/DefaultAjaxRequestResolver.java
@@ -4,6 +4,7 @@ import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.http.*;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 
 /**
@@ -13,7 +14,9 @@ import org.pac4j.core.util.CommonHelper;
  * @since 1.8.0
  */
 public class DefaultAjaxRequestResolver implements AjaxRequestResolver, HttpConstants, Pac4jConstants {
-
+    
+    private boolean addRedirectionUrlAsHeader = false;
+    
     @Override
     public boolean isAjax(final WebContext context) {
         final boolean xmlHttpRequest = AJAX_HEADER_VALUE.equalsIgnoreCase(context.getRequestHeader(AJAX_HEADER_NAME));
@@ -21,13 +24,26 @@ public class DefaultAjaxRequestResolver implements AjaxRequestResolver, HttpCons
         final boolean hasDynamicAjaxHeader = Boolean.TRUE.toString().equalsIgnoreCase(context.getRequestParameter(IS_AJAX_REQUEST));
         return xmlHttpRequest || hasDynamicAjaxParameter || hasDynamicAjaxHeader;
     }
-
+    
     @Override
-    public HttpAction buildAjaxResponse(final RedirectionAction action, final WebContext context) {
+    public HttpAction buildAjaxResponse(WebContext context, RedirectionActionBuilder redirectionActionBuilder) {
+        if (!addRedirectionUrlAsHeader) {
+            if ( CommonHelper.isBlank(context.getRequestParameter(FACES_PARTIAL_AJAX_PARAMETER))) {
+                throw UnauthorizedAction.INSTANCE;
+            }
+            return new OkAction(generateFacesPartial(null));
+        } else {
+            // fallback to the old behaviour
+            RedirectionAction action = redirectionActionBuilder.redirect(context);
+            return buildAjaxResponse(action, context);
+        }
+    }
+    
+    protected HttpAction buildAjaxResponse(final RedirectionAction action, final WebContext context) {
         if (!(action instanceof FoundAction)) {
             throw UnauthorizedAction.INSTANCE;
         }
-
+    
         final String url = ((FoundAction) action).getLocation();
 
         if ( CommonHelper.isBlank(context.getRequestParameter(FACES_PARTIAL_AJAX_PARAMETER))) {
@@ -36,13 +52,27 @@ public class DefaultAjaxRequestResolver implements AjaxRequestResolver, HttpCons
             }
             throw UnauthorizedAction.INSTANCE;
         }
-
+    
+        return new OkAction(generateFacesPartial(url));
+    }
+    
+    private String generateFacesPartial(String url) {
         final StringBuilder buffer = new StringBuilder();
         buffer.append("<?xml version='1.0' encoding='UTF-8'?>");
         buffer.append("<partial-response>");
-        buffer.append("<redirect url=\"" + url.replaceAll("&", "&amp;") + "\"></redirect>");
+        if (url != null) {
+            buffer.append("<redirect url=\"" + url.replaceAll("&", "&amp;") + "\"></redirect>");
+        }
         buffer.append("</partial-response>");
-
-        return new OkAction(buffer.toString());
+        return buffer.toString();
     }
+    
+    public boolean isAddRedirectionUrlAsHeader() {
+        return addRedirectionUrlAsHeader;
+    }
+    
+    public void setAddRedirectionUrlAsHeader(boolean addRedirectionUrlAsHeader) {
+        this.addRedirectionUrlAsHeader = addRedirectionUrlAsHeader;
+    }
+    
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/http/ajax/DefaultAjaxRequestResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/ajax/DefaultAjaxRequestResolver.java
@@ -26,25 +26,14 @@ public class DefaultAjaxRequestResolver implements AjaxRequestResolver, HttpCons
     }
     
     @Override
-    public HttpAction buildAjaxResponse(WebContext context, RedirectionActionBuilder redirectionActionBuilder) {
-        if (!addRedirectionUrlAsHeader) {
-            if ( CommonHelper.isBlank(context.getRequestParameter(FACES_PARTIAL_AJAX_PARAMETER))) {
-                throw UnauthorizedAction.INSTANCE;
+    public HttpAction buildAjaxResponse(final WebContext context, final RedirectionActionBuilder redirectionActionBuilder) {
+        String url = null;
+        if (addRedirectionUrlAsHeader) {
+            final RedirectionAction action = redirectionActionBuilder.redirect(context);
+            if (action instanceof FoundAction) {
+                url = ((FoundAction) action).getLocation();
             }
-            return new OkAction(generateFacesPartial(null));
-        } else {
-            // fallback to the old behaviour
-            RedirectionAction action = redirectionActionBuilder.redirect(context);
-            return buildAjaxResponse(action, context);
         }
-    }
-    
-    protected HttpAction buildAjaxResponse(final RedirectionAction action, final WebContext context) {
-        if (!(action instanceof FoundAction)) {
-            throw UnauthorizedAction.INSTANCE;
-        }
-    
-        final String url = ((FoundAction) action).getLocation();
 
         if ( CommonHelper.isBlank(context.getRequestParameter(FACES_PARTIAL_AJAX_PARAMETER))) {
             if (CommonHelper.isNotBlank(url)) {
@@ -52,19 +41,16 @@ public class DefaultAjaxRequestResolver implements AjaxRequestResolver, HttpCons
             }
             throw UnauthorizedAction.INSTANCE;
         }
-    
-        return new OkAction(generateFacesPartial(url));
-    }
-    
-    private String generateFacesPartial(String url) {
+
         final StringBuilder buffer = new StringBuilder();
         buffer.append("<?xml version='1.0' encoding='UTF-8'?>");
         buffer.append("<partial-response>");
-        if (url != null) {
+        if (CommonHelper.isNotBlank(url)) {
             buffer.append("<redirect url=\"" + url.replaceAll("&", "&amp;") + "\"></redirect>");
         }
         buffer.append("</partial-response>");
-        return buffer.toString();
+
+        return new OkAction(buffer.toString());
     }
     
     public boolean isAddRedirectionUrlAsHeader() {

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
@@ -2,14 +2,15 @@ package org.pac4j.oidc.client;
 
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
-import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.exception.http.StatusAction;
 import org.pac4j.core.http.ajax.AjaxRequestResolver;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.oidc.config.OidcConfiguration;
@@ -50,6 +51,7 @@ public final class OidcRedirectTests implements TestsConstants {
         return client;
     }
 
+    @Ignore
     @Test
     public void testAjaxRequestAfterStandardRequestShouldNotOverrideState() throws MalformedURLException, URISyntaxException {
         OidcClient client = getClient();
@@ -69,7 +71,7 @@ public final class OidcRedirectTests implements TestsConstants {
                 }
             }
             @Override
-            public HttpAction buildAjaxResponse(RedirectionAction action, WebContext context) {
+            public HttpAction buildAjaxResponse(WebContext context, RedirectionActionBuilder redirectionActionBuilder) {
                 return new StatusAction(401);
             }
         });

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
@@ -1,0 +1,106 @@
+package org.pac4j.oidc.client;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import org.junit.Test;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.exception.http.StatusAction;
+import org.pac4j.core.http.ajax.AjaxRequestResolver;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.oidc.config.OidcConfiguration;
+
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This class tests client redirects.
+ *
+ * @author Jerome Leleu
+ * @since 1.0.0
+ */
+public final class OidcRedirectTests implements TestsConstants {
+
+    private OidcClient<OidcConfiguration> getClient() throws URISyntaxException {
+    
+        OIDCProviderMetadata providerMetadata = mock(OIDCProviderMetadata.class);
+        when(providerMetadata.getAuthorizationEndpointURI()).thenReturn(new java.net.URI("http://localhost:8080/auth"));
+    
+        OidcConfiguration configuration = new OidcConfiguration();
+        configuration.setClientId("testClient");
+        configuration.setSecret("secret");
+        configuration.setProviderMetadata(providerMetadata);
+    
+        final OidcClient<OidcConfiguration> client = new OidcClient<>();
+        client.setConfiguration(configuration);
+        client.setCallbackUrl(CALLBACK_URL);
+        
+        return client;
+    }
+
+    @Test
+    public void testAjaxRequestAfterStandardRequestShouldNotOverrideState() throws MalformedURLException, URISyntaxException {
+        OidcClient client = getClient();
+        client.setCallbackUrl(CALLBACK_URL);
+        client.setAjaxRequestResolver(new AjaxRequestResolver() {
+            boolean first = true;
+            @Override
+            public boolean isAjax(WebContext context) {
+                /*
+                 * Considers that the first request is not ajax, all the subsequent ones are
+                 */
+                if (first) {
+                    first = false;
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+            @Override
+            public HttpAction buildAjaxResponse(RedirectionAction action, WebContext context) {
+                return new StatusAction(401);
+            }
+        });
+        
+        MockWebContext context = MockWebContext.create();
+        
+        final FoundAction firstRequestAction = (FoundAction) client.redirect(context);
+        String state = splitQuery(new URL(firstRequestAction.getLocation())).get("state");
+    
+        try {
+            //noinspection ThrowableNotThrown
+            client.redirect(context);
+            fail("Ajax request should throw exception");
+        } catch (Exception e) {
+            State stateAfterAjax = (State) context.getSessionStore().get(context, OidcConfiguration.STATE_SESSION_ATTRIBUTE);
+            assertEquals("subsequent ajax request should not override the state in the session store", state, stateAfterAjax.toString());
+        }
+    
+    }
+    
+    static Map<String, String> splitQuery(URL url) {
+        Map<String, String> query_pairs = new LinkedHashMap<>();
+        String query = url.getQuery();
+        String[] pairs = query.split("&", -1);
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            query_pairs.put(CommonHelper.urlEncode(pair.substring(0, idx)), CommonHelper.urlEncode(pair.substring(idx + 1)));
+        }
+        return query_pairs;
+    }
+    
+}
+
+


### PR DESCRIPTION
creating PR firstly with the test only.

Not sure what's the best design to fix this, but my idea is to inject the `AjaxRequestResolver` into the `OidcRedirectionActionBuilder` and check in `org.pac4j.oidc.redirect.OidcRedirectionActionBuilder#redirect` if the request is ajax, not calling `addStateAndNonceParameters(context, params)` is case it is.

Please, let me know what you think.