### PR TITLE
Allow saml metadata generator to create MDUI elements

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -56,6 +56,7 @@ import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.InitializableObject;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.metadata.SAML2MetadataContactPerson;
+import org.pac4j.saml.metadata.SAML2MetadataUIInfo;
 import org.pac4j.saml.metadata.SAML2ServiceProvicerRequestedAttribute;
 import org.pac4j.saml.store.EmptyStoreFactory;
 import org.pac4j.saml.store.SAMLMessageStoreFactory;
@@ -172,6 +173,8 @@ public class SAML2Configuration extends InitializableObject {
 
     private List<SAML2MetadataContactPerson> contactPersons = new ArrayList<>();
 
+    private List<SAML2MetadataUIInfo> metadataUIInfos = new ArrayList<>();
+    
     private List<String> supportedProtocols = new ArrayList<>(Arrays.asList(SAMLConstants.SAML20P_NS,
         SAMLConstants.SAML10P_NS, SAMLConstants.SAML11P_NS));
     
@@ -249,6 +252,14 @@ public class SAML2Configuration extends InitializableObject {
 
     public void setContactPersons(final List<SAML2MetadataContactPerson> contactPersons) {
         this.contactPersons = contactPersons;
+    }
+
+    public List<SAML2MetadataUIInfo> getMetadataUIInfos() {
+        return metadataUIInfos;
+    }
+
+    public void setMetadataUIInfos(final List<SAML2MetadataUIInfo> metadataUIInfos) {
+        this.metadataUIInfos = metadataUIInfos;
     }
 
     public List<String> getSupportedProtocols() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataUIInfo.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataUIInfo.java
@@ -1,0 +1,104 @@
+package org.pac4j.saml.metadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is {@link SAML2MetadataUIInfo} that allows one to specify
+ * metadata UI information in saml2 metadata generation.
+ *
+ * @author Misagh Moayyed
+ * @since 4.0.0
+ */
+public class SAML2MetadataUIInfo {
+    private List<String> displayNames = new ArrayList<>();
+    private List<String> descriptions = new ArrayList<>();
+    private List<String> keywords = new ArrayList<>();
+    private List<String> informationUrls = new ArrayList<>();
+    private List<String> privacyUrls = new ArrayList<>();
+    private List<SAML2MetadataUILogo> logos = new ArrayList<>();
+
+    public List<SAML2MetadataUILogo> getLogos() {
+        return logos;
+    }
+
+    public void setLogos(final List<SAML2MetadataUILogo> logos) {
+        this.logos = logos;
+    }
+
+    public List<String> getDisplayNames() {
+        return displayNames;
+    }
+
+    public void setDisplayNames(final List<String> displayNames) {
+        this.displayNames = displayNames;
+    }
+
+    public List<String> getDescriptions() {
+        return descriptions;
+    }
+
+    public void setDescriptions(final List<String> descriptions) {
+        this.descriptions = descriptions;
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
+    }
+
+    public void setKeywords(final List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    public List<String> getInformationUrls() {
+        return informationUrls;
+    }
+
+    public void setInformationUrls(final List<String> informationUrls) {
+        this.informationUrls = informationUrls;
+    }
+
+    public List<String> getPrivacyUrls() {
+        return privacyUrls;
+    }
+
+    public void setPrivacyUrls(final List<String> privacyUrls) {
+        this.privacyUrls = privacyUrls;
+    }
+
+    public static class SAML2MetadataUILogo {
+        private String url;
+        private int width;
+        private int height;
+
+        public SAML2MetadataUILogo(final String url, final int width, final int height) {
+            this.url = url;
+            this.width = width;
+            this.height = height;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(final String url) {
+            this.url = url;
+        }
+
+        public int getWidth() {
+            return width;
+        }
+
+        public void setWidth(final int width) {
+            this.width = width;
+        }
+
+        public int getHeight() {
+            return height;
+        }
+
+        public void setHeight(final int height) {
+            this.height = height;
+        }
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -22,7 +22,12 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-import java.io.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.io.StringWriter;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -123,6 +128,7 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
 
         metadataGenerator.setSupportedProtocols(configuration.getSupportedProtocols());
         metadataGenerator.setContactPersons(configuration.getContactPersons());
+        metadataGenerator.setMetadataUIInfos(configuration.getMetadataUIInfos());
     }
 
     private void writeServiceProviderMetadataToResource(final String tempMetadata) throws Exception {

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -8,6 +8,7 @@ import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.metadata.SAML2MetadataContactPerson;
+import org.pac4j.saml.metadata.SAML2MetadataUIInfo;
 import org.pac4j.saml.state.SAML2StateGenerator;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -41,6 +42,15 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
         person.setEmailAddresses(Collections.singletonList("test@example.org"));
         person.setTelephoneNumbers(Collections.singletonList("+13476547689"));
         client.getConfiguration().getContactPersons().add(person);
+
+        final SAML2MetadataUIInfo uiInfo = new SAML2MetadataUIInfo();
+        uiInfo.setDescriptions(Collections.singletonList("description1"));
+        uiInfo.setDisplayNames(Collections.singletonList("displayName"));
+        uiInfo.setPrivacyUrls(Collections.singletonList("https://pac4j.org"));
+        uiInfo.setInformationUrls(Collections.singletonList("https://pac4j.org"));
+        uiInfo.setKeywords(Collections.singletonList("keyword1,keyword2,keyword3"));
+        uiInfo.setLogos(Collections.singletonList(new SAML2MetadataUIInfo.SAML2MetadataUILogo("https://pac4j.org/logo.png", 16, 16)));
+        client.getConfiguration().getMetadataUIInfos().add(uiInfo);
         
         final WebContext context = new JEEContext(new MockHttpServletRequest(), new MockHttpServletResponse());
         final OkAction action = (OkAction) client.getRedirectionAction(context).get();


### PR DESCRIPTION
The motivation for the change comes from the Kantara SAML2 deployment profile where MDUI compliance is a required item for SAML2 SPs. (There are a few other things that I might add, as we cover more ground in the spec).