### PR TITLE
#1488 error log with JSON Object containing error code and description

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/UserInfoOidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/UserInfoOidcAuthenticator.java
@@ -81,7 +81,7 @@ public class UserInfoOidcAuthenticator extends InitializableObject implements Au
             final UserInfoResponse userInfoResponse = UserInfoResponse.parse(httpResponse);
             if (userInfoResponse instanceof UserInfoErrorResponse) {
                 logger.error("Bad User Info response, error={}",
-                    ((UserInfoErrorResponse) userInfoResponse).getErrorObject());
+                    ((UserInfoErrorResponse) userInfoResponse).getErrorObject().toJSONObject());
                 throw new AuthenticationException();
             } else {
                 final UserInfoSuccessResponse userInfoSuccessResponse = (UserInfoSuccessResponse) userInfoResponse;


### PR DESCRIPTION
 print toJSONObject in the error log to not only print the error code but more information for better log analysis 