### PR TITLE
Expose certificate algorithm, expiration and key length in SAML2 configuration

### DIFF
--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -75,7 +75,7 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
 
     @Test
     public void testSetComparisonTypeWithPostBinding() {
-        final SAML2Client client =  getClient();
+        final SAML2Client client = getClient();
         client.getConfiguration().setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final OkAction action = (OkAction) client.getRedirectionAction(context).get();


### PR DESCRIPTION
We might also consider to switch key sizes to 3072 in the future.
