### PR TITLE
Support refresh grant in OidcClient

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
@@ -110,6 +110,8 @@ public class ProfileManager<U extends UserProfile> {
                         final Optional<U> newProfile = client.get().renewUserProfile(profile, context);
                         if (newProfile.isPresent()) {
                             profiles.put(key, newProfile.get());
+                            // TODO GET BOOLEANS FROM CONFIG OR MOVE THIS LOGIC ELSEWHERE
+                            save(true, newProfile.get(), false);
                         }
                     }
                 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
@@ -112,8 +112,6 @@ public class ProfileManager<U extends UserProfile> {
                         final Optional<U> newProfile = client.get().renewUserProfile(profile, context);
                         if (newProfile.isPresent()) {
                             profiles.put(key, newProfile.get());
-                            // TODO GET BOOLEANS FROM CONFIG OR MOVE THIS LOGIC ELSEWHERE
-                            save(true, newProfile.get(), false);
                         }
                     }
                 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -1,6 +1,9 @@
 package org.pac4j.oidc.client;
 
+import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import org.pac4j.core.client.IndirectClient;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
@@ -8,8 +11,11 @@ import org.pac4j.oidc.credentials.authenticator.OidcAuthenticator;
 import org.pac4j.oidc.credentials.extractor.OidcExtractor;
 
 import org.pac4j.oidc.logout.OidcLogoutActionBuilder;
+import org.pac4j.oidc.profile.OidcProfile;
 import org.pac4j.oidc.profile.creator.OidcProfileCreator;
 import org.pac4j.oidc.redirect.OidcRedirectionActionBuilder;
+
+import java.util.Optional;
 
 /**
  * This class is the client to authenticate users with an OpenID Connect 1.0 provider.
@@ -58,5 +64,27 @@ public class OidcClient<V extends OidcConfiguration> extends IndirectClient<Oidc
             "authenticator", getAuthenticator(), "profileCreator", getProfileCreator(),
             "logoutActionBuilder", getLogoutActionBuilder(), "authorizationGenerators", getAuthorizationGenerators(),
             "configuration", configuration);
+    }
+
+    @Override
+    public Optional<UserProfile> renewUserProfile(UserProfile profile, WebContext context) {
+        OidcProfile oidcProfile = (OidcProfile)profile;
+        if(!oidcProfile.isRefreshTokenExpired()){
+            Object refreshTokenObject = profile.getAttribute("refresh_token");
+            if(refreshTokenObject != null){
+                RefreshToken refreshToken = (RefreshToken)refreshTokenObject;
+                OidcCredentials credentials = new OidcCredentials();
+                credentials.setRefreshToken(refreshToken);
+                OidcAuthenticator authenticator =  new OidcAuthenticator(getConfiguration(), this);
+                authenticator.refresh(credentials);
+
+                // Create a profile if the refresh grant was successful
+                if(credentials.getAccessToken() != null){
+                    return getUserProfile(credentials, context);
+                }
+            }
+        }
+
+        return Optional.empty();
     }
 }


### PR DESCRIPTION
This feature was discussed here https://groups.google.com/forum/?hl=en#!topic/pac4j-dev/r7As1SYp_To

First of all, this my first contribution to pac4j, so please bear with me if I made some obvious mistakes.

I have not yet found an elegant way to save the renewed profile into the session store, the only way I found it to work so far, was to save the profile from within the profilemanager, but this scope is missing the boolean configurations "saveInSession" and "multiProfile".

Ideally the new profile should be saved from within DefaultSecurityLogic, but I have yet to understand the intricacies of pac4j to figure how to do that. Maybe someone more experienced on the matter could point me in the right direction?