### PR TITLE
Build on jdk11

### DIFF
--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GenericOAuth20Client.java
@@ -118,7 +118,7 @@ public class GenericOAuth20Client extends OAuth20Client<OAuth20Profile> {
                         AbstractAttributeConverter<?> converter = (AbstractAttributeConverter<?>) x.getDeclaredConstructor().newInstance();
                         Method accept = AbstractAttributeConverter.class.getDeclaredMethod("accept", String.class);
                         return (Boolean) accept.invoke(converter, typeName);
-                    } catch (Exception e) {
+                    } catch (ReflectiveOperationException e) {
                         LOG.warn("Ignore type which no parameterless constructor:" + x.getName());
                     }
                     return false;

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -31,11 +31,19 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/cb");
         final WebContext context = new J2EContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final RedirectAction action = client.getRedirectAction(context);
-        assertTrue(getDecodedAuthnRequest(action.getContent())
-                .contains("<saml2:Issuer "
-                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
-                        + "NameQualifier=\"http://localhost:8080/cb\" "
-                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
+        
+        // JDK8 and JDK11 do not produce the same XML (attributes in different order)
+        // something like xmlunit would have been better but may be a bit overkill for just 2 failing tests
+        final String issuerJdk8 = "<saml2:Issuer "
+                + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
+                + "NameQualifier=\"http://localhost:8080/cb\" "
+                + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>";
+        final String issuerJdk11 = "<saml2:Issuer "
+                + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\" "
+                + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
+                + "NameQualifier=\"http://localhost:8080/cb\">http://localhost:8080/cb</saml2:Issuer>";
+        final String decodedAuthnRequest = getDecodedAuthnRequest(action.getContent());
+        assertTrue(decodedAuthnRequest.contains(issuerJdk8) || decodedAuthnRequest.contains(issuerJdk11));
     }
 
     @Test

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -42,11 +42,17 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         final RedirectAction action = client.getRedirectAction(context);
         final String inflated = getInflatedAuthnRequest(action.getLocation());
 
-        assertTrue(inflated.contains(
-                "<saml2:Issuer "
-                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
-                        + "NameQualifier=\"http://localhost:8080/callback\" "
-                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
+        // JDK8 and JDK11 do not produce the same XML (attributes in different order)
+        // something like xmlunit would have been better but may be a bit overkill for just 2 failing tests
+        final String issuerJdk8 = "<saml2:Issuer "
+                + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
+                + "NameQualifier=\"http://localhost:8080/callback\" "
+                + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>";
+        final String issuerJdk11 = "<saml2:Issuer "
+                + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\" "
+                + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
+                + "NameQualifier=\"http://localhost:8080/callback\">http://localhost:8080/callback</saml2:Issuer>";
+        assertTrue(inflated.contains(issuerJdk8) || inflated.contains(issuerJdk11));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 		<spring.security.version>5.0.0.RELEASE</spring.security.version>
 		<shiro.version>1.4.0</shiro.version>
         <jbcrypt.version>0.4.1</jbcrypt.version>
-		<mockito.version>2.13.0</mockito.version>
+		<mockito.version>2.28.2</mockito.version>
 		<slf4j.version>1.7.25</slf4j.version>
         <unboundid.version>4.0.3</unboundid.version>
         <h2.version>1.4.196</h2.version>
@@ -454,7 +454,11 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.1.0</version>
+					<configuration>
+						<source>${java.version}</source>
+						<doclint>none</doclint>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -396,19 +396,19 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.5</version>
+				<groupId>com.github.spotbugs</groupId>
+				<artifactId>spotbugs-maven-plugin</artifactId>
+				<version>3.1.12</version>
 				<configuration>
 					<effort>Low</effort> <!-- Max -->
 					<threshold>Max</threshold> <!-- Medium Low -->
 					<failOnError>true</failOnError>
-					<excludeFilterFile>${basedir}/../findbugs-exclude.xml</excludeFilterFile>
+					<excludeFilterFile>${basedir}/../spotbugs-exclude.xml</excludeFilterFile>
 					<includeTests>true</includeTests>
 				</configuration>
 				<executions>
 					<execution>
-						<id>run-findbugs</id>
+						<id>run-spotbugs</id>
 						<phase>compile</phase>
 						<goals>
 							<goal>check</goal>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -16,6 +16,10 @@
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE" />
     </Match>
     <Match>
+        <Class name="~.*MongoProfileService"/>
+        <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE" />
+    </Match>
+    <Match>
         <Class name="~.*SAML2Credentials"/>
         <Bug code="Se" />
     </Match>


### PR DESCRIPTION
This PR fixes the Pac4j build on JDK11. No functional changes were made.

2 SAML related tests were fixed in a 'quick and dirty' way, but that seemed the best to me in the current code base. These tests would benefit from something like xmlunit, but that would require many more changes.