### PR TITLE
Backport to 3.8: NameQualifier should not be sent in authentication requests 

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -115,6 +115,13 @@ But you can force your own entity ID with the `serviceProviderEntityId` paramete
 cfg.setServiceProviderEntityId("http://localhost:8080/callback?extraParameter");
 ```
 
+By SAML specification, the authentication request must not contain a NameQualifier, if the SP entity is in the format nameid-format:entity. However, some IdP require that information to be present. You can force a NameQualifier in the request with the `useNameQualifier` parameter:
+
+```java
+// force NameQualifier in the authn request
+cfg.setUseNameQualifier(true);
+```
+
 To allow the authentication request sent to the identity provider to specify an attribute consuming index:
 
 ```java
@@ -216,8 +223,7 @@ Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files c
 
 ### c) Disable Name Qualifier for format urn:oasis:names:tc:SAML:2.0:nameid-format:entity
 
-ADFS 3.0 does not accept NameQualifier when using urn:oasis:names:tc:SAML:2.0:nameid-format:entity. In the `SAML2Configuration`, you can use setUseNameQualifier to disable the NameQualifier from SAML Request.
-
+ADFS 3.0 does not accept NameQualifier when using urn:oasis:names:tc:SAML:2.0:nameid-format:entity. For this reason, the parameter `useNameQualifier` in the `SAML2Configuration` must be set to false, which is the default value.
 
 # Integration with various IdPs
 

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -4,6 +4,7 @@ title: Release notes&#58;
 ---
 
 **v3.8.0**:
+- QualifiedName must not be included by default in SAML authentication requests
 
 **v3.7.0**:
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -115,7 +115,7 @@ public class SAML2Configuration extends InitializableObject {
 
     private String nameIdPolicyFormat = null;
 
-    private boolean useNameQualifier = true;
+    private boolean useNameQualifier = false;
 
     private boolean signMetadata;
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -29,12 +29,25 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testCustomSpEntityIdForPostBinding() {
         final SAML2Client client = getClient();
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/cb");
+        client.getConfiguration().setUseNameQualifier(true);
         final WebContext context = new J2EContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final RedirectAction action = client.getRedirectAction(context);
         assertTrue(getDecodedAuthnRequest(action.getContent())
                 .contains("<saml2:Issuer "
                         + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "NameQualifier=\"http://localhost:8080/cb\" "
+                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
+    }
+
+    @Test
+    public void testStandardSpEntityIdForPostBinding() {
+        final SAML2Client client = getClient();
+        client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/cb");
+        final WebContext context = new J2EContext(new MockHttpServletRequest(), new MockHttpServletResponse());
+        final RedirectAction action = client.getRedirectAction(context);
+        assertTrue(getDecodedAuthnRequest(action.getContent())
+                .contains("<saml2:Issuer "
+                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/cb</saml2:Issuer>"));
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -37,6 +37,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testCustomSpEntityIdForRedirectBinding() {
         final SAML2Client client = getClient();
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/callback");
+        client.getConfiguration().setUseNameQualifier(true);
 
         final WebContext context = new J2EContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final RedirectAction action = client.getRedirectAction(context);
@@ -46,6 +47,21 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
                 "<saml2:Issuer "
                         + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "NameQualifier=\"http://localhost:8080/callback\" "
+                        + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
+    }
+
+    @Test
+    public void testStandardSpEntityIdForRedirectBinding() {
+        final SAML2Client client = getClient();
+        client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/callback");
+
+        final WebContext context = new J2EContext(new MockHttpServletRequest(), new MockHttpServletResponse());
+        final RedirectAction action = client.getRedirectAction(context);
+        final String inflated = getInflatedAuthnRequest(action.getLocation());
+
+        assertTrue(inflated.contains(
+                "<saml2:Issuer "
+                        + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
                         + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">http://localhost:8080/callback</saml2:Issuer>"));
     }
 


### PR DESCRIPTION
This is a backport to branch 3.8.x of the pull request #1323.
By default SAML authentication requests do not include the NameQualifier anymore. It can still be added by configuration. This change makes the authentication requests compatible with SAML specification by default.
See the pull request #1323 for other details.