### PR TITLE
NameQualifier should not be sent in authentication requests

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -115,6 +115,13 @@ But you can force your own entity ID with the `serviceProviderEntityId` paramete
 cfg.setServiceProviderEntityId("http://localhost:8080/callback?extraParameter");
 ```
 
+By SAML specification, the authentication request must not contain a NameQualifier, if the SP entity is in the format nameid-format:entity. However, some IdP require that information to be present. You can force a NameQualifier in the request with the `useNameQualifier` parameter:
+
+```java
+// force NameQualifier in the authn request
+cfg.setUseNameQualifier(true);
+```
+
 To allow the authentication request sent to the identity provider to specify an attribute consuming index:
 
 ```java
@@ -216,8 +223,7 @@ Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files c
 
 ### c) Disable Name Qualifier for format urn:oasis:names:tc:SAML:2.0:nameid-format:entity
 
-ADFS 3.0 does not accept NameQualifier when using urn:oasis:names:tc:SAML:2.0:nameid-format:entity. In the `SAML2Configuration`, you can use setUseNameQualifier to disable the NameQualifier from SAML Request.
-
+ADFS 3.0 does not accept NameQualifier when using urn:oasis:names:tc:SAML:2.0:nameid-format:entity. For this reason, the parameter `useNameQualifier` in the `SAML2Configuration` must be set to false, which is the default value.
 
 # Integration with various IdPs
 

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -19,10 +19,7 @@ title: Release notes&#58;
 - Use the 303 "See Other" and 307 "Temporary Redirect" HTTP actions after a POST request (`RedirectionActionHelper`)
 - Handles originally requested URLs with POST method
 - Add HTTP POST Simple-Sign protocol implementation
-- Add customizable SAML post Logout URL
 - QualifiedName must not be included by default in SAML authentication requests
-
-**v3.8.0**:
 
 **v3.7.0**:
 

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -19,7 +19,10 @@ title: Release notes&#58;
 - Use the 303 "See Other" and 307 "Temporary Redirect" HTTP actions after a POST request (`RedirectionActionHelper`)
 - Handles originally requested URLs with POST method
 - Add HTTP POST Simple-Sign protocol implementation
+- Add customizable SAML post Logout URL
 - QualifiedName must not be included by default in SAML authentication requests
+
+**v3.8.0**:
 
 **v3.7.0**:
 

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -19,6 +19,7 @@ title: Release notes&#58;
 - Use the 303 "See Other" and 307 "Temporary Redirect" HTTP actions after a POST request (`RedirectionActionHelper`)
 - Handles originally requested URLs with POST method
 - Add HTTP POST Simple-Sign protocol implementation
+- QualifiedName must not be included by default in SAML authentication requests
 
 **v3.7.0**:
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -114,7 +114,7 @@ public class SAML2Configuration extends InitializableObject {
 
     private String nameIdPolicyFormat = null;
 
-    private boolean useNameQualifier = true;
+    private boolean useNameQualifier = false;
 
     private boolean signMetadata;
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -29,12 +29,25 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testCustomSpEntityIdForPostBinding() {
         final SAML2Client client = getClient();
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/cb");
+        client.getConfiguration().setUseNameQualifier(true);
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final OkAction action = (OkAction) client.redirect(context).get();
         assertTrue(getDecodedAuthnRequest(action.getContent())
                 .contains("<saml2:Issuer "
                         + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "NameQualifier=\"http://localhost:8080/cb\" "
+                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
+    }
+
+    @Test
+    public void testStandardSpEntityIdForPostBinding() {
+        final SAML2Client client = getClient();
+        client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/cb");
+        final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
+        final OkAction action = (OkAction) client.redirect(context).get();
+        assertTrue(getDecodedAuthnRequest(action.getContent())
+                .contains("<saml2:Issuer "
+                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -38,6 +38,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testCustomSpEntityIdForRedirectBinding() {
         final SAML2Client client = getClient();
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/callback");
+        client.getConfiguration().setUseNameQualifier(true);
 
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.redirect(context).get();
@@ -47,6 +48,21 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
                 "<saml2:Issuer "
                         + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "NameQualifier=\"http://localhost:8080/callback\" "
+                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
+    }
+
+    @Test
+    public void testStandardSpEntityIdForRedirectBinding() {
+        final SAML2Client client = getClient();
+        client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/callback");
+
+        final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
+        final FoundAction action = (FoundAction) client.redirect(context).get();
+        final String inflated = getInflatedAuthnRequest(action.getLocation());
+
+        assertTrue(inflated.contains(
+                "<saml2:Issuer "
+                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
     }
 


### PR DESCRIPTION
This fix makes the default authentication request coherent with SAML core specification.
