### PR TITLE
Never sign AuthnRequests when using REDIRECT binding

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -28,6 +28,7 @@ title: Release notes&#58;
 - Fix SAML signature validation w.r.t. WantAssertionsSigned handling. Signing is now always required, even when WantAssertionsSigned is disabled. WantAssertionsSigned now requires explicit signing of the assertions, not the response.
 - Added support for the SAML artifact binding for the authentication response.
 - Sign metadata when configured to do so and open up the metadata generation API for customization.
+- Never sign AuthnRequests with XMLSig when using REDIRECT binding, signing is done via the Signature query parameter.
 
 **v3.7.0**:
 


### PR DESCRIPTION
Same as #1337 but for master.

Signing is done via the Signature query parameter. This is explained in
section 3.4.4.1 DEFLATE Encoding of the binding specification. The
signature is never generated for AuthnRequests when using REDIRECT, and
if it were, it is now always removed as part of the DEFLATE encoding.

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html