### PR TITLE
SAML signing certificate validity increase: 1 -> 20 years

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -681,7 +681,7 @@ public class SAML2Configuration extends InitializableObject {
 
         final Calendar c = Calendar.getInstance();
         c.setTime(new Date());
-        c.add(Calendar.YEAR, 1);
+        c.add(Calendar.YEAR, 20);
         certGen.setEndDate(new Time(c.getTime()));
 
         certGen.setSignature(sigAlgID);


### PR DESCRIPTION
Valid time of the self signed certificate increased as per the following discussion:

https://groups.google.com/forum/?hl=en#!topic/pac4j-dev/bBaZgBk1mFE