### PR TITLE
AbstractProfileService::convertAttributesToProfile sets profile id with username instead of id

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/AbstractProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/AbstractProfileService.java
@@ -235,11 +235,8 @@ public abstract class AbstractProfileService<U extends CommonProfile> extends Pr
                 profile.addAttribute(USERNAME, username);
             }
             final Object retrievedId = storageAttributes.get(getIdAttribute());
-            if (retrievedId != null) {
-                profile.setId(ProfileHelper.sanitizeIdentifier(profile, retrievedId));
-            } else {
-                throw new TechnicalException("Could not retrieve id"); //Should not happen
-            }
+            assertNotNull(getIdAttribute(), retrievedId);
+            profile.setId(ProfileHelper.sanitizeIdentifier(profile, retrievedId));
             if (isNotBlank(linkedId)) {
                 profile.setLinkedId(linkedId);
             }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/AbstractProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/AbstractProfileService.java
@@ -230,9 +230,15 @@ public abstract class AbstractProfileService<U extends CommonProfile> extends Pr
             }
             final Object retrievedUsername = storageAttributes.get(getUsernameAttribute());
             if (retrievedUsername != null) {
-                profile.setId(ProfileHelper.sanitizeIdentifier(profile, retrievedUsername));
+                profile.addAttribute(USERNAME, retrievedUsername);
             } else {
-                profile.setId(username);
+                profile.addAttribute(USERNAME, username);
+            }
+            final Object retrievedId = storageAttributes.get(getIdAttribute());
+            if (retrievedId != null) {
+                profile.setId(ProfileHelper.sanitizeIdentifier(profile, retrievedId));
+            } else {
+                throw new TechnicalException("Could not retrieve id"); //Should not happen
             }
             if (isNotBlank(linkedId)) {
                 profile.setLinkedId(linkedId);


### PR DESCRIPTION
Set profile id with id instead of username in legacy mode