### PR TITLE
Never sign AuthnRequests when using REDIRECT binding

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -11,6 +11,7 @@ title: Release notes&#58;
 - Added support for the SAML artifact binding for the authentication response.
 - Fix SAML signature validation w.r.t. WantAssertionsSigned handling. Signing is now always required, even when WantAssertionsSigned is disabled. WantAssertionsSigned now requires explicit signing of the assertions, not the response.
 - Sign metadata when configured to do so and open up the metadata generation API for customization.
+- Never sign AuthnRequests with XMLSig when using REDIRECT binding, signing is done via the Signature query parameter.
 
 **v3.7.0**:
 


### PR DESCRIPTION
Signing is done via the Signature query parameter. This is explained in
section 3.4.4.1 DEFLATE Encoding of the binding specification. The
signature is never generated for AuthnRequests when using REDIRECT, and
if it were, it is now always removed as part of the DEFLATE encoding.

Note that the specification states that you should first generate an XMLSig, then remove it and then generate the Signature query parameter if the XMLSig was present in the first place. I found this rather inefficient (signature generation is quite expensive), so I opted for not generating the XMLSig at all.