### PR TITLE
Update maven-javadoc-plugin to 3.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -385,6 +385,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>


### PR DESCRIPTION
Backport from master.

Fixes the following:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:jar (attach-javadocs) on project pac4j-core: Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.0:jar failed.: NullPointerException -> [Help 1]
