### PR TITLE
Add isInitialized() to InitializableObject

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/util/InitializableObject.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/InitializableObject.java
@@ -24,6 +24,10 @@ public abstract class InitializableObject {
         }
     }
 
+    public final boolean isInitialized() {
+        return this.initialized;
+    }
+    
     /**
      * Internal initialization of the object.
      */


### PR DESCRIPTION
Expose initialization state in form of a getter as a convenience to let extensions know whether a client is in fact initialized.