### PR TITLE
pac4j-kerberos does not implement SPNEGO with DirectClient (#1294)

### DIFF
--- a/documentation/docs/clients/kerberos.md
+++ b/documentation/docs/clients/kerberos.md
@@ -29,7 +29,7 @@ You can use the following clients depending on how they are passed in the HTTP r
 | Behaviour wanted | Client |
 |-------------|--------|
 | **Web Browser** (Firefox/Safari/IE)<br/> after ticket validation, it stores user profile in the session| [`IndirectKerberosClient`](https://github.com/pac4j/pac4j/blob/master/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/indirect/IndirectKerberosClient.java)<br>(upon failure it sends a `HTTP 401` with a `WWW-Authenticate: Negotiate` header asking the browser to provide the Kerberos/SPNEGO credentials) |
-| **Stateless Web service** | [`DirectKerberosClient`](https://github.com/pac4j/pac4j/blob/master/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/direct/DirectKerberosClient.java) <br/>credentials are expected to be already provided as a request's HTTP header:<br/>`Authentication: Negotiate SomeBase64EncKerberosTicket`<br/> (it will not send any headers to indicate expected mechanism) |
+| **Stateless Web service** | [`DirectKerberosClient`](https://github.com/pac4j/pac4j/blob/master/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/direct/DirectKerberosClient.java) <br/>credentials can be provided upfront as a request's HTTP header:<br/>`Authentication: Negotiate SomeBase64EncKerberosTicket`<br/> (if not provided, the default strategy with send a `HTTP 401` with a `WWW-Authenticate: Negotiate` header asking the remote to provide the Kerberos/SPNEGO credentials) |
 {:.table-striped}
 
 **Example:**

--- a/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/direct/DirectKerberosClient.java
+++ b/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/direct/DirectKerberosClient.java
@@ -1,6 +1,8 @@
 package org.pac4j.kerberos.client.direct;
 
 import org.pac4j.core.client.DirectClient;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.authenticator.Authenticator;
 import org.pac4j.core.profile.creator.ProfileCreator;
 import org.pac4j.kerberos.credentials.KerberosCredentials;
@@ -33,4 +35,13 @@ public class DirectKerberosClient extends DirectClient<KerberosCredentials, Kerb
     protected void clientInit() {
         defaultCredentialsExtractor(new KerberosExtractor());
     }
+
+    @Override
+    protected KerberosCredentials retrieveCredentials(WebContext context) {
+        // Set the WWW-Authenticate: Negotiate header in case no credentials are found
+        // to trigger the SPNEGO process by replying with 401 Unauthorized
+        context.setResponseHeader(HttpConstants.AUTHENTICATE_HEADER, "Negotiate");
+        return super.retrieveCredentials(context);
+    }
+
 }

--- a/pac4j-kerberos/src/test/java/org/pac4j/kerberos/client/direct/KerberosClientTests.java
+++ b/pac4j-kerberos/src/test/java/org/pac4j/kerberos/client/direct/KerberosClientTests.java
@@ -73,6 +73,16 @@ public class KerberosClientTests implements TestsConstants {
     }
 
     @Test
+    public void testWWWAuthenticateNegotiateHeaderIsSetToTriggerSPNEGOWhenNoCredentialsAreFound() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        final DirectKerberosClient client = new DirectKerberosClient(new KerberosAuthenticator(krbValidator));
+        KerberosCredentials credentials = client.getCredentials(new J2EContext(request, response));
+        assertNull(credentials);
+        verify(response).setHeader(HttpConstants.AUTHENTICATE_HEADER, "Negotiate");
+    }
+
+    @Test
     public void testAuthentication() {
         when(krbValidator.validateTicket(any())).thenReturn(new KerberosTicketValidation("garry", null, null, null));
         final DirectKerberosClient client = new DirectKerberosClient(new KerberosAuthenticator(krbValidator));


### PR DESCRIPTION
Added appropriate header to response so that SPNEGO is triggered when sending 401 back to remote and credentials are missing - 3.7.x branch