### PR TITLE
Remove only specific query parameters from HTTP-Redirect

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPRedirectDeflateEncoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPRedirectDeflateEncoder.java
@@ -176,7 +176,13 @@ public class Pac4jHTTPRedirectDeflateEncoder extends AbstractMessageEncoder<SAML
         }
 
         List<Pair<String, String>> queryParams = urlBuilder.getQueryParams();
-        queryParams.clear();
+        // remove the query parameters set below
+        queryParams.removeIf(p ->
+            p.getFirst().equals("SAMLRequest") ||
+            p.getFirst().equals("SAMLResponse") ||
+            p.getFirst().equals("RelayState") ||
+            p.getFirst().equals("SigAlg") ||
+            p.getFirst().equals("Signature"));
 
         SAMLObject outboundMessage = messageContext.getMessage();
 


### PR DESCRIPTION
An Identity Provider Location URL can have query parameters that should
persist through an HTTP-Redirect encoding.

Testing done:
[x] Ran all tests in Pac4jHTTPRedirectDeflateDecoderTest