### PR TITLE
add Pac4j HTTPPostSimpleSignEncoder implementation

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -95,6 +95,7 @@ You can define the binding type for the authentication request via the `setAuthn
 ```java
 cfg.setAuthnRequestBindingType(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 // or cfg.setAuthnRequestBindingType(SAMLConstants.SAML2_POST_BINDING_URI);
+// or cfg.setAuthnRequestBindingType(SAMLConstants.SAML2_POST_SIMPLE_SIGN_BINDING_URI);
 ```
 
 Notice that the SP metadata will define the POST binding for the authentication response and for the IdP logout request.

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
@@ -192,6 +192,7 @@ public class SAML2MetadataGenerator implements SAMLMetadataGenerator {
         spDescriptor.getAssertionConsumerServices()
             .add(getAssertionConsumerService(SAMLConstants.SAML2_POST_BINDING_URI, index++, this.defaultACSIndex == index));
         spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_POST_BINDING_URI));
+        spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_POST_SIMPLE_SIGN_BINDING_URI));
         spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_REDIRECT_BINDING_URI));
         spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_SOAP11_BINDING_URI));
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
@@ -11,13 +11,17 @@ import org.opensaml.saml.common.binding.security.impl.SAMLOutboundProtocolMessag
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
 import org.opensaml.saml.saml2.core.StatusResponseType;
-import org.opensaml.saml.saml2.metadata.*;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.Endpoint;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.crypto.SignatureSigningParametersProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2MessageSender;
 import org.pac4j.saml.storage.SAMLMessageStorage;
 import org.pac4j.saml.transport.Pac4jHTTPPostEncoder;
+import org.pac4j.saml.transport.Pac4jHTTPPostSimpleSignEncoder;
 import org.pac4j.saml.transport.Pac4jHTTPRedirectDeflateEncoder;
 import org.pac4j.saml.transport.Pac4jSAMLResponse;
 import org.pac4j.saml.util.VelocityEngineFactory;
@@ -146,6 +150,12 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
         if (SAMLConstants.SAML2_POST_BINDING_URI.equals(destinationBindingType)) {
             final VelocityEngine velocityEngine = VelocityEngineFactory.getEngine();
             final Pac4jHTTPPostEncoder encoder = new Pac4jHTTPPostEncoder(adapter);
+            encoder.setVelocityEngine(velocityEngine);
+            return encoder;
+
+        } else if (SAMLConstants.SAML2_POST_SIMPLE_SIGN_BINDING_URI.equals(destinationBindingType)) {
+            final VelocityEngine velocityEngine = VelocityEngineFactory.getEngine();
+            final Pac4jHTTPPostSimpleSignEncoder encoder = new Pac4jHTTPPostSimpleSignEncoder(adapter);
             encoder.setVelocityEngine(velocityEngine);
             return encoder;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectActionBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectActionBuilder.java
@@ -41,7 +41,10 @@ public class SAML2RedirectActionBuilder implements RedirectActionBuilder {
         this.client.getProfileHandler().send(context, authnRequest, relayState);
 
         final Pac4jSAMLResponse adapter = context.getProfileRequestContextOutboundMessageTransportResponse();
-        if (this.client.getConfiguration().getAuthnRequestBindingType().equalsIgnoreCase(SAMLConstants.SAML2_POST_BINDING_URI)) {
+
+        final String bindingType = this.client.getConfiguration().getAuthnRequestBindingType();
+        if (SAMLConstants.SAML2_POST_BINDING_URI.equalsIgnoreCase(bindingType) ||
+                SAMLConstants.SAML2_POST_SIMPLE_SIGN_BINDING_URI.equalsIgnoreCase(bindingType)) {
             final String content = adapter.getOutgoingContent();
             return RedirectAction.success(content);
         }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPPostSimpleSignEncoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPPostSimpleSignEncoder.java
@@ -1,0 +1,67 @@
+package org.pac4j.saml.transport;
+
+import org.apache.velocity.VelocityContext;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.messaging.encoder.MessageEncodingException;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.binding.BindingException;
+import org.opensaml.saml.common.binding.SAMLBindingSupport;
+import org.opensaml.saml.saml2.binding.encoding.impl.HTTPPostSimpleSignEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStreamWriter;
+import java.net.URI;
+
+/**
+ * Pac4j implementation for HTTP Post Simple-Sign extending openSAML {@link HTTPPostSimpleSignEncoder}.
+ *
+ * @author Misagh Moayyed
+ * @since 1.8
+ */
+public class Pac4jHTTPPostSimpleSignEncoder extends HTTPPostSimpleSignEncoder {
+    private final static Logger log = LoggerFactory.getLogger(Pac4jHTTPPostSimpleSignEncoder.class);
+
+    private final Pac4jSAMLResponse responseAdapter;
+
+    public Pac4jHTTPPostSimpleSignEncoder(final Pac4jSAMLResponse responseAdapter) {
+        this.responseAdapter = responseAdapter;
+        setVelocityTemplateId(DEFAULT_TEMPLATE_ID);
+    }
+
+    /**
+     * Gets the response URL from the message context.
+     *
+     * @param messageContext current message context
+     * @return response URL from the message context
+     * @throws MessageEncodingException throw if no relying party endpoint is available
+     */
+    protected URI getEndpointURL(MessageContext<SAMLObject> messageContext) throws MessageEncodingException {
+        try {
+            return SAMLBindingSupport.getEndpointURL(messageContext);
+        } catch (BindingException e) {
+            throw new MessageEncodingException("Could not obtain message endpoint URL", e);
+        }
+    }
+
+    protected void postEncode(final MessageContext<SAMLObject> messageContext, final String endpointURL) throws MessageEncodingException {
+        log.debug("Invoking Velocity template to create POST body");
+
+        try {
+            final VelocityContext velocityContext = new VelocityContext();
+            this.populateVelocityContext(velocityContext, messageContext, endpointURL);
+
+            responseAdapter.setContentType("text/html");
+            responseAdapter.init();
+
+            final OutputStreamWriter out = responseAdapter.getOutputStreamWriter();
+            this.getVelocityEngine().mergeTemplate(this.getVelocityTemplateId(), "UTF-8", velocityContext, out);
+            out.flush();
+        } catch (Exception e) {
+            throw new MessageEncodingException("Error creating output document", e);
+        }
+    }
+
+    @Override
+    protected void doInitialize() { }
+}


### PR DESCRIPTION
Implementing HTTP Post **Simple-Sign** protocol, inspired from `Pac4jHTTPPostEncoder` but extending directly openSAML class `HTTPPostSimpleSignEncoder`.