### PR TITLE
Travis CI: Build pac4j against JDK 8 and 11 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ dist: trusty
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - openjdk10
   - openjdk11
 
 cache:


### PR DESCRIPTION
I don't think it's any longer necessary to build against JDK 9 and 10 as they are both EOLed. JDK 8 and 11 should for now be the canonical JDKs used for CI builds.