### PR TITLE
Handle not falling back to anonymous if credentials to a client are provided but the client does not authenticate

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.pac4j.core.authorization.generator.AuthorizationGenerator;
 import org.pac4j.core.context.WebContext;
@@ -41,6 +42,8 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseClient<C extends Credentials, U extends CommonProfile> extends InitializableObject implements Client<C, U> {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+    
+    public static final String CREDENTIALS_SUPPLIED_MAP = "credentialsSuppliedMap";
 
     private String name;
 
@@ -66,6 +69,14 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
             if (credentials == null) {
                 return null;
             }
+            @SuppressWarnings("unchecked")
+            Map<Client<C, U>, C> credentialsSuppliedMap = 
+                (Map<Client<C, U>, C>) context.getRequestAttribute(CREDENTIALS_SUPPLIED_MAP);
+            if (credentialsSuppliedMap == null) {
+                credentialsSuppliedMap = new ConcurrentHashMap<>();
+                context.setRequestAttribute(CREDENTIALS_SUPPLIED_MAP, credentialsSuppliedMap);
+            }
+            credentialsSuppliedMap.put(this, credentials);
             final long t0 = System.currentTimeMillis();
             try {
                 this.authenticator.validate(credentials, context);


### PR DESCRIPTION
If in general you fall back to anonymous credentials you won't want to
do that if credentials are presented for some client otherwise you will
not get back results as the user you attempted to get results as.

Hence add the ability to detect if credentials were supplied for the
client so that if multiple clients are in play you know what credentials
are supplied. Example of usage:


if (lastAnonymousAuthentication.get() != null &&
!isCredentialsPresented.get()) {

Then you'd do the fallback scenario...


To do populate this I use pass the isCredentialsPresented to this method

which checks the map in the base class in pac4j code.

The map captures per client what credentials were passed so you can
action on that.

    private static void populateIsCredentialsPresented(Client<? extends
Credentials, ? extends UserProfile> client, J2EContext context,
AtomicBoolean isCredentialsPresented) {
        @SuppressWarnings("unchecked")
        Map<Client<? extends Credentials, ? extends UserProfile>,
Credentials> credentialsSuppliedMap = (Map<Client<? extends Credentials,
? extends UserProfile>, Credentials>)
context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
        if (credentialsSuppliedMap != null) {
            Credentials credentialsSupplied =
credentialsSuppliedMap.get(client);
            if (credentialsSupplied != null && !(credentialsSupplied
instanceof AnonymousCredentials)) {
                if (credentialsSupplied instanceof
UsernamePasswordCredentials) {
                    UsernamePasswordCredentials usernamePwdCred =
(UsernamePasswordCredentials) credentialsSupplied;
                    if ((usernamePwdCred.getUsername() == null ||
usernamePwdCred.getUsername().isEmpty()) &&
(usernamePwdCred.getPassword() == null ||
usernamePwdCred.getPassword().isEmpty())) {
                        return;
                    }
                }
                isCredentialsPresented.set(true);
            }
        }
    }