### PR TITLE
Upgrade some SAML depedencies

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -13,10 +13,11 @@
     <name>pac4j for SAML protocol</name>
 
     <properties>
-        <opensaml.version>3.4.0</opensaml.version>
+        <opensaml.version>3.4.3</opensaml.version>
         <joda-time.version>2.9.9</joda-time.version>
         <velocity.version>1.7</velocity.version>
         <xmlsectool.version>2.0.0</xmlsectool.version>
+        <xmlsec.version>2.1.3</xmlsec.version>
         <!-- The dependency to commons-collections 3.2.2 is explicitly made to replace 3.2.1 (vulnerable) used by
         velocity 1.7. It can be removed as soon as velocity 1.7 is not used anymore-->
         <commons-collections.version>3.2.2</commons-collections.version>
@@ -25,6 +26,16 @@
         <!-- This version is used to override the version xmlsectool depends on. it should be compatible -->
         <httpcore.version>4.4.8</httpcore.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.santuario</groupId>
+                <artifactId>xmlsec</artifactId>
+                <version>${xmlsec.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Some minor upgrades to SAML dependencies: opensaml 3.4.0 to 3.4.3 and manage xmlsec at version 2.1.3.