### PR TITLE
Allow relative callback URI resolution at request-time for SAMLv2 client

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
@@ -49,7 +49,7 @@ public abstract class IndirectClient<C extends Credentials> extends BaseClient<C
         // check configuration
         CommonHelper.assertNotBlank("callbackUrl", this.callbackUrl, "set it up either on this IndirectClient or on the global Config");
         if (this.urlResolver == null) {
-            this.urlResolver = new DefaultUrlResolver();
+            this.urlResolver = new DefaultUrlResolver(true);
         }
         if (this.callbackUrlResolver == null) {
             this.callbackUrlResolver = newDefaultCallbackUrlResolver();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectionActionBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectionActionBuilder.java
@@ -32,7 +32,7 @@ public class SAML2RedirectionActionBuilder implements RedirectionActionBuilder {
         CommonHelper.assertNotNull("client", client);
         this.client = client;
         final SAML2Configuration cfg = client.getConfiguration();
-        this.saml2ObjectBuilder = new SAML2AuthnRequestBuilder(cfg);
+        this.saml2ObjectBuilder = new SAML2AuthnRequestBuilder(cfg, client.getUrlResolver());
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -90,7 +90,6 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         final SingleSignOnService ssoService = context.getIDPSingleSignOnService(this.bindingType);
         final String idx = this.assertionConsumerServiceIndex > 0 ? String.valueOf(assertionConsumerServiceIndex) : null;
         final AssertionConsumerService assertionConsumerService = context.getSPAssertionConsumerService(idx);
-        assertionConsumerService.setLocation(this.urlResolver.compute(assertionConsumerService.getLocation(), context.getWebContext()));
         return buildAuthnRequest(context, assertionConsumerService, ssoService);
     }
 
@@ -134,7 +133,9 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         if (assertionConsumerServiceIndex >= 0) {
             request.setAssertionConsumerServiceIndex(assertionConsumerServiceIndex);
         } else {
-            request.setAssertionConsumerServiceURL(assertionConsumerService.getLocation());
+            request.setAssertionConsumerServiceURL(
+                this.urlResolver.compute(assertionConsumerService.getLocation(), context.getWebContext())
+            );
         }
         request.setProtocolBinding(assertionConsumerService.getBinding());
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -23,6 +23,7 @@ import org.opensaml.saml.saml2.core.impl.NameIDPolicyBuilder;
 import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.profile.api.SAML2ObjectBuilder;
@@ -62,12 +63,14 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
 
     private final XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
 
+    private final UrlResolver urlResolver;
+
     /**
      * Instantiates a new Saml 2 authn request builder.
      *
      * @param cfg Client configuration.
      */
-    public SAML2AuthnRequestBuilder(final SAML2Configuration cfg) {
+    public SAML2AuthnRequestBuilder(final SAML2Configuration cfg, final UrlResolver urlResolver) {
         this.forceAuth = cfg.isForceAuth();
         this.comparisonType = getComparisonTypeEnumFromString(cfg.getComparisonType());
         this.bindingType = cfg.getAuthnRequestBindingType();
@@ -79,6 +82,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         this.providerName = cfg.getProviderName();
         this.extensions = cfg.getAuthnRequestExtensions();
         this.useNameQualifier = cfg.isUseNameQualifier();
+        this.urlResolver = urlResolver;
     }
 
     @Override
@@ -86,6 +90,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         final SingleSignOnService ssoService = context.getIDPSingleSignOnService(this.bindingType);
         final String idx = this.assertionConsumerServiceIndex > 0 ? String.valueOf(assertionConsumerServiceIndex) : null;
         final AssertionConsumerService assertionConsumerService = context.getSPAssertionConsumerService(idx);
+        assertionConsumerService.setLocation(this.urlResolver.compute(assertionConsumerService.getLocation(), context.getWebContext()));
         return buildAuthnRequest(context, assertionConsumerService, ssoService);
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/AuthnRequestInflator.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/AuthnRequestInflator.java
@@ -13,6 +13,13 @@ import java.util.zip.InflaterInputStream;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 
+/**
+ * Utility class for decoding SAML authentication request payload.
+ * Originally present in class {@link RedirectSAML2ClientTests} and extracted for reuse in other tests. 
+ * 
+ * @author davoustp
+ * @since 4.0.0
+ */
 public class AuthnRequestInflator {
 
     /**

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/AuthnRequestInflator.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/AuthnRequestInflator.java
@@ -15,6 +15,11 @@ import org.apache.http.client.utils.URLEncodedUtils;
 
 public class AuthnRequestInflator {
 
+    /**
+     * Extracts the AuthnRequest payload from the encoded URL location.
+     * @param location the URL location containing the encoded AuthnRequest payload
+     * @return the plain decoded AuthnRequest payload
+     */
     public static String getInflatedAuthnRequest(final String location) {
         final List<NameValuePair> pairs = URLEncodedUtils.parse(java.net.URI.create(location), "UTF-8");
         final Inflater inflater = new Inflater(true);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/AuthnRequestInflator.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/AuthnRequestInflator.java
@@ -1,0 +1,37 @@
+package org.pac4j.saml.client;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+
+public class AuthnRequestInflator {
+
+    public static String getInflatedAuthnRequest(final String location) {
+        final List<NameValuePair> pairs = URLEncodedUtils.parse(java.net.URI.create(location), "UTF-8");
+        final Inflater inflater = new Inflater(true);
+        final byte[] decodedRequest = Base64.getDecoder().decode(pairs.get(0).getValue());
+        final ByteArrayInputStream is = new ByteArrayInputStream(decodedRequest);
+        final InflaterInputStream inputStream = new InflaterInputStream(is, inflater);
+        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+        String line;
+        final StringBuilder bldr = new StringBuilder();
+        try {
+            while ((line = reader.readLine()) != null) {
+                bldr.append(line);
+            }
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+        return bldr.toString();
+    }
+
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -13,7 +13,6 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import java.util.Arrays;
 
 import static org.junit.Assert.*;
-import static org.pac4j.saml.client.AuthnRequestInflator.getInflatedAuthnRequest;
 
 /**
  * Redirection tests on the {@link SAML2Client}.
@@ -32,7 +31,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
 
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
-        final String inflated = getInflatedAuthnRequest(action.getLocation());
+        final String inflated = AuthnRequestInflator.getInflatedAuthnRequest(action.getLocation());
 
         // JDK8 and JDK11 do not produce the same XML (attributes in different order)
         // something like xmlunit would have been better but may be a bit overkill for just 2 failing tests
@@ -54,7 +53,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
 
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
-        final String inflated = getInflatedAuthnRequest(action.getLocation());
+        final String inflated = AuthnRequestInflator.getInflatedAuthnRequest(action.getLocation());
 
         final String issuerJdk8 = "<saml2:Issuer "
             + "Format=\"urn:oasis:names:tc:SAML:2.0:nameid-format:entity\" "
@@ -71,7 +70,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         client.getConfiguration().setForceAuth(true);
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
-        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("ForceAuthn=\"true\""));
+        assertTrue(AuthnRequestInflator.getInflatedAuthnRequest(action.getLocation()).contains("ForceAuthn=\"true\""));
     }
 
     @Test
@@ -80,7 +79,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         client.getConfiguration().setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
-        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("Comparison=\"exact\""));
+        assertTrue(AuthnRequestInflator.getInflatedAuthnRequest(action.getLocation()).contains("Comparison=\"exact\""));
     }
 
     @Test
@@ -90,7 +89,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
         final String loc = action.getLocation();
-        assertTrue(getInflatedAuthnRequest(loc).contains("<saml2p:NameIDPolicy AllowCreate=\"true\" " +
+        assertTrue(AuthnRequestInflator.getInflatedAuthnRequest(loc).contains("<saml2p:NameIDPolicy AllowCreate=\"true\" " +
                 "Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\"/></saml2p:AuthnRequest>"));
     }
 
@@ -108,7 +107,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
                 "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml2:AuthnContextClassRef>" +
                 "</saml2p:RequestedAuthnContext>";
 
-        assertTrue(getInflatedAuthnRequest(action.getLocation()).contains(checkClass));
+        assertTrue(AuthnRequestInflator.getInflatedAuthnRequest(action.getLocation()).contains(checkClass));
     }
 
     @Test

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -1,7 +1,5 @@
 package org.pac4j.saml.client;
 
-import org.apache.http.NameValuePair;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.junit.Test;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.AuthnContextComparisonTypeEnumeration;
@@ -12,18 +10,10 @@ import org.pac4j.saml.state.SAML2StateGenerator;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Base64;
-import java.util.List;
-import java.util.zip.Inflater;
-import java.util.zip.InflaterInputStream;
 
 import static org.junit.Assert.*;
+import static org.pac4j.saml.client.AuthnRequestInflator.getInflatedAuthnRequest;
 
 /**
  * Redirection tests on the {@link SAML2Client}.
@@ -140,22 +130,4 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         return SAMLConstants.SAML2_REDIRECT_BINDING_URI;
     }
 
-    private String getInflatedAuthnRequest(final String location) {
-        final List<NameValuePair> pairs = URLEncodedUtils.parse(java.net.URI.create(location), "UTF-8");
-        final Inflater inflater = new Inflater(true);
-        final byte[] decodedRequest = Base64.getDecoder().decode(pairs.get(0).getValue());
-        final ByteArrayInputStream is = new ByteArrayInputStream(decodedRequest);
-        final InflaterInputStream inputStream = new InflaterInputStream(is, inflater);
-        final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-        String line;
-        final StringBuilder bldr = new StringBuilder();
-        try {
-            while ((line = reader.readLine()) != null) {
-                bldr.append(line);
-            }
-        } catch (final IOException e) {
-            throw new RuntimeException(e);
-        }
-        return bldr.toString();
-    }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientWithRelativeCallbackURITests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientWithRelativeCallbackURITests.java
@@ -1,7 +1,6 @@
 package org.pac4j.saml.client;
 
 import static org.junit.Assert.assertTrue;
-import static org.pac4j.saml.client.AuthnRequestInflator.getInflatedAuthnRequest;
 
 import org.junit.Test;
 import org.opensaml.saml.common.xml.SAMLConstants;
@@ -30,7 +29,7 @@ public class RedirectSAML2ClientWithRelativeCallbackURITests extends AbstractSAM
         final SAML2Client client = getClient();
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
-        String authnRequest = getInflatedAuthnRequest(action.getLocation());
+        String authnRequest = AuthnRequestInflator.getInflatedAuthnRequest(action.getLocation());
         assertTrue(authnRequest.contains("AssertionConsumerServiceURL=\"http://localhost"+RELATIVE_CALLBACK_URI+"\""));
     }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientWithRelativeCallbackURITests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientWithRelativeCallbackURITests.java
@@ -1,0 +1,36 @@
+package org.pac4j.saml.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.pac4j.saml.client.AuthnRequestInflator.getInflatedAuthnRequest;
+
+import org.junit.Test;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.http.FoundAction;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+public class RedirectSAML2ClientWithRelativeCallbackURITests extends AbstractSAML2ClientTests {
+
+    public static final String RELATIVE_CALLBACK_URI = "/callback?client_name=" + SAML2Client.class.getSimpleName();
+    
+    @Override
+    protected String getCallbackUrl() {
+        return RELATIVE_CALLBACK_URI;
+    }
+
+    @Override
+    protected String getAuthnRequestBindingType() {
+        return SAMLConstants.SAML2_REDIRECT_BINDING_URI;
+    }
+
+    @Test
+    public void testRedirectLocationIsAppropriatelyResolved() {
+        final SAML2Client client = getClient();
+        final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
+        final FoundAction action = (FoundAction) client.getRedirectionAction(context).get();
+        String authnRequest = getInflatedAuthnRequest(action.getLocation());
+        assertTrue(authnRequest.contains("AssertionConsumerServiceURL=\"http://localhost"+RELATIVE_CALLBACK_URI+"\""));
+    }
+}


### PR DESCRIPTION
The current implementation forces to configure an absolute callback URI when instantiating the SAMLv2 client.

This might be a problem when the pac4j-equipped application is multi-homed and can be reached using various URLs/domains, or when the application is moved from one domain to another ( requires reconfiguration of the SAMLv2 part of the app in the process).

This pull request streamlines these use cases by allowing to define a relative callback URI at configuration time (say: `/auth/callback`) and performs the callback URI resolution at request-processing time using the configured client's `UrlResolver`, so that the callback URI is resolved against the URI which was used initially to reach the app.

Note: you'll see that the `DefaultUrlResolver` was instantiated in the `IndirectClient` internal init without the flag allowing this resolution to occur, so I switched it on - but I don't have the full picture of the entire pac4j codebase, so I'm not sure if there is any side-effect that could affect other indirect clients. Let me know...

In case you want to move forward with this code change, I suspect another pull request on the 3.x branch is required - I'll be happy to do that as well.