### PR TITLE
Add replay protection

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -76,10 +76,12 @@ Or you can even use the empty constructor and the appropriate setters:
 Finally, you need to declare the `SAML2Client` based on the previous configuration:
 
 ```java
-Saml2Client client = new Saml2Client(cfg);
+SAML2Client client = new SAML2Client(cfg);
 ```
 
 After a successful authentication, a [`SAML2Profile`](https://github.com/pac4j/pac4j/blob/master/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java) is returned.
+
+The `SAML2Client` configures a `ReplayCache`, which protects against replay attacks. This `ReplayCache` must keep state between authentications. Therefore a single instance of the `SAML2Client` must be used. If this is not possible, you can override the `initSAMLReplayCache` method to create a custom `ReplayCacheProvider`.
 
 ## 3) Additional configuration:
 

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,6 +5,8 @@ title: Release notes&#58;
 
 **v3.8.0**:
 
+- Added replay protectection to the SAML client.
+
 **v3.7.0**:
 
 - Fix SAML SP metadata signature

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -92,6 +92,11 @@
         </dependency>
         <dependency>
             <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-storage-impl</artifactId>
+            <version>${opensaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.opensaml</groupId>
             <artifactId>opensaml-xmlsec-impl</artifactId>
             <version>${opensaml.version}</version>
         </dependency>

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLReplayException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLReplayException.java
@@ -1,0 +1,22 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLReplayException}.
+ *
+ * @since 3.8.0
+ */
+public class SAMLReplayException extends SAMLException {
+    private static final long serialVersionUID = 6973714579016063655L;
+
+    public SAMLReplayException(final String message) {
+        super(message);
+    }
+
+    public SAMLReplayException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLReplayException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -13,6 +13,7 @@ import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.impl.AbstractSAML2ResponseValidator;
+import org.pac4j.saml.replay.ReplayCacheProvider;
 
 import java.util.List;
 
@@ -25,9 +26,18 @@ import java.util.List;
  */
 public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
 
+    /**
+     * @deprecated this constructor does not accept a replay cache, replay protection will be disabled
+     */
+    @Deprecated
     public SAML2LogoutValidator(final SAML2SignatureTrustEngineProvider engine, final Decrypter decrypter,
                                 final LogoutHandler logoutHandler) {
-        super(engine, decrypter, logoutHandler);
+        this(engine, decrypter, logoutHandler, null);
+    }
+
+    public SAML2LogoutValidator(final SAML2SignatureTrustEngineProvider engine, final Decrypter decrypter,
+            final LogoutHandler logoutHandler, final ReplayCacheProvider replayCache) {
+        super(engine, decrypter, logoutHandler, replayCache);
     }
 
     /**

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -36,7 +36,6 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
 
         peerContext.setRole(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
         context.getSAMLSelfProtocolContext().setProtocol(SAMLConstants.SAML20P_NS);
-        context.getSAMLSelfProtocolContext().setProtocol(SAMLConstants.SAML20P_NS);
 
         final AbstractPac4jDecoder decoder = getDecoder(webContext);
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/replay/InMemoryReplayCacheProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/replay/InMemoryReplayCacheProvider.java
@@ -1,0 +1,30 @@
+package org.pac4j.saml.replay;
+
+import org.opensaml.storage.ReplayCache;
+import org.opensaml.storage.impl.MemoryStorageService;
+import org.pac4j.saml.exceptions.SAMLException;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+
+public class InMemoryReplayCacheProvider implements ReplayCacheProvider {
+    private ReplayCache cache;
+
+    public InMemoryReplayCacheProvider() {
+        try {
+            MemoryStorageService storageService = new MemoryStorageService();
+            storageService.setId("pac4j-replay-storage");
+            storageService.initialize();
+
+            cache = new ReplayCache();
+            cache.setStorage(storageService);
+            cache.initialize();
+        } catch (ComponentInitializationException e) {
+            throw new SAMLException(e);
+        }
+    }
+
+    @Override
+    public ReplayCache get() {
+        return cache;
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/replay/InMemoryReplayCacheProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/replay/InMemoryReplayCacheProvider.java
@@ -6,6 +6,11 @@ import org.pac4j.saml.exceptions.SAMLException;
 
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 
+/**
+ * Default replay cache provider which stores the identifiers in memory. This
+ * implementation will not work in a clustered environment and requires the same
+ * instance is used for all SAML authentications.
+ */
 public class InMemoryReplayCacheProvider implements ReplayCacheProvider {
     private ReplayCache cache;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/replay/ReplayCacheProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/replay/ReplayCacheProvider.java
@@ -1,0 +1,14 @@
+package org.pac4j.saml.replay;
+
+import org.opensaml.storage.ReplayCache;
+
+/**
+ * Builds or resolves the replay cache that is used to prevent replay attacks.
+ * It is important that this returns the same {@code ReplayCache} instance over
+ * multiple invocations.
+ * 
+ * @since 3.8
+ */
+public interface ReplayCacheProvider {
+    ReplayCache get();
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -36,16 +36,18 @@ import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.exceptions.SAMAssertionSubjectException;
 import org.pac4j.saml.exceptions.SAMLAssertionAudienceException;
 import org.pac4j.saml.exceptions.SAMLAssertionConditionException;
 import org.pac4j.saml.exceptions.SAMLAuthnInstantException;
 import org.pac4j.saml.exceptions.SAMLAuthnSessionCriteriaException;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.exceptions.SAMLInResponseToMismatchException;
+import org.pac4j.saml.exceptions.SAMLReplayException;
 import org.pac4j.saml.exceptions.SAMLSignatureRequiredException;
-import org.pac4j.saml.exceptions.SAMAssertionSubjectException;
 import org.pac4j.saml.exceptions.SAMLSubjectConfirmationException;
 import org.pac4j.saml.profile.impl.AbstractSAML2ResponseValidator;
+import org.pac4j.saml.replay.ReplayCacheProvider;
 import org.pac4j.saml.storage.SAMLMessageStorage;
 import org.pac4j.saml.util.SAML2Utils;
 
@@ -71,13 +73,30 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
     private int maximumAuthenticationLifetime;
 
     private final boolean wantsAssertionsSigned;
-
+    
+    /**
+     * @deprecated this constructor does not accept a replay cache, replay protection will be disabled
+     */
+    @Deprecated
     public SAML2AuthnResponseValidator(final SAML2SignatureTrustEngineProvider engine,
-                                       final Decrypter decrypter,
-                                       final LogoutHandler logoutHandler,
-                                       final int maximumAuthenticationLifetime,
-                                       final boolean wantsAssertionsSigned) {
-        this(engine, decrypter, logoutHandler, maximumAuthenticationLifetime, wantsAssertionsSigned, new BasicURLComparator());
+            final Decrypter decrypter,
+            final LogoutHandler logoutHandler,
+            final int maximumAuthenticationLifetime,
+            final boolean wantsAssertionsSigned) {
+        this(engine, decrypter, logoutHandler, maximumAuthenticationLifetime, wantsAssertionsSigned, null, new BasicURLComparator());
+    }
+
+    /**
+     * @deprecated this constructor does not accept a replay cache, replay protection will be disabled
+     */
+    @Deprecated
+    public SAML2AuthnResponseValidator(final SAML2SignatureTrustEngineProvider engine,
+            final Decrypter decrypter,
+            final LogoutHandler logoutHandler,
+            final int maximumAuthenticationLifetime,
+            final boolean wantsAssertionsSigned,
+            final URIComparator uriComparator) {
+        this(engine, decrypter, logoutHandler, maximumAuthenticationLifetime, wantsAssertionsSigned, null, uriComparator);
     }
 
     public SAML2AuthnResponseValidator(final SAML2SignatureTrustEngineProvider engine,
@@ -85,8 +104,18 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
                                        final LogoutHandler logoutHandler,
                                        final int maximumAuthenticationLifetime,
                                        final boolean wantsAssertionsSigned,
+                                       final ReplayCacheProvider replayCache) {
+        this(engine, decrypter, logoutHandler, maximumAuthenticationLifetime, wantsAssertionsSigned, replayCache, new BasicURLComparator());
+    }
+
+    public SAML2AuthnResponseValidator(final SAML2SignatureTrustEngineProvider engine,
+                                       final Decrypter decrypter,
+                                       final LogoutHandler logoutHandler,
+                                       final int maximumAuthenticationLifetime,
+                                       final boolean wantsAssertionsSigned,
+                                       final ReplayCacheProvider replayCache,
                                        final URIComparator uriComparator) {
-        super(engine, decrypter, logoutHandler, uriComparator);
+        super(engine, decrypter, logoutHandler, replayCache, uriComparator);
         this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
         this.wantsAssertionsSigned = wantsAssertionsSigned;
     }
@@ -101,6 +130,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
         }
         final Response response = (Response) message;
         final SignatureTrustEngine engine = this.signatureTrustEngineProvider.build();
+        verifyMessageReplay(context);
         validateSamlProtocolResponse(response, context, engine);
 
         if (decrypter != null) {
@@ -381,6 +411,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
         for (final SubjectConfirmation confirmation : subject.getSubjectConfirmations()) {
             if (SubjectConfirmation.METHOD_BEARER.equals(confirmation.getMethod()) &&
                 isValidBearerSubjectConfirmationData(confirmation.getSubjectConfirmationData(), context)) {
+                validateAssertionReplay((Assertion) subject.getParent(), confirmation.getSubjectConfirmationData());
                 NameID nameIDFromConfirmation = confirmation.getNameID();
                 final BaseID baseIDFromConfirmation = confirmation.getBaseID();
                 final EncryptedID encryptedIDFromConfirmation = confirmation.getEncryptedID();
@@ -468,6 +499,28 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
         }
 
         return true;
+    }
+    
+    /**
+     * Checks that the bearer assertion is not being replayed.
+     * 
+     * @param assertion The Assertion to check
+     * @param data      The SubjectConfirmationData to check the assertion against
+     */
+    protected void validateAssertionReplay(final Assertion assertion, final SubjectConfirmationData data) {
+        if (assertion.getID() == null) {
+            throw new SAMLReplayException("The assertion does not have an ID");
+        }
+
+        if (replayCache == null) {
+            logger.warn("No replay cache specified, skipping replay verification");
+            return;
+        }
+
+        if (!replayCache.get().check(getClass().getName(), assertion.getID(),
+                data.getNotOnOrAfter().getMillis() + acceptedSkew * 1000)) {
+            throw new SAMLReplayException("Rejecting replayed assertion ID '" + assertion.getID() + "'");
+        }
     }
 
     /**

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -8,6 +8,7 @@ import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.replay.InMemoryReplayCacheProvider;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -24,7 +25,8 @@ public class SAML2DefaultResponseValidatorTests {
     private SAML2AuthnResponseValidator createResponseValidatorWithSigningValidationOf(boolean wantsAssertionsSigned) {
         SAML2SignatureTrustEngineProvider trustEngineProvider = mock(SAML2SignatureTrustEngineProvider.class);
         Decrypter decrypter = mock(Decrypter.class);
-        return new SAML2AuthnResponseValidator(trustEngineProvider, decrypter, null, 0, wantsAssertionsSigned);
+        return new SAML2AuthnResponseValidator(trustEngineProvider, decrypter, null, 0, wantsAssertionsSigned,
+                new InMemoryReplayCacheProvider());
     }
 
     @Test


### PR DESCRIPTION
This pull requests adds replay protection to the `SAML2Client`. This is actually mandatory in the Web Profile when using POST binding, see 4.1.4.5 POST-Specific Processing Rules:

> The service provider MUST ensure that bearer assertions are not replayed, by maintaining the set of used ID values for the length of time for which the assertion would be considered valid based on the
`NotOnOrAfter` attribute in the `<SubjectConfirmationData>`.

I've implemented both a message replay protection, which will invalidate any message with a previously seen ID and a replay protection on the assertion itself. The former is not required by the spec (at least I cannot find such a statement), but I've seen it in many implementations and think it is considered good practice.

To work correctly, this does require the `SAML2Client` to be instantiated only once. I've put this in the documentation and provided a way to circumvent this problem. For example, we will be using a cache that is replicated in our cluster.

I know that PR (and any change for that respect) requires tests, but I couldn't find any tests for actual SAML response validation. `SAML2DefaultResponseValidatorTests` only checks a few very basic things and there is no code that actual constructs a `Response` to validate. Therefore this PR does not contain any tests.