### PR TITLE
Artifact binding

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -100,7 +100,14 @@ cfg.setAuthnRequestBindingType(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 // or cfg.setAuthnRequestBindingType(SAMLConstants.SAML2_POST_SIMPLE_SIGN_BINDING_URI);
 ```
 
-Notice that the SP metadata will define the POST binding for the authentication response and for the IdP logout request.
+You can define the binding type for the authentication response via the `setResponseBindingType` method (defaults to POST):
+
+```java
+cfg.setResponseBindingType(SAMLConstants.SAML2_POST_BINDING_URI);
+// or cfg.setResponseBindingType(SAMLConstants.SAML2_ARTIFACT_BINDING_URI);
+```
+
+Notice that the SP metadata will define the POST binding for the IdP logout request.
 
 Once you have an authenticated web session on the Identity Provider, usually it won't prompt you again to enter your credentials and it will automatically generate a new assertion for you. By default, the SAML client will accept assertions based on a previous authentication for one hour. If you want to change this behavior, set the `maximumAuthenticationLifetime` parameter:
 

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -4,10 +4,10 @@ title: Release notes&#58;
 ---
 
 **v3.8.0**:
+
 - QualifiedName must not be included by default in SAML authentication requests
-
 - Added replay protectection to the SAML client.
-
+- Added support for the SAML artifact binding for the authentication response.
 - Fix SAML signature validation w.r.t. WantAssertionsSigned handling. Signing is now always required, even when WantAssertionsSigned is disabled. WantAssertionsSigned now requires explicit signing of the assertions, not the response.
 
 **v3.7.0**:

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.client;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
 
+import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.metadata.resolver.ChainingMetadataResolver;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.core.AuthnRequest;
@@ -39,8 +40,12 @@ import org.pac4j.saml.profile.SAML2Profile;
 import org.pac4j.saml.redirect.SAML2RedirectActionBuilder;
 import org.pac4j.saml.replay.InMemoryReplayCacheProvider;
 import org.pac4j.saml.replay.ReplayCacheProvider;
+import org.pac4j.saml.profile.api.SAML2MessageReceiver;
 import org.pac4j.saml.profile.api.SAML2ProfileHandler;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
+import org.pac4j.saml.sso.artifact.DefaultSOAPPipelineProvider;
+import org.pac4j.saml.sso.artifact.SAML2ArtifactBindingMessageReceiver;
+import org.pac4j.saml.sso.artifact.SOAPPipelineProvider;
 import org.pac4j.saml.sso.impl.*;
 import org.pac4j.saml.state.SAML2StateGenerator;
 import org.pac4j.saml.util.Configuration;
@@ -86,6 +91,8 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
     protected StateGenerator stateGenerator = new SAML2StateGenerator(this);
 
     protected ReplayCacheProvider replayCache;
+    
+    protected SOAPPipelineProvider soapPipelineProvider;
 
     static {
         CommonHelper.assertNotNull("parserPool", Configuration.getParserPool());
@@ -122,6 +129,7 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
         initSignatureTrustEngineProvider(metadataManager);
         initSAMLReplayCache();
         initSAMLResponseValidator();
+        initSOAPPipelineProvider();
         initSAMLProfileHandler();
         initSAMLLogoutResponseValidator();
         initSAMLLogoutProfileHandler();
@@ -132,13 +140,28 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
         defaultLogoutActionBuilder(new SAML2LogoutActionBuilder<>(this));
     }
 
+    protected void initSOAPPipelineProvider() {
+        this.soapPipelineProvider = new DefaultSOAPPipelineProvider(this);
+    }
+
     protected void initSAMLProfileHandler() {
+        SAML2MessageReceiver messageReceiver;
+        if (configuration.getResponseBindingType().equals(SAMLConstants.SAML2_POST_BINDING_URI)) {
+            messageReceiver = new SAML2WebSSOMessageReceiver(this.authnResponseValidator);
+        } else if (configuration.getResponseBindingType().equals(SAMLConstants.SAML2_ARTIFACT_BINDING_URI)) {
+            messageReceiver = new SAML2ArtifactBindingMessageReceiver(this.authnResponseValidator,
+                    this.idpMetadataResolver, this.spMetadataResolver, this.soapPipelineProvider);
+        } else {
+            throw new TechnicalException(
+                    "Unsupported response binding type: " + configuration.getResponseBindingType());
+        }
+        
         this.profileHandler = new SAML2WebSSOProfileHandler(
                 new SAML2WebSSOMessageSender(this.signatureSigningParametersProvider,
                         this.configuration.getAuthnRequestBindingType(),
                         true,
                         this.configuration.isAuthnRequestSigned()),
-                new SAML2WebSSOMessageReceiver(this.authnResponseValidator));
+                messageReceiver);
     }
 
     protected void initSAMLLogoutProfileHandler() {
@@ -301,5 +324,9 @@ public class SAML2Client extends IndirectClient<SAML2Credentials, SAML2Profile> 
 
     public void setLogoutProfileHandler(final SAML2ProfileHandler<LogoutRequest> logoutProfileHandler) {
         this.logoutProfileHandler = logoutProfileHandler;
+    }
+
+    public ReplayCacheProvider getReplayCache() {
+        return replayCache;
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -107,6 +107,8 @@ public class SAML2Configuration extends InitializableObject {
 
     private String authnRequestBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
 
+    private String responseBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
+
     private String spLogoutRequestBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
 
     private String spLogoutResponseBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
@@ -457,6 +459,14 @@ public class SAML2Configuration extends InitializableObject {
 
     public void setAuthnRequestBindingType(final String authnRequestBindingType) {
         this.authnRequestBindingType = authnRequestBindingType;
+    }
+
+    public String getResponseBindingType() {
+        return responseBindingType;
+    }
+
+    public void setResponseBindingType(String responseBindingType) {
+        this.responseBindingType = responseBindingType;
     }
 
     public String getSpLogoutRequestBindingType() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -8,6 +8,7 @@ import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
+import org.opensaml.saml.metadata.resolver.index.impl.RoleMetadataIndex;
 import org.opensaml.saml.saml2.metadata.EntitiesDescriptor;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.pac4j.core.exception.TechnicalException;
@@ -25,6 +26,7 @@ import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Iterator;
 
 /**
@@ -68,6 +70,7 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
                 final Document inCommonMDDoc = Configuration.getParserPool().parse(in);
                 final Element metadataRoot = inCommonMDDoc.getDocumentElement();
                 idpMetadataProvider = new DOMMetadataResolver(metadataRoot);
+                idpMetadataProvider.setIndexes(Collections.singleton(new RoleMetadataIndex()));
                 idpMetadataProvider.setParserPool(Configuration.getParserPool());
                 idpMetadataProvider.setFailFastInitialization(true);
                 idpMetadataProvider.setRequireValidMetadata(true);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
@@ -66,6 +66,8 @@ public class SAML2MetadataGenerator implements SAMLMetadataGenerator {
 
     protected String assertionConsumerServiceUrl;
 
+    protected String responseBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
+
     protected String singleLogoutServiceUrl;
 
     protected boolean authnRequestSigned = false;
@@ -190,7 +192,7 @@ public class SAML2MetadataGenerator implements SAMLMetadataGenerator {
 
         int index = 0;
         spDescriptor.getAssertionConsumerServices()
-            .add(getAssertionConsumerService(SAMLConstants.SAML2_POST_BINDING_URI, index++, this.defaultACSIndex == index));
+            .add(getAssertionConsumerService(responseBindingType, index++, this.defaultACSIndex == index));
         spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_POST_BINDING_URI));
         spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_POST_SIMPLE_SIGN_BINDING_URI));
         spDescriptor.getSingleLogoutServices().add(getSingleLogoutService(SAMLConstants.SAML2_REDIRECT_BINDING_URI));
@@ -326,6 +328,10 @@ public class SAML2MetadataGenerator implements SAMLMetadataGenerator {
 
     public final void setAssertionConsumerServiceUrl(final String assertionConsumerServiceUrl) {
         this.assertionConsumerServiceUrl = assertionConsumerServiceUrl;
+    }
+
+    public void setResponseBindingType(String responseBindingType) {
+        this.responseBindingType = responseBindingType;
     }
 
     public final void setSingleLogoutServiceUrl(final String singleLogoutServiceUrl) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -92,6 +92,7 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
             metadataGenerator.setRequestInitiatorLocation(callbackUrl);
             // Assertion consumer service url is the callback URL
             metadataGenerator.setAssertionConsumerServiceUrl(callbackUrl);
+            metadataGenerator.setResponseBindingType(configuration.getResponseBindingType());
             final String logoutUrl = CommonHelper.addParameter(callbackUrl, LOGOUT_ENDPOINT_PARAMETER, "true");
             // the logout URL is callback URL with an extra parameter
             metadataGenerator.setSingleLogoutServiceUrl(logoutUrl);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -65,7 +65,10 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
             throw new SAMLException("IDP Metadata cannot be null");
         }
 
+        final SAMLPeerEntityContext decodedPeerContext = decodedCtx.getParent()
+                .getSubcontext(SAMLPeerEntityContext.class);
         decodedCtx.getSAMLPeerEntityContext().setEntityId(metadata.getEntityID());
+        decodedCtx.getSAMLPeerEntityContext().setAuthenticated(decodedPeerContext.isAuthenticated());
 
         decodedCtx.getSAMLSelfEntityContext().setEntityId(context.getSAMLSelfEntityContext().getEntityId());
         decodedCtx.getSAMLSelfEndpointContext().setEndpoint(context.getSAMLSelfEndpointContext().getEndpoint());

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineFactory.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineFactory.java
@@ -50,6 +50,15 @@ import org.xml.sax.SAXException;
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 
+/**
+ * A default implementation of the pipeline factory, which enforces the rules
+ * set by the web SSO profile. To add additional handlers, you can override
+ * {@link #getInboundHandlers()}, {@link #getOutboundPayloadHandlers()} and/or
+ * {@link #getOutboundTransportHandlers()}. To modify the configuration of a
+ * specific handler, override the build method for that handler.
+ * 
+ * @since 3.8.0
+ */
 @SuppressWarnings("unchecked")
 public class DefaultSOAPPipelineFactory implements HttpClientMessagePipelineFactory<SAMLObject, SAMLObject> {
     protected final SAML2Configuration configuration;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineFactory.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineFactory.java
@@ -1,0 +1,267 @@
+package org.pac4j.saml.sso.artifact;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.xml.namespace.QName;
+
+import org.opensaml.messaging.handler.MessageHandler;
+import org.opensaml.messaging.handler.impl.BasicMessageHandlerChain;
+import org.opensaml.messaging.handler.impl.CheckExpectedIssuer;
+import org.opensaml.messaging.handler.impl.CheckMandatoryAuthentication;
+import org.opensaml.messaging.handler.impl.CheckMandatoryIssuer;
+import org.opensaml.messaging.handler.impl.SchemaValidateXMLMessage;
+import org.opensaml.messaging.pipeline.httpclient.BasicHttpClientMessagePipeline;
+import org.opensaml.messaging.pipeline.httpclient.HttpClientMessagePipeline;
+import org.opensaml.messaging.pipeline.httpclient.HttpClientMessagePipelineFactory;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.binding.impl.CheckMessageVersionHandler;
+import org.opensaml.saml.common.binding.impl.PopulateSignatureSigningParametersHandler;
+import org.opensaml.saml.common.binding.impl.SAMLMetadataLookupHandler;
+import org.opensaml.saml.common.binding.impl.SAMLProtocolAndRoleHandler;
+import org.opensaml.saml.common.binding.impl.SAMLSOAPDecoderBodyHandler;
+import org.opensaml.saml.common.binding.security.impl.CheckAndRecordServerTLSEntityAuthenticationtHandler;
+import org.opensaml.saml.common.binding.security.impl.InResponseToSecurityHandler;
+import org.opensaml.saml.common.binding.security.impl.MessageLifetimeSecurityHandler;
+import org.opensaml.saml.common.binding.security.impl.MessageReplaySecurityHandler;
+import org.opensaml.saml.common.binding.security.impl.SAMLOutboundProtocolMessageSigningHandler;
+import org.opensaml.saml.common.binding.security.impl.SAMLProtocolMessageXMLSignatureSecurityHandler;
+import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.common.xml.SAMLSchemaBuilder;
+import org.opensaml.saml.common.xml.SAMLSchemaBuilder.SAML1Version;
+import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
+import org.opensaml.saml.saml2.binding.decoding.impl.HttpClientResponseSOAP11Decoder;
+import org.opensaml.saml.saml2.binding.encoding.impl.HttpClientRequestSOAP11Encoder;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.xmlsec.impl.BasicSignatureValidationParametersResolver;
+import org.opensaml.xmlsec.messaging.impl.PopulateSignatureValidationParametersHandler;
+import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.crypto.SignatureSigningParametersProvider;
+import org.pac4j.saml.metadata.SAML2MetadataResolver;
+import org.pac4j.saml.replay.ReplayCacheProvider;
+import org.xml.sax.SAXException;
+
+import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+
+@SuppressWarnings("unchecked")
+public class DefaultSOAPPipelineFactory implements HttpClientMessagePipelineFactory<SAMLObject, SAMLObject> {
+    protected final SAML2Configuration configuration;
+
+    protected final SAML2MetadataResolver idpMetadataResolver;
+
+    protected final SAML2MetadataResolver spMetadataResolver;
+
+    protected final SignatureSigningParametersProvider signingParametersProvider;
+
+    protected final SAML2SignatureTrustEngineProvider signatureTrustEngineProvider;
+
+    protected final ReplayCacheProvider replayCache;
+
+    public DefaultSOAPPipelineFactory(SAML2Configuration configuration, SAML2MetadataResolver idpMetadataResolver,
+            SAML2MetadataResolver spMetadataResolver, SignatureSigningParametersProvider signingParametersProvider,
+            SAML2SignatureTrustEngineProvider signatureTrustEngineProvider, ReplayCacheProvider replayCache) {
+        this.configuration = configuration;
+        this.idpMetadataResolver = idpMetadataResolver;
+        this.spMetadataResolver = spMetadataResolver;
+        this.signingParametersProvider = signingParametersProvider;
+        this.signatureTrustEngineProvider = signatureTrustEngineProvider;
+        this.replayCache = replayCache;
+    }
+
+    protected List<MessageHandler<SAMLObject>> getInboundHandlers() throws ComponentInitializationException {
+        List<MessageHandler<SAMLObject>> handlers = new ArrayList<>();
+        handlers.add(buildSAMLProtocolAndRoleHandler(IDPSSODescriptor.DEFAULT_ELEMENT_NAME));
+        handlers.add(buildSAMLMetadataLookupHandler(idpMetadataResolver));
+        handlers.add(buildSchemaValidateXMLMessage());
+        handlers.add(buildCheckMessageVersionHandler());
+        handlers.add(buildMessageLifetimeSecurityHandler());
+        handlers.add(buildInResponseToSecurityHandler());
+        handlers.add(buildMessageReplaySecurityHandler());
+        handlers.add(buildCheckMandatoryIssuer());
+        handlers.add(buildCheckExpectedIssuer());
+        handlers.add(buildPopulateSignatureSigningParametersHandler());
+        handlers.add(buildPopulateSignatureValidationParametersHandler());
+        handlers.add(buildSAMLProtocolMessageXMLSignatureSecurityHandler());
+        handlers.add(buildCheckAndRecordServerTLSEntityAuthenticationtHandler());
+        handlers.add(buildCheckMandatoryAuthentication());
+        handlers.add(buildSAMLSOAPDecoderBodyHandler());
+        return handlers;
+    }
+
+    protected List<MessageHandler<SAMLObject>> getOutboundPayloadHandlers() throws ComponentInitializationException {
+        List<MessageHandler<SAMLObject>> handlers = new ArrayList<>();
+        handlers.add(buildSAMLProtocolAndRoleHandler(SPSSODescriptor.DEFAULT_ELEMENT_NAME));
+        handlers.add(buildSAMLMetadataLookupHandler(spMetadataResolver));
+        handlers.add(buildPopulateSignatureSigningParametersHandler());
+        handlers.add(buildSAMLOutboundProtocolMessageSigningHandler());
+        return handlers;
+    }
+
+    protected List<MessageHandler<SAMLObject>> getOutboundTransportHandlers() throws ComponentInitializationException {
+        return new ArrayList<>();
+    }
+
+    protected MessageHandler<SAMLObject> buildSAMLProtocolAndRoleHandler(QName roleName)
+            throws ComponentInitializationException {
+        SAMLProtocolAndRoleHandler protocolAndRoleHandler = new SAMLProtocolAndRoleHandler();
+        protocolAndRoleHandler.setProtocol(SAMLConstants.SAML20P_NS);
+        protocolAndRoleHandler.setRole(roleName);
+        protocolAndRoleHandler.initialize();
+        return protocolAndRoleHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildSAMLMetadataLookupHandler(SAML2MetadataResolver metadataResolver)
+            throws ComponentInitializationException {
+        PredicateRoleDescriptorResolver roleResolver = new PredicateRoleDescriptorResolver(metadataResolver.resolve());
+        roleResolver.initialize();
+
+        SAMLMetadataLookupHandler metadataLookupHandler = new SAMLMetadataLookupHandler();
+        metadataLookupHandler.setRoleDescriptorResolver(roleResolver);
+        metadataLookupHandler.initialize();
+        return metadataLookupHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildSchemaValidateXMLMessage() throws ComponentInitializationException {
+        try {
+            SchemaValidateXMLMessage<SAMLObject> validateXMLHandler = new SchemaValidateXMLMessage<>(
+                    new SAMLSchemaBuilder(SAML1Version.SAML_11).getSAMLSchema());
+            validateXMLHandler.initialize();
+            return validateXMLHandler;
+        } catch (SAXException e) {
+            throw new ComponentInitializationException(e);
+        }
+    }
+
+    protected MessageHandler<SAMLObject> buildCheckMessageVersionHandler() throws ComponentInitializationException {
+        CheckMessageVersionHandler messageVersionHandler = new CheckMessageVersionHandler();
+        messageVersionHandler.initialize();
+        return messageVersionHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildMessageLifetimeSecurityHandler() throws ComponentInitializationException {
+        MessageLifetimeSecurityHandler lifetimeHandler = new MessageLifetimeSecurityHandler();
+        lifetimeHandler.setClockSkew(configuration.getAcceptedSkew() * 1000);
+        lifetimeHandler.initialize();
+        return lifetimeHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildInResponseToSecurityHandler() throws ComponentInitializationException {
+        InResponseToSecurityHandler inResponseToHandler = new InResponseToSecurityHandler();
+        inResponseToHandler.initialize();
+        return inResponseToHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildMessageReplaySecurityHandler() throws ComponentInitializationException {
+        MessageReplaySecurityHandler messageReplayHandler = new MessageReplaySecurityHandler();
+        messageReplayHandler.setExpires(configuration.getAcceptedSkew() * 1000);
+        messageReplayHandler.setReplayCache(replayCache.get());
+        messageReplayHandler.initialize();
+        return messageReplayHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildCheckMandatoryIssuer() throws ComponentInitializationException {
+        CheckMandatoryIssuer mandatoryIssuer = new CheckMandatoryIssuer();
+        mandatoryIssuer.setIssuerLookupStrategy(new IssuerFunction());
+        mandatoryIssuer.initialize();
+        return mandatoryIssuer;
+    }
+
+    protected MessageHandler<SAMLObject> buildCheckExpectedIssuer() throws ComponentInitializationException {
+        CheckExpectedIssuer expectedIssuer = new CheckExpectedIssuer();
+        expectedIssuer.setIssuerLookupStrategy(new IssuerFunction());
+        expectedIssuer.setExpectedIssuerLookupStrategy(messageContext -> idpMetadataResolver.getEntityId());
+        expectedIssuer.initialize();
+        return expectedIssuer;
+    }
+
+    protected MessageHandler<SAMLObject> buildPopulateSignatureSigningParametersHandler()
+            throws ComponentInitializationException {
+        PopulateSignatureSigningParametersHandler signatureSigningParameters = new PopulateSignatureSigningParametersHandler();
+        signatureSigningParameters.setSignatureSigningParametersResolver(
+                new DefaultSignatureSigningParametersResolver(signingParametersProvider));
+        signatureSigningParameters.initialize();
+        return signatureSigningParameters;
+    }
+
+    protected MessageHandler<SAMLObject> buildPopulateSignatureValidationParametersHandler()
+            throws ComponentInitializationException {
+        PopulateSignatureValidationParametersHandler signatureValidationParameters = new PopulateSignatureValidationParametersHandler();
+        signatureValidationParameters
+                .setSignatureValidationParametersResolver(new BasicSignatureValidationParametersResolver() {
+                    @Override
+                    protected SignatureTrustEngine resolveSignatureTrustEngine(CriteriaSet criteria) {
+                        return signatureTrustEngineProvider.build();
+                    }
+                });
+        signatureValidationParameters.initialize();
+        return signatureValidationParameters;
+    }
+
+    protected MessageHandler<SAMLObject> buildSAMLProtocolMessageXMLSignatureSecurityHandler()
+            throws ComponentInitializationException {
+        SAMLProtocolMessageXMLSignatureSecurityHandler messageXMLSignatureHandler = new SAMLProtocolMessageXMLSignatureSecurityHandler();
+        messageXMLSignatureHandler.initialize();
+        return messageXMLSignatureHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildCheckAndRecordServerTLSEntityAuthenticationtHandler()
+            throws ComponentInitializationException {
+        CheckAndRecordServerTLSEntityAuthenticationtHandler tlsHandler = new CheckAndRecordServerTLSEntityAuthenticationtHandler();
+        tlsHandler.initialize();
+        return tlsHandler;
+    }
+
+    protected MessageHandler<SAMLObject> buildCheckMandatoryAuthentication() {
+        CheckMandatoryAuthentication mandatoryAuthentication = new CheckMandatoryAuthentication();
+        mandatoryAuthentication.setAuthenticationLookupStrategy(
+            context -> context.getSubcontext(SAMLPeerEntityContext.class).isAuthenticated());
+        return mandatoryAuthentication;
+    }
+
+    protected MessageHandler<SAMLObject> buildSAMLSOAPDecoderBodyHandler() throws ComponentInitializationException {
+        SAMLSOAPDecoderBodyHandler soapDecoderBody = new SAMLSOAPDecoderBodyHandler();
+        soapDecoderBody.initialize();
+        return soapDecoderBody;
+    }
+
+    protected MessageHandler<SAMLObject> buildSAMLOutboundProtocolMessageSigningHandler()
+            throws ComponentInitializationException {
+        SAMLOutboundProtocolMessageSigningHandler messageSigner = new SAMLOutboundProtocolMessageSigningHandler();
+        messageSigner.initialize();
+        return messageSigner;
+    }
+
+    protected BasicMessageHandlerChain<SAMLObject> toHandlerChain(List<MessageHandler<SAMLObject>> handlers) {
+        BasicMessageHandlerChain<SAMLObject> ret = new BasicMessageHandlerChain<>();
+        ret.setHandlers(handlers);
+        return ret;
+    }
+
+    @Override
+    @Nonnull
+    public HttpClientMessagePipeline<SAMLObject, SAMLObject> newInstance() {
+        BasicHttpClientMessagePipeline<SAMLObject, SAMLObject> ret = new BasicHttpClientMessagePipeline<>(
+                new HttpClientRequestSOAP11Encoder(), new HttpClientResponseSOAP11Decoder());
+        try {
+            ret.setInboundHandler(toHandlerChain(getInboundHandlers()));
+            ret.setOutboundPayloadHandler(toHandlerChain(getOutboundPayloadHandlers()));
+            ret.setOutboundTransportHandler(toHandlerChain(getOutboundTransportHandlers()));
+        } catch (ComponentInitializationException e) {
+            throw new RuntimeException(e);
+        }
+        return ret;
+    }
+
+    @Override
+    @Nonnull
+    public HttpClientMessagePipeline<SAMLObject, SAMLObject> newInstance(@Nullable String pipelineName) {
+        return newInstance();
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineProvider.java
@@ -1,0 +1,26 @@
+package org.pac4j.saml.sso.artifact;
+
+import net.shibboleth.utilities.java.support.httpclient.HttpClientBuilder;
+import org.opensaml.messaging.pipeline.httpclient.HttpClientMessagePipelineFactory;
+import org.opensaml.saml.common.SAMLObject;
+import org.pac4j.saml.client.SAML2Client;
+
+public class DefaultSOAPPipelineProvider implements SOAPPipelineProvider {
+    private final SAML2Client client;
+
+    public DefaultSOAPPipelineProvider(final SAML2Client client) {
+        this.client = client;
+    }
+
+    @Override
+    public HttpClientBuilder getHttpClientBuilder() {
+        return new HttpClientBuilder();
+    }
+
+    @Override
+    public HttpClientMessagePipelineFactory<SAMLObject, SAMLObject> getPipelineFactory() {
+        return new DefaultSOAPPipelineFactory(client.getConfiguration(), client.getIdentityProviderMetadataResolver(),
+                client.getServiceProviderMetadataResolver(), client.getSignatureSigningParametersProvider(),
+                client.getSignatureTrustEngineProvider(), client.getReplayCache());
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSOAPPipelineProvider.java
@@ -5,6 +5,12 @@ import org.opensaml.messaging.pipeline.httpclient.HttpClientMessagePipelineFacto
 import org.opensaml.saml.common.SAMLObject;
 import org.pac4j.saml.client.SAML2Client;
 
+/**
+ * A default implementation of {@link SOAPPipelineProvider}, which enforces the
+ * default rules set by the SAML SSO Profile.
+ * 
+ * @since 3.8.0
+ */
 public class DefaultSOAPPipelineProvider implements SOAPPipelineProvider {
     private final SAML2Client client;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSignatureSigningParametersResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSignatureSigningParametersResolver.java
@@ -13,6 +13,13 @@ import org.opensaml.xmlsec.SignatureSigningParameters;
 import org.opensaml.xmlsec.SignatureSigningParametersResolver;
 import org.pac4j.saml.crypto.SignatureSigningParametersProvider;
 
+/**
+ * A {@link SignatureSigningParametersResolver} that resolves the
+ * {@link SignatureSigningParameters} from the pac4j
+ * {@link SignatureSigningParametersProvider}.
+ * 
+ * @since 3.8.0
+ */
 public class DefaultSignatureSigningParametersResolver implements SignatureSigningParametersResolver {
     private SignatureSigningParametersProvider provider;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSignatureSigningParametersResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/DefaultSignatureSigningParametersResolver.java
@@ -1,0 +1,42 @@
+package org.pac4j.saml.sso.artifact;
+
+import java.util.Collections;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.ResolverException;
+import org.opensaml.saml.criterion.RoleDescriptorCriterion;
+import org.opensaml.saml.saml2.metadata.SSODescriptor;
+import org.opensaml.xmlsec.SignatureSigningParameters;
+import org.opensaml.xmlsec.SignatureSigningParametersResolver;
+import org.pac4j.saml.crypto.SignatureSigningParametersProvider;
+
+public class DefaultSignatureSigningParametersResolver implements SignatureSigningParametersResolver {
+    private SignatureSigningParametersProvider provider;
+
+    public DefaultSignatureSigningParametersResolver(SignatureSigningParametersProvider provider) {
+        this.provider = provider;
+    }
+
+    @Override
+    @Nonnull
+    public Iterable<SignatureSigningParameters> resolve(@Nullable CriteriaSet criteria) throws ResolverException {
+        SignatureSigningParameters ret = resolveSingle(criteria);
+        return ret == null ? Collections.emptySet() : Collections.singleton(ret);
+    }
+
+    @Override
+    @Nullable
+    public SignatureSigningParameters resolveSingle(@Nullable CriteriaSet criteria) throws ResolverException {
+        if (criteria == null) {
+            throw new ResolverException("CriteriaSet was null");
+        }
+        RoleDescriptorCriterion role = criteria.get(RoleDescriptorCriterion.class);
+        if (role == null) {
+            throw new ResolverException("No RoleDescriptorCriterion specified");
+        }
+        return provider.build((SSODescriptor) role.getRole());
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/FixedEntityIdResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/FixedEntityIdResolver.java
@@ -1,0 +1,30 @@
+package org.pac4j.saml.sso.artifact;
+
+import java.util.Collections;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.resolver.Resolver;
+import org.pac4j.saml.metadata.SAML2MetadataResolver;
+
+public class FixedEntityIdResolver implements Resolver<String, CriteriaSet> {
+    private SAML2MetadataResolver metadataResolver;
+
+    public FixedEntityIdResolver(SAML2MetadataResolver metadataResolver) {
+        this.metadataResolver = metadataResolver;
+    }
+
+    @Override
+    @Nonnull
+    public Iterable<String> resolve(@Nullable CriteriaSet criteria) {
+        return Collections.singletonList(metadataResolver.getEntityId());
+    }
+
+    @Override
+    @Nullable
+    public String resolveSingle(@Nullable CriteriaSet criteria) {
+        return metadataResolver.getEntityId();
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/FixedEntityIdResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/FixedEntityIdResolver.java
@@ -9,6 +9,12 @@ import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import net.shibboleth.utilities.java.support.resolver.Resolver;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 
+/**
+ * A resolver for the entity id specified by the given
+ * {@link SAML2MetadataResolver}.
+ * 
+ * @since 3.8.0
+ */
 public class FixedEntityIdResolver implements Resolver<String, CriteriaSet> {
     private SAML2MetadataResolver metadataResolver;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/IssuerFunction.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/IssuerFunction.java
@@ -1,0 +1,26 @@
+package org.pac4j.saml.sso.artifact;
+
+import com.google.common.base.Function;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.RequestAbstractType;
+import org.opensaml.saml.saml2.core.StatusResponseType;
+
+@SuppressWarnings("rawtypes")
+public class IssuerFunction implements Function<MessageContext, String> {
+    @Override
+    public String apply(MessageContext context) {
+        if (context == null) {
+            return null;
+        }
+        SAMLObject message = (SAMLObject) context.getMessage();
+        Issuer issuer = null;
+        if (message instanceof RequestAbstractType) {
+            issuer = ((RequestAbstractType) message).getIssuer();
+        } else if (message instanceof StatusResponseType) {
+            issuer = ((StatusResponseType) message).getIssuer();
+        }
+        return issuer != null ? issuer.getValue() : null;
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/IssuerFunction.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/IssuerFunction.java
@@ -7,6 +7,12 @@ import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.RequestAbstractType;
 import org.opensaml.saml.saml2.core.StatusResponseType;
 
+/**
+ * A simple function that returns the issuer set on the {@link MessageContext}.
+ * This is read from the message in the context.
+ * 
+ * @since 3.8.0
+ */
 @SuppressWarnings("rawtypes")
 public class IssuerFunction implements Function<MessageContext, String> {
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingDecoder.java
@@ -1,0 +1,88 @@
+package org.pac4j.saml.sso.artifact;
+
+import org.opensaml.messaging.context.InOutOperationContext;
+import org.opensaml.messaging.decoder.MessageDecodingException;
+import org.opensaml.saml.common.SAMLObject;
+import org.opensaml.saml.common.binding.impl.DefaultEndpointResolver;
+import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.metadata.resolver.impl.PredicateRoleDescriptorResolver;
+import org.opensaml.saml.saml2.binding.decoding.impl.HTTPArtifactDecoder;
+import org.opensaml.saml.saml2.metadata.ArtifactResolutionService;
+import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
+import org.opensaml.security.SecurityException;
+import org.opensaml.soap.client.http.PipelineFactoryHttpSOAPClient;
+import org.opensaml.soap.common.SOAPException;
+import org.pac4j.core.context.J2EContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.metadata.SAML2MetadataResolver;
+import org.pac4j.saml.transport.AbstractPac4jDecoder;
+
+public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
+    private final SAML2MetadataResolver idpMetadataResolver;
+
+    private final SAML2MetadataResolver spMetadataResolver;
+
+    private final SOAPPipelineProvider soapPipelineProvider;
+
+    public SAML2ArtifactBindingDecoder(final WebContext context, final SAML2MetadataResolver idpMetadataResolver,
+            final SAML2MetadataResolver spMetadataResolver, final SOAPPipelineProvider soapPipelineProvider) {
+        super(context);
+        this.idpMetadataResolver = idpMetadataResolver;
+        this.spMetadataResolver = spMetadataResolver;
+        this.soapPipelineProvider = soapPipelineProvider;
+    }
+
+    @Override
+    public String getBindingURI(SAML2MessageContext messageContext) {
+        return SAMLConstants.SAML2_ARTIFACT_BINDING_URI;
+    }
+
+    @Override
+    protected void doDecode() throws MessageDecodingException {
+        try {
+            DefaultEndpointResolver<ArtifactResolutionService> endpointResolver = new DefaultEndpointResolver<>();
+            endpointResolver.initialize();
+
+            PredicateRoleDescriptorResolver roleResolver = new PredicateRoleDescriptorResolver(
+                    idpMetadataResolver.resolve());
+            roleResolver.initialize();
+
+            SAML2MessageContext messageContext = new SAML2MessageContext();
+
+            PipelineFactoryHttpSOAPClient<SAMLObject, SAMLObject> soapClient = new PipelineFactoryHttpSOAPClient<SAMLObject, SAMLObject>() {
+                public void send(String endpoint, InOutOperationContext operationContext)
+                        throws SOAPException, SecurityException {
+                    super.send(endpoint, operationContext);
+                    transferContext(operationContext, messageContext);
+                }
+            };
+            soapClient.setPipelineFactory(soapPipelineProvider.getPipelineFactory());
+            soapClient.setHttpClient(soapPipelineProvider.getHttpClientBuilder().buildClient());
+
+            HTTPArtifactDecoder artifactDecoder = new HTTPArtifactDecoder();
+            artifactDecoder.setHttpServletRequest(((J2EContext) context).getRequest());
+            artifactDecoder.setSelfEntityIDResolver(new FixedEntityIdResolver(spMetadataResolver));
+            artifactDecoder.setRoleDescriptorResolver(roleResolver);
+            artifactDecoder.setArtifactEndpointResolver(endpointResolver);
+            artifactDecoder.setPeerEntityRole(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
+            artifactDecoder.setSOAPClient(soapClient);
+            artifactDecoder.setParserPool(getParserPool());
+            artifactDecoder.initialize();
+            artifactDecoder.decode();
+
+            messageContext.setMessage(artifactDecoder.getMessageContext().getMessage());
+
+            this.populateBindingContext(messageContext);
+            this.setMessageContext(messageContext);
+        } catch (Exception e) {
+            throw new MessageDecodingException(e);
+        }
+    }
+
+    protected void transferContext(InOutOperationContext operationContext, SAML2MessageContext messageContext) {
+        messageContext
+                .addSubcontext(operationContext.getInboundMessageContext().getSubcontext(SAMLPeerEntityContext.class));
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingDecoder.java
@@ -19,6 +19,12 @@ import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
 
+/**
+ * Decodes a SAML artifact binding request by fetching the actual artifact via
+ * SOAP.
+ * 
+ * @since 3.8.0
+ */
 public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
     private final SAML2MetadataResolver idpMetadataResolver;
 
@@ -52,6 +58,8 @@ public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
             SAML2MessageContext messageContext = new SAML2MessageContext();
 
             PipelineFactoryHttpSOAPClient<SAMLObject, SAMLObject> soapClient = new PipelineFactoryHttpSOAPClient<SAMLObject, SAMLObject>() {
+                @SuppressWarnings("rawtypes")
+                @Override
                 public void send(String endpoint, InOutOperationContext operationContext)
                         throws SOAPException, SecurityException {
                     super.send(endpoint, operationContext);
@@ -81,7 +89,7 @@ public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
         }
     }
 
-    protected void transferContext(InOutOperationContext operationContext, SAML2MessageContext messageContext) {
+    protected void transferContext(InOutOperationContext<?, ?> operationContext, SAML2MessageContext messageContext) {
         messageContext
                 .addSubcontext(operationContext.getInboundMessageContext().getSubcontext(SAMLPeerEntityContext.class));
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
@@ -1,0 +1,47 @@
+package org.pac4j.saml.sso.artifact;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.metadata.SAML2MetadataResolver;
+import org.pac4j.saml.profile.api.SAML2ResponseValidator;
+import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
+import org.pac4j.saml.transport.AbstractPac4jDecoder;
+import org.pac4j.saml.util.Configuration;
+
+public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageReceiver {
+    private static final String SAML2_WEBSSO_PROFILE_URI = "urn:oasis:names:tc:SAML:2.0:profiles:SSO:browser";
+
+    private SAML2MetadataResolver idpMetadataResolver;
+
+    private SAML2MetadataResolver spMetadataResolver;
+
+    private SOAPPipelineProvider soapPipelineProvider;
+
+    public SAML2ArtifactBindingMessageReceiver(final SAML2ResponseValidator validator,
+            final SAML2MetadataResolver idpMetadataResolver, final SAML2MetadataResolver spMetadataResolver,
+            final SOAPPipelineProvider soapPipelineProvider) {
+        super(validator);
+        this.idpMetadataResolver = idpMetadataResolver;
+        this.spMetadataResolver = spMetadataResolver;
+        this.soapPipelineProvider = soapPipelineProvider;
+    }
+
+    @Override
+    protected AbstractPac4jDecoder getDecoder(WebContext webContext) {
+        final SAML2ArtifactBindingDecoder decoder = new SAML2ArtifactBindingDecoder(webContext, idpMetadataResolver,
+                spMetadataResolver, soapPipelineProvider);
+        try {
+            decoder.setParserPool(Configuration.getParserPool());
+            decoder.initialize();
+            decoder.decode();
+        } catch (final Exception e) {
+            throw new SAMLException("Error decoding SAML message", e);
+        }
+        return decoder;
+    }
+
+    @Override
+    protected String getProfileUri() {
+        return SAML2_WEBSSO_PROFILE_URI;
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
@@ -8,6 +8,11 @@ import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.util.Configuration;
 
+/**
+ * A message receiver which fetches the actual artifact using SOAP.
+ * 
+ * @since 3.8.0
+ */
 public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageReceiver {
     private static final String SAML2_WEBSSO_PROFILE_URI = "urn:oasis:names:tc:SAML:2.0:profiles:SSO:browser";
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SOAPPipelineProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SOAPPipelineProvider.java
@@ -1,0 +1,11 @@
+package org.pac4j.saml.sso.artifact;
+
+import net.shibboleth.utilities.java.support.httpclient.HttpClientBuilder;
+import org.opensaml.messaging.pipeline.httpclient.HttpClientMessagePipelineFactory;
+import org.opensaml.saml.common.SAMLObject;
+
+public interface SOAPPipelineProvider {
+    HttpClientBuilder getHttpClientBuilder();
+
+    HttpClientMessagePipelineFactory<SAMLObject, SAMLObject> getPipelineFactory();
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SOAPPipelineProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SOAPPipelineProvider.java
@@ -4,8 +4,22 @@ import net.shibboleth.utilities.java.support.httpclient.HttpClientBuilder;
 import org.opensaml.messaging.pipeline.httpclient.HttpClientMessagePipelineFactory;
 import org.opensaml.saml.common.SAMLObject;
 
+/**
+ * Provider for the components required to perform SOAP calls for
+ * ArtifactResolve.
+ * 
+ * @since 3.8.0
+ */
 public interface SOAPPipelineProvider {
+    /**
+     * @return the configured builder for the http client.
+     */
     HttpClientBuilder getHttpClientBuilder();
 
+    /**
+     * @return a pipeline factory that will be used by the
+     *         {@code PipelineFactoryHttpSOAPClient} to process incoming and
+     *         outgoing messages.
+     */
     HttpClientMessagePipelineFactory<SAMLObject, SAMLObject> getPipelineFactory();
 }


### PR DESCRIPTION
This PR adds support for the artifact binding for the SAML Reponse (not for the AuthnRequest). The artifact is resolved via a SOAP call to the artifact resolution service.

The implementation is complete, but it is lacking tests at the moment. Unfortunately, I see no way of testing the the majority of the classes without setting up an actual artifact resolution service. The most important classes are `SAML2ArtifactBindingDecoder` (which 'decodes' the artifact reference into the actual response) and `DefaultSOAPPipelineFactory` (which defines all checks on the communication and what information needs to be collected). These classes require a real `HttpSOAPClient` to test, which in turn requires an artifact resolution service. This would be hard to mock. Do you have any ideas on this? 