### PR TITLE
feat: be able to configure a unique name on client signing certificates

### DIFF
--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/SAML2ClientConfigurationTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/SAML2ClientConfigurationTests.java
@@ -1,13 +1,13 @@
 package org.pac4j.saml.client;
 
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
 import org.junit.Test;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
-
-import java.io.File;
-
-import static org.junit.Assert.*;
 
 /**
  * This is {@link SAML2ClientConfigurationTests}.
@@ -29,5 +29,28 @@ public class SAML2ClientConfigurationTests {
         assertTrue(signingCertPem.exists());
         final File signingCert = new File("target/saml-signing-cert.crt");
         assertTrue(signingCert.exists());
+        final File signingCertKey = new File("target/saml-signing-cert.key");
+        assertTrue(signingCertKey.exists());
+    }
+
+    @Test
+    public void verifySigningCertNamedExported() {
+        final String certNamePart = "id-09 _*#AD";
+        final String certNameResult = "id-09_AD";
+        final SAML2Configuration configuration = new SAML2Configuration();
+        configuration.setForceKeystoreGeneration(true);
+        configuration.setKeystorePath("target/keystore.jks");
+        configuration.setCertificateNameToAppend(certNamePart);
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+        configuration.setServiceProviderMetadataResource(new FileSystemResource("target/out.xml"));
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.init();
+        final File signingCertPem = new File("target/saml-signing-cert-" + certNameResult + ".pem");
+        assertTrue(signingCertPem.exists());
+        final File signingCert = new File("target/saml-signing-cert-" + certNameResult + ".crt");
+        assertTrue(signingCert.exists());
+        final File signingCertKey = new File("target/saml-signing-cert-" + certNameResult + ".key");
+        assertTrue(signingCertKey.exists());
     }
 }


### PR DESCRIPTION
Like already discussed here is the PR to customize certificate name generated for one client.
Test change are provided