### PR TITLE
Handle not falling back to anonymous if credentials to a client are provided but the client does not authenticate

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/BaseClient.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.pac4j.core.authorization.generator.AuthorizationGenerator;
 import org.pac4j.core.context.WebContext;
@@ -41,6 +42,8 @@ import org.slf4j.LoggerFactory;
 public abstract class BaseClient<C extends Credentials, U extends CommonProfile> extends InitializableObject implements Client<C, U> {
 
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+    
+    public static final String CREDENTIALS_SUPPLIED_MAP = "credentialsSuppliedMap";
 
     private String name;
 
@@ -66,6 +69,14 @@ public abstract class BaseClient<C extends Credentials, U extends CommonProfile>
             if (credentials == null) {
                 return null;
             }
+            @SuppressWarnings("unchecked")
+            Map<Client<C, U>, C> credentialsSuppliedMap = 
+                (Map<Client<C, U>, C>) context.getRequestAttribute(CREDENTIALS_SUPPLIED_MAP);
+            if (credentialsSuppliedMap == null) {
+                credentialsSuppliedMap = new ConcurrentHashMap<>();
+                context.setRequestAttribute(CREDENTIALS_SUPPLIED_MAP, credentialsSuppliedMap);
+            }
+            credentialsSuppliedMap.put(this, credentials);
             final long t0 = System.currentTimeMillis();
             try {
                 this.authenticator.validate(credentials, context);

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
@@ -1,6 +1,7 @@
 package org.pac4j.http.client.direct;
 
 import org.junit.Test;
+import org.pac4j.core.client.BaseClient;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
@@ -10,6 +11,9 @@ import org.pac4j.core.credentials.TokenCredentials;
 import org.pac4j.http.credentials.authenticator.test.SimpleTestTokenAuthenticator;
 
 import static org.junit.Assert.*;
+
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * This class tests the {@link HeaderClient} class.
@@ -52,6 +56,11 @@ public final class HeaderClientTests implements TestsConstants {
         final MockWebContext context = MockWebContext.create();
         context.addRequestHeader(HEADER_NAME, PREFIX_HEADER + VALUE);
         final TokenCredentials credentials = client.getCredentials(context);
+        @SuppressWarnings("unchecked")
+		Map<HeaderClient, TokenCredentials> csm = (Map<HeaderClient, TokenCredentials>) context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
+        assertNotNull(csm);
+        TokenCredentials tc = csm.get(client);
+        assertEquals(VALUE, tc.getToken());
         final CommonProfile profile = client.getUserProfile(credentials, context);
         assertEquals(VALUE, profile.getId());
     }

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
@@ -57,7 +57,8 @@ public final class HeaderClientTests implements TestsConstants {
         context.addRequestHeader(HEADER_NAME, PREFIX_HEADER + VALUE);
         final TokenCredentials credentials = client.getCredentials(context);
         @SuppressWarnings("unchecked")
-        Map<HeaderClient, TokenCredentials> csm = (Map<HeaderClient, TokenCredentials>) context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
+        Map<HeaderClient, TokenCredentials> csm = 
+                (Map<HeaderClient, TokenCredentials>) context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
         assertNotNull(csm);
         TokenCredentials tc = csm.get(client);
         assertEquals(VALUE, tc.getToken());

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
@@ -57,7 +57,7 @@ public final class HeaderClientTests implements TestsConstants {
         context.addRequestHeader(HEADER_NAME, PREFIX_HEADER + VALUE);
         final TokenCredentials credentials = client.getCredentials(context);
         @SuppressWarnings("unchecked")
-		Map<HeaderClient, TokenCredentials> csm = (Map<HeaderClient, TokenCredentials>) context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
+        Map<HeaderClient, TokenCredentials> csm = (Map<HeaderClient, TokenCredentials>) context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
         assertNotNull(csm);
         TokenCredentials tc = csm.get(client);
         assertEquals(VALUE, tc.getToken());

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/HeaderClientTests.java
@@ -13,7 +13,6 @@ import org.pac4j.http.credentials.authenticator.test.SimpleTestTokenAuthenticato
 import static org.junit.Assert.*;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * This class tests the {@link HeaderClient} class.


### PR DESCRIPTION
In my use case I attempt multiple clients including the anonymous client to see if one of them authenticates. At the end if none does authenticate but anonymous does then you can proceed with anonymous authentication only if no credentials were provided to any of the other clients that determined that there were credentials for it, but then did not authenticate,

You wouldn't want to for instance query a db for stuff you could see as a particular user and then get back results instead for anonymous user. the client may want to error out in that case.

In my usage I keep track of lastAnonymousAuthentication and  sCredentialsPresented which I determine by calling below method. then if (lastAnonymousAuthentication.get() != null &&
!isCredentialsPresented.get() I allow the anonymous credentials/

With this method in a request the map captures per client what credentials were passed so you can
action on that.

```
    private static void populateIsCredentialsPresented(Client<? extends
Credentials, ? extends UserProfile> client, J2EContext context,
AtomicBoolean isCredentialsPresented) {
        @SuppressWarnings("unchecked")
        Map<Client<? extends Credentials, ? extends UserProfile>,
Credentials> credentialsSuppliedMap = (Map<Client<? extends Credentials,
? extends UserProfile>, Credentials>)
context.getRequestAttribute(BaseClient.CREDENTIALS_SUPPLIED_MAP);
        if (credentialsSuppliedMap != null) {
            Credentials credentialsSupplied =
credentialsSuppliedMap.get(client);
            if (credentialsSupplied != null && !(credentialsSupplied
instanceof AnonymousCredentials)) {
                if (credentialsSupplied instanceof
UsernamePasswordCredentials) {
                    UsernamePasswordCredentials usernamePwdCred =
(UsernamePasswordCredentials) credentialsSupplied;
                    if ((usernamePwdCred.getUsername() == null ||
usernamePwdCred.getUsername().isEmpty()) &&
(usernamePwdCred.getPassword() == null ||
usernamePwdCred.getPassword().isEmpty())) {
                        return;
                    }
                }
                isCredentialsPresented.set(true);
            }
        }
    }
```
