### PR TITLE
Ensure allow-create and provider-name are optional for saml2 authn requests

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -174,7 +174,14 @@ public class SAML2Configuration extends InitializableObject {
     private List<SAML2MetadataContactPerson> contactPersons = new ArrayList<>();
 
     private List<SAML2MetadataUIInfo> metadataUIInfos = new ArrayList<>();
-    
+
+    /**
+     * If {@link #nameIdPolicyFormat} is defined, this setting
+     * will control whether the allow-create flag is used and set.
+     * A {@code null} value will skip setting the allow-create flag altogether.
+     */
+    private Boolean nameIdPolicyAllowCreate = Boolean.TRUE;
+
     private List<String> supportedProtocols = new ArrayList<>(Arrays.asList(SAMLConstants.SAML20P_NS,
         SAMLConstants.SAML10P_NS, SAMLConstants.SAML11P_NS));
     
@@ -244,6 +251,14 @@ public class SAML2Configuration extends InitializableObject {
         }
 
         initSignatureSigningConfiguration();
+    }
+
+    public Boolean isNameIdPolicyAllowCreate() {
+        return nameIdPolicyAllowCreate;
+    }
+
+    public void setNameIdPolicyAllowCreate(final Boolean nameIdPolicyAllowCreate) {
+        this.nameIdPolicyAllowCreate = nameIdPolicyAllowCreate;
     }
 
     public List<SAML2MetadataContactPerson> getContactPersons() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
@@ -95,7 +95,7 @@ public class SAML2MessageContext extends MessageContext<SAMLObject> {
             + binding);
     }
 
-    public final SingleSignOnService getIDPSingleSignOnService(final String binding) {
+    public SingleSignOnService getIDPSingleSignOnService(final String binding) {
         final List<SingleSignOnService> services = getIDPSSODescriptor().getSingleSignOnServices();
         for (final SingleSignOnService service : services) {
             if (service.getBinding().equals(binding)) {
@@ -106,11 +106,11 @@ public class SAML2MessageContext extends MessageContext<SAMLObject> {
                 + binding);
     }
 
-    public final AssertionConsumerService getSPAssertionConsumerService() {
+    public AssertionConsumerService getSPAssertionConsumerService() {
         return getSPAssertionConsumerService(null);
     }
 
-    public final AssertionConsumerService getSPAssertionConsumerService(final String acsIndex) {
+    public AssertionConsumerService getSPAssertionConsumerService(final String acsIndex) {
         final SPSSODescriptor spssoDescriptor = getSPSSODescriptor();
         final List<AssertionConsumerService> services = spssoDescriptor.getAssertionConsumerServices();
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/AbstractSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/AbstractSAML2ClientTests.java
@@ -24,6 +24,13 @@ public abstract class AbstractSAML2ClientTests implements TestsConstants {
     }
 
     protected final SAML2Client getClient() {
+        final SAML2Configuration cfg = getSaml2Configuration();
+        final SAML2Client saml2Client = new SAML2Client(cfg);
+        saml2Client.setCallbackUrl(getCallbackUrl());
+        return saml2Client;
+    }
+
+    protected SAML2Configuration getSaml2Configuration() {
         final SAML2Configuration cfg =
                 new SAML2Configuration(new FileSystemResource("target/samlKeystore.jks"),
                         "pac4j-demo-passwd",
@@ -37,9 +44,7 @@ public abstract class AbstractSAML2ClientTests implements TestsConstants {
         cfg.setForceKeystoreGeneration(true);
         cfg.setServiceProviderMetadataResource(new FileSystemResource(new File("target", "sp-metadata.xml").getAbsolutePath()));
         cfg.setSamlMessageStoreFactory(new HttpSessionStoreFactory());
-        final SAML2Client saml2Client = new SAML2Client(cfg);
-        saml2Client.setCallbackUrl(getCallbackUrl());
-        return saml2Client;
+        return cfg;
     }
 
     protected abstract String getCallbackUrl();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
@@ -1,0 +1,59 @@
+package org.pac4j.saml.sso.impl;
+
+import org.junit.Test;
+import org.opensaml.saml.common.messaging.context.SAMLSelfEntityContext;
+import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+import org.pac4j.saml.client.AbstractSAML2ClientTests;
+import org.pac4j.saml.client.SAML2Client;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.context.SAML2MessageContext;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.*;
+
+
+/**
+ * This is {@link SAML2AuthnRequestBuilderTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 4.0.0
+ */
+public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
+
+    @Test
+    public void testBuildAuthnRequestWithNoProviderAndNameIdPolicyAllowCreate() {
+        final SAML2Configuration configuration = getSaml2Configuration();
+        configuration.setAssertionConsumerServiceIndex(1);
+        configuration.setProviderName(null);
+        configuration.setUseNameQualifier(true);
+        configuration.setNameIdPolicyFormat("sample-nameid-format");
+        configuration.setNameIdPolicyAllowCreate(null);
+        final SAML2AuthnRequestBuilder builder = new SAML2AuthnRequestBuilder(configuration);
+
+        final SAMLSelfEntityContext selfEntityContext = mock(SAMLSelfEntityContext.class);
+        when(selfEntityContext.getEntityId()).thenReturn("entity-id");
+
+        final AssertionConsumerService acs = mock(AssertionConsumerService.class);
+        when(acs.getLocation()).thenReturn("https://pac4j.org");
+        final SingleSignOnService ssoService = mock(SingleSignOnService.class);
+        final SAML2MessageContext context = mock(SAML2MessageContext.class);
+        
+        when(context.getIDPSingleSignOnService(anyString())).thenReturn(ssoService);
+        when(context.getSPAssertionConsumerService(anyString())).thenReturn(acs);
+        when(context.getSAMLSelfEntityContext()).thenReturn(selfEntityContext);
+
+        assertNotNull(builder.build(context));
+    }
+
+    @Override
+    protected String getCallbackUrl() {
+        return "http://localhost:8080/callback?client_name=" + SAML2Client.class.getSimpleName();
+    }
+
+    @Override
+    protected String getAuthnRequestBindingType() {
+        return SAMLConstants.SAML2_POST_BINDING_URI;
+    }
+}


### PR DESCRIPTION
Clean up `SAML2AuthnRequestBuilder.java` and:

- Make sure the AllowCreate flag can be optionally created
- Make sure the ProviderName attribute can be optionally created
- Add test case for the `SAML2AuthnRequestBuilder.java` (Remove finality from methods to ensure mocks can be created)
- Clean up `SAML2AuthnRequestBuilder.java` to allow for easier configuration; replace parameter-passing with configuration object instead.