### PR TITLE
Disable type-checking for CAS Profile definitions

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
@@ -2,7 +2,9 @@ package org.pac4j.cas.profile;
 
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.pac4j.cas.client.CasProxyReceptor;
+import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
 
 /**
@@ -26,5 +28,19 @@ public class CasProfileDefinition extends CommonProfileDefinition<CommonProfile>
             }
             return casProfile;
         });
+    }
+
+    @Override
+    protected void configurePrimaryAttributes() {
+        primary(EMAIL, Converters.STRING);
+        primary(FIRST_NAME, Converters.STRING);
+        primary(FAMILY_NAME, Converters.STRING);
+        primary(DISPLAY_NAME, Converters.STRING);
+        primary(GENDER, Converters.STRING);
+        primary(LOCALE, Converters.STRING);
+        primary(PICTURE_URL, Converters.STRING);
+        primary(PROFILE_URL, Converters.STRING);
+        primary(LOCATION, Converters.STRING);
+        primary(Pac4jConstants.USERNAME, Converters.STRING);
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/converter/GenderConverter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/converter/GenderConverter.java
@@ -17,8 +17,8 @@ public final class GenderConverter extends AbstractAttributeConverter<Gender> {
 
     public GenderConverter() {
         super(Gender.class);
-        this.maleText = Pattern.compile("(^m$)|(^male$)");
-        this.femaleText = Pattern.compile("(^f$)|(^female$)");
+        this.maleText = Pattern.compile("(^m$)|(^male$)", Pattern.CASE_INSENSITIVE);
+        this.femaleText = Pattern.compile("(^f$)|(^female$)", Pattern.CASE_INSENSITIVE);
     }
 
     public GenderConverter(final String maleText, final String femaleText) {

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
@@ -25,6 +25,10 @@ public class CommonProfileDefinition<P extends CommonProfile> extends ProfileDef
     public static final String LOCATION = "location";
 
     public CommonProfileDefinition() {
+        configurePrimaryAttributes();
+    }
+
+    protected void configurePrimaryAttributes() {
         primary(EMAIL, Converters.STRING);
         primary(FIRST_NAME, Converters.STRING);
         primary(FAMILY_NAME, Converters.STRING);


### PR DESCRIPTION
## Problem

The CAS profile definition, as part of the hierarchy, attempts to install a number of attribute converters to auto-convert attributes such as `gender`, `locale`, etc. These attributes are only converted if they match the converter's required attribute type. This assumption does not hold true for CAS, as all attribute released in validation payloads are of type `String` and will never be classified with their own dedicated type. With such type restrictions, (specially more so when CAS is running as an OIDC provider), certain attributes can never be released to clients because their value will never match the required type.

## Patch

- Allow gender matching to be case insensitive
- For CAS profile definitions, disable type checking that requires certain attributes such as `gender` to match a certain class

This should also be backported to 3.7.x.