### PR TITLE
Upgrade maven-surefire-plugin to v2.22.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.20.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<includes>
                         <include>**/*Test.java</include>


### PR DESCRIPTION
Backport from master.

Fixes the following error:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test (default-test) on project pac4j-core: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.20.1:test failed.: NullPointerException -> [Help 1]
