### PR TITLE
[Azure Ad] Failed when using `common` tenant ID

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAdOidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAdOidcConfiguration.java
@@ -2,6 +2,7 @@ package org.pac4j.oidc.config;
 
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpUtils;
+import org.pac4j.oidc.client.azuread.AzureAdResourceRetriever;
 
 /**
  * AzureAd OpenID Connect configuration.
@@ -15,6 +16,7 @@ public class AzureAdOidcConfiguration extends OidcConfiguration {
     private String tenant;
 
     public AzureAdOidcConfiguration() {
+        this.setResourceRetriever(new AzureAdResourceRetriever());
     }
 
     public AzureAdOidcConfiguration(final OidcConfiguration oidcConfiguration) {


### PR DESCRIPTION
This bug was discover when using **CAS 5.3.x with delegated Azure AD client**, but I figure this probably should be fix at pac4j so I report here:

I was configuring **Azure AD** with tenant ID equals `common`, and it keep giving me this error `Illegal character in path at index 24: https://sts.windows.net/{tenantid}/` or `"https://login.microsoftonline.com/{tenantid}/v2.0"`

I found that the issue is because the `AzureAdResourceRetriever` is not being applied to the configuration for some reason.

After some digging, I found that by using the implementation of CAS to pac4j [here](https://github.com/apereo/cas/blob/v6.0.5.1/support/cas-server-support-pac4j-core-clients/src/main/java/org/apereo/cas/support/pac4j/authentication/DelegatedClientFactory.java#L528) which I think is pretty normal usage, the AzureAdResourceRetriever is not being applied

I found that adding `this.setResourceRetriever(new AzureAdResourceRetriever());` to the empty constructor of `AzureAdOidcConfiguration.java` will fix the issue nicely. 

Would be grateful if this PR is to be reviewed and potentially merged, many thanks!


