### PR TITLE
Open up AbstractSAML2ResponseValidator for modification in subclasses

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
@@ -95,7 +95,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
      *
      * @param status the response status.
      */
-    protected final void validateSuccess(final Status status) {
+    protected void validateSuccess(final Status status) {
         String statusValue = status.getStatusCode().getValue();
         if (!StatusCode.SUCCESS.equals(statusValue)) {
             final StatusMessage statusMessage = status.getStatusMessage();
@@ -106,7 +106,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         }
     }
 
-    protected final void validateSignatureIfItExists(final Signature signature, final SAML2MessageContext context,
+    protected void validateSignatureIfItExists(final Signature signature, final SAML2MessageContext context,
                                                final SignatureTrustEngine engine) {
         if (signature != null) {
             final String entityId = context.getSAMLPeerEntityContext().getEntityId();
@@ -122,8 +122,8 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
      * @param idpEntityId the idp entity id
      * @param trustEngine the trust engine
      */
-    protected final void validateSignature(final Signature signature, final String idpEntityId,
-                                           final SignatureTrustEngine trustEngine) {
+    protected void validateSignature(final Signature signature, final String idpEntityId,
+                                     final SignatureTrustEngine trustEngine) {
 
         final SAMLSignatureProfileValidator validator = new SAMLSignatureProfileValidator();
         try {
@@ -148,7 +148,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         }
     }
 
-    protected final void validateIssuerIfItExists(final Issuer isser, final SAML2MessageContext context) {
+    protected void validateIssuerIfItExists(final Issuer isser, final SAML2MessageContext context) {
         if (isser != null) {
             validateIssuer(isser, context);
         }
@@ -160,7 +160,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
      * @param issuer  the issuer
      * @param context the context
      */
-    protected final void validateIssuer(final Issuer issuer, final SAML2MessageContext context) {
+    protected void validateIssuer(final Issuer issuer, final SAML2MessageContext context) {
         if (issuer.getFormat() != null && !issuer.getFormat().equals(NameIDType.ENTITY)) {
             throw new SAMLIssuerException("Issuer type is not entity but " + issuer.getFormat());
         }
@@ -171,17 +171,17 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         }
     }
 
-    protected final void validateIssueInstant(final DateTime issueInstant) {
+    protected void validateIssueInstant(final DateTime issueInstant) {
         if (!isIssueInstantValid(issueInstant)) {
             throw new SAMLIssueInstantException("Issue instant is too old or in the future");
         }
     }
 
-    protected final boolean isIssueInstantValid(final DateTime issueInstant) {
+    protected boolean isIssueInstantValid(final DateTime issueInstant) {
         return isDateValid(issueInstant, 0);
     }
 
-    protected final boolean isDateValid(final DateTime issueInstant, final int interval) {
+    protected boolean isDateValid(final DateTime issueInstant, final int interval) {
         final DateTime now = DateTime.now(DateTimeZone.UTC);
 
         final DateTime before = now.plusSeconds(acceptedSkew);
@@ -197,7 +197,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         return isDateValid;
     }
 
-    protected final void verifyEndpoint(final Endpoint endpoint, final String destination) {
+    protected void verifyEndpoint(final Endpoint endpoint, final String destination) {
         try {
             if (destination != null && !uriComparator.compare(destination, endpoint.getLocation())
                 && !uriComparator.compare(destination, endpoint.getResponseLocation())) {
@@ -237,7 +237,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
      * @return Decrypted ID or {@code null} if any input is {@code null}.
      * @throws SAMLException If the input ID cannot be decrypted.
      */
-    protected final NameID decryptEncryptedId(final EncryptedID encryptedId, final Decrypter decrypter) throws SAMLException {
+    protected NameID decryptEncryptedId(final EncryptedID encryptedId, final Decrypter decrypter) throws SAMLException {
         if (encryptedId == null) {
             return null;
         }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -113,7 +113,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
         return buildSAML2Credentials(context);
     }
 
-    protected final SAML2Credentials buildSAML2Credentials(final SAML2MessageContext context) {
+    protected SAML2Credentials buildSAML2Credentials(final SAML2MessageContext context) {
 
         final NameID nameId = context.getSAMLSubjectNameIdentifierContext().getSAML2SubjectNameID();
         final Assertion subjectAssertion = context.getSubjectAssertion();
@@ -184,8 +184,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param context  the context
      * @param engine   the engine
      */
-    protected final void validateSamlProtocolResponse(final Response response, final SAML2MessageContext context,
-                                                      final SignatureTrustEngine engine) {
+    protected void validateSamlProtocolResponse(final Response response, final SAML2MessageContext context,
+                                                final SignatureTrustEngine engine) {
 
         validateSuccess(response.getStatus());
 
@@ -255,8 +255,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param engine    the engine
      * @param decrypter the decrypter
      */
-    protected final void validateSamlSSOResponse(final Response response, final SAML2MessageContext context,
-                                                 final SignatureTrustEngine engine, final Decrypter decrypter) {
+    protected void validateSamlSSOResponse(final Response response, final SAML2MessageContext context,
+                                           final SignatureTrustEngine engine, final Decrypter decrypter) {
 
         final List<SAMLException> errors = new ArrayList<>();
         for (final Assertion assertion : response.getAssertions()) {
@@ -296,7 +296,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param response  the response
      * @param decrypter the decrypter
      */
-    protected final void decryptEncryptedAssertions(final Response response, final Decrypter decrypter) {
+    protected void decryptEncryptedAssertions(final Response response, final Decrypter decrypter) {
 
         for (final EncryptedAssertion encryptedAssertion : response.getEncryptedAssertions()) {
             try {
@@ -323,8 +323,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param engine    the engine
      * @param decrypter the decrypter
      */
-    protected final void validateAssertion(final Assertion assertion, final SAML2MessageContext context,
-                                           final SignatureTrustEngine engine, final Decrypter decrypter) {
+    protected void validateAssertion(final Assertion assertion, final SAML2MessageContext context,
+                                     final SignatureTrustEngine engine, final Decrypter decrypter) {
 
         validateIssueInstant(assertion.getIssueInstant());
 
@@ -356,8 +356,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      *                  May be {@code null}, no decryption will be possible then.
      */
     @SuppressWarnings("unchecked")
-    protected final void validateSubject(final Subject subject, final SAML2MessageContext context,
-                                         final Decrypter decrypter) {
+    protected void validateSubject(final Subject subject, final SAML2MessageContext context,
+                                   final Decrypter decrypter) {
         boolean samlIDFound = false;
 
         // Read NameID/BaseID/EncryptedID from the subject. If not present directly in the subject, try to find it in subject confirmations.
@@ -422,8 +422,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param context the context
      * @return true if all Bearer subject checks are passing
      */
-    protected final boolean isValidBearerSubjectConfirmationData(final SubjectConfirmationData data,
-                                                                 final SAML2MessageContext context) {
+    protected boolean isValidBearerSubjectConfirmationData(final SubjectConfirmationData data,
+                                                           final SAML2MessageContext context) {
         if (data == null) {
             logger.debug("SubjectConfirmationData cannot be null for Bearer confirmation");
             return false;
@@ -503,7 +503,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param conditions the conditions
      * @param context    the context
      */
-    protected final void validateAssertionConditions(final Conditions conditions, final SAML2MessageContext context) {
+    protected void validateAssertionConditions(final Conditions conditions, final SAML2MessageContext context) {
 
         if (conditions == null) {
             return;
@@ -527,8 +527,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param audienceRestrictions the audience restrictions
      * @param spEntityId           the sp entity id
      */
-    protected final void validateAudienceRestrictions(final List<AudienceRestriction> audienceRestrictions,
-                                                      final String spEntityId) {
+    protected void validateAudienceRestrictions(final List<AudienceRestriction> audienceRestrictions,
+                                                final String spEntityId) {
 
         if (audienceRestrictions == null || audienceRestrictions.isEmpty()) {
             throw new SAMLAssertionAudienceException("Audience restrictions cannot be null or empty");
@@ -556,8 +556,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param authnStatements the authn statements
      * @param context         the context
      */
-    protected final void validateAuthenticationStatements(final List<AuthnStatement> authnStatements,
-                                                          final SAML2MessageContext context) {
+    protected void validateAuthenticationStatements(final List<AuthnStatement> authnStatements,
+                                                    final SAML2MessageContext context) {
 
         for (final AuthnStatement statement : authnStatements) {
             if (!isAuthnInstantValid(statement.getAuthnInstant())) {
@@ -578,8 +578,8 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
      * @param context   the context
      * @param engine    the engine
      */
-    protected final void validateAssertionSignature(final Signature signature, final SAML2MessageContext context,
-                                                    final SignatureTrustEngine engine) {
+    protected void validateAssertionSignature(final Signature signature, final SAML2MessageContext context,
+                                              final SignatureTrustEngine engine) {
 
         final SAMLPeerEntityContext peerContext = context.getSAMLPeerEntityContext();
 


### PR DESCRIPTION
Same as #1352, but for master:
For our project, we need to do some additional validation of responses. Also, we need more detailed information about the cause of a failure. Currently, almost all methods in `AbstractSAML2ResponseValidator` and `SAML2AuthnResponseValidator` are final, making it impossible to implement these checks without copying both classes. This PR simply removes the final modifiers from the methods, allowing subclasses to override or augment the behavior.