### PR TITLE
 Current implementation does not support selected SP assertion consumer service different from the default one

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -4,6 +4,7 @@ import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
 import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
 import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
@@ -56,7 +57,8 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
         decodedCtx.getSAMLBindingContext().setRelayState(relayState);
         context.getSAMLBindingContext().setRelayState(relayState);
 
-        final AssertionConsumerService acsService = context.getSPAssertionConsumerService();
+        final AssertionConsumerService acsService
+                = context.getSPAssertionConsumerService((Response) decodedCtx.getMessage());
         decodedCtx.getSAMLEndpointContext().setEndpoint(acsService);
 
         final EntityDescriptor metadata = context.getSAMLPeerMetadataContext().getEntityDescriptor();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -16,8 +16,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.File;
+import java.io.FileReader;
 import java.util.Collections;
 import net.shibboleth.utilities.java.support.codec.Base64Support;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
@@ -45,11 +45,11 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test
     public void testAssertionConsumingServiceWithMultipleIDP() throws Exception {
-        InputStream is = SAML2DefaultResponseValidatorTests.class.getClassLoader().
-                getResourceAsStream(SAMPLE_RESPONSE_FILE_NAME);
-
-        final XMLObject xmlObject
-                = XMLObjectSupport.unmarshallFromReader(Configuration.getParserPool(), new InputStreamReader(is));
+        File file = new File(SAML2DefaultResponseValidatorTests.class.getClassLoader().
+                getResource(SAMPLE_RESPONSE_FILE_NAME).getFile());
+        
+        final XMLObject xmlObject = XMLObjectSupport.unmarshallFromReader(
+                Configuration.getParserPool(), new FileReader(file));
 
         Response response = (Response) xmlObject;
         response.setIssueInstant(DateTime.now(DateTimeZone.UTC));
@@ -74,7 +74,6 @@ public class SAML2DefaultResponseValidatorTests {
         request.setParameter("SAMLResponse", Base64Support.encode(os.toByteArray(), Base64Support.UNCHUNKED));
         request.setParameter("RelayState", "TST-2-FZOsWEfjC-IH-h6Xb333DRbu5UPMHqfL");
         WebContext webContext = new JEEContext(request, new MockHttpServletResponse());
-        webContext.getRequestMethod();
         context.setWebContext(webContext);
 
         EntityDescriptor idpDescriptor = mock(EntityDescriptor.class);
@@ -87,7 +86,7 @@ public class SAML2DefaultResponseValidatorTests {
 
         context.getSAMLSelfEntityContext().setEntityId("https://auth.izslt.it");
         context.getSAMLPeerEntityContext().setAuthenticated(true);
-        
+
         AssertionConsumerServiceImpl acs = new AssertionConsumerServiceImpl(
                 response.getDestination(),
                 response.getDestination(),

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -17,7 +17,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import net.shibboleth.utilities.java.support.codec.Base64Support;
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
@@ -49,7 +51,8 @@ public class SAML2DefaultResponseValidatorTests {
                 getResource(SAMPLE_RESPONSE_FILE_NAME).getFile());
         
         final XMLObject xmlObject = XMLObjectSupport.unmarshallFromReader(
-                Configuration.getParserPool(), new FileReader(file));
+                Configuration.getParserPool(), 
+                new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
 
         Response response = (Response) xmlObject;
         response.setIssueInstant(DateTime.now(DateTimeZone.UTC));

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -11,10 +11,97 @@ import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.replay.InMemoryReplayCacheProvider;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import net.shibboleth.utilities.java.support.codec.Base64Support;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.impl.AssertionConsumerServiceImpl;
+import org.opensaml.security.SecurityException;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.logout.handler.LogoutHandler;
+import org.pac4j.saml.util.Configuration;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
 public class SAML2DefaultResponseValidatorTests {
+
+    private final static String SAMPLE_RESPONSE_FILE_NAME = "sample_authn_response.xml";
+
+    @Test
+    public void testAssertionConsumingServiceWithMultipleIDP() throws Exception {
+        InputStream is = SAML2DefaultResponseValidatorTests.class.getClassLoader().
+                getResourceAsStream(SAMPLE_RESPONSE_FILE_NAME);
+
+        final XMLObject xmlObject
+                = XMLObjectSupport.unmarshallFromReader(Configuration.getParserPool(), new InputStreamReader(is));
+
+        Response response = (Response) xmlObject;
+        response.setIssueInstant(DateTime.now(DateTimeZone.UTC));
+        response.getAssertions().forEach(assertion -> {
+            assertion.setIssueInstant(DateTime.now(DateTimeZone.UTC));
+            assertion.getSubject().getSubjectConfirmations().get(0).
+                    getSubjectConfirmationData().setNotOnOrAfter(DateTime.now(DateTimeZone.UTC));
+            assertion.getConditions().setNotOnOrAfter(DateTime.now(DateTimeZone.UTC));
+            assertion.getAuthnStatements().forEach(authnStatement -> authnStatement.setAuthnInstant(
+                    DateTime.now(DateTimeZone.UTC)));
+        });
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        XMLObjectSupport.marshallToOutputStream(xmlObject, os);
+
+        SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false);
+        SAML2MessageContext context = new SAML2MessageContext();
+        context.setMessage(response);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod(HttpConstants.HTTP_METHOD.POST.name());
+        request.setParameter("SAMLResponse", Base64Support.encode(os.toByteArray(), Base64Support.UNCHUNKED));
+        request.setParameter("RelayState", "TST-2-FZOsWEfjC-IH-h6Xb333DRbu5UPMHqfL");
+        WebContext webContext = new JEEContext(request, new MockHttpServletResponse());
+        webContext.getRequestMethod();
+        context.setWebContext(webContext);
+
+        EntityDescriptor idpDescriptor = mock(EntityDescriptor.class);
+        context.getSAMLPeerMetadataContext().setEntityDescriptor(idpDescriptor);
+        when(idpDescriptor.getEntityID()).thenReturn("http://localhost:8088");
+
+        SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
+        SPSSODescriptor roleDescriptor = mock(SPSSODescriptor.class);
+        when(roleDescriptor.getWantAssertionsSigned()).thenReturn(false);
+
+        context.getSAMLSelfEntityContext().setEntityId("https://auth.izslt.it");
+        context.getSAMLPeerEntityContext().setAuthenticated(true);
+        
+        AssertionConsumerServiceImpl acs = new AssertionConsumerServiceImpl(
+                response.getDestination(),
+                response.getDestination(),
+                response.getDestination()) {
+        };
+        acs.setLocation("https://auth.izslt.it/cas/login?client_name=idptest");
+
+        when(roleDescriptor.getAssertionConsumerServices()).thenReturn(Collections.singletonList(acs));
+
+        samlSelfMetadataContext.setRoleDescriptor(roleDescriptor);
+
+        SAML2WebSSOMessageReceiver receiver = new SAML2WebSSOMessageReceiver(validator);
+        receiver.receiveMessage(context);
+    }
 
     @Test
     public void testDoesNotWantAssertionsSignedWithNullContext() {
@@ -24,8 +111,17 @@ public class SAML2DefaultResponseValidatorTests {
 
     private SAML2AuthnResponseValidator createResponseValidatorWithSigningValidationOf(boolean wantsAssertionsSigned) {
         SAML2SignatureTrustEngineProvider trustEngineProvider = mock(SAML2SignatureTrustEngineProvider.class);
+        LogoutHandler logoutHandler = mock(LogoutHandler.class);
+        SignatureTrustEngine engine = mock(SignatureTrustEngine.class);
+        
+        try {
+            when(engine.validate(any(Signature.class), any(CriteriaSet.class))).thenReturn(true);
+        } catch (SecurityException ex) {
+            fail();
+        }
+        when(trustEngineProvider.build()).thenReturn(engine);
         Decrypter decrypter = mock(Decrypter.class);
-        return new SAML2AuthnResponseValidator(trustEngineProvider, decrypter, null, 0, wantsAssertionsSigned,
+        return new SAML2AuthnResponseValidator(trustEngineProvider, decrypter, logoutHandler, 0, wantsAssertionsSigned,
                 new InMemoryReplayCacheProvider(), false);
     }
 

--- a/pac4j-saml/src/test/resources/sample_authn_response.xml
+++ b/pac4j-saml/src/test/resources/sample_authn_response.xml
@@ -1,0 +1,95 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Version="2.0" IssueInstant="2020-01-31T15:55:38Z" InResponseTo="_5815d22eaf804954b84ce1418f16edad3018926" Destination="https://auth.izslt.it/cas/login?client_name=idptest" ID="id_c082f790d3a0eb69cff209a0a1de34d3bf428b71">
+  <saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" NameQualifier="http://localhost:8088">http://localhost:8088</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI="#id_c082f790d3a0eb69cff209a0a1de34d3bf428b71"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>Jvq7KJnbhqQx5EI8pbkPa4Isk4gKorVugi9qaN0PgzA=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>XboEc8nGkORSkRWtu11O/hZv8XUq9CfMagBTrHtsq8UGVUAAiHBYKRQlLDtEsLUzWU9GENbg6IO3NA9hfiFJoWprj5cXiqUTgmZ7IGSjQab7cV3Ta7d/g4Uux15LzFH7QKET8Tbtsln5p++BkUxmuqG5qFU6bIMRKRlpbV5HsiRRXARFbUS5OL1SxSdz60W3sEdrlYeox8q7DxIfiJaTLS1GxTqtjlxXCe9C2ZuT5nmVS0/YQIzJPODZPYDukICbOcXSqxjoInaCPRRcxbuVRF0CM+DGXc8H+l6JTDysfN15AQp9XIBmJPR3fElTIJnhAOqkK9BqUg8xaKT/kjnqCQ==</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIC7TCCAdWgAwIBAgIJAPilQcSjwd+pMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNV
+BAYTAklUMB4XDTE5MDYxMTEyMzkwN1oXDTE5MDcxMTEyMzkwN1owDTELMAkGA1UE
+BhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCcBsGU+Je53Xw2
+kgjRY/25Bi93eNO96CfYu3ZYCj/VOV1DytAWpCXtLQXAG1SVaeP3Ak8tkNi+RbCW
+w0/WRTrUBEujLXjyHJHD80Dc6vuPuqJbZ1AClhIZyDIfwiMxmDRsYwf9QbEUoeX+
+jqLK1i5+DGJBlAhWxn6cWfcXYRyGYihVh87B7wAqS0d2P5E3tvMx669IL3cuV2qn
+y74l0OhK6xkYVwheb5b1XtmekBGVbiBVtz6CjTAh1d89lSOp0LVo19rCzDwI+4cO
+jEmtDL0Fw6knzm29fUI8c5PLwAHfu+OjsHUONJj/YEjeqQqpQiFUHg3CkX18hPxs
+WAZqjB7fAgMBAAGjUDBOMB0GA1UdDgQWBBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAf
+BgNVHSMEGDAWgBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAMBgNVHRMEBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4IBAQCBjICQbLfbKlDUfcm2AqsPD7crvq+jEH54Plnsj2WI
+1iTnK0WWXs0OE4RymAqsP/4mvq95e0MxPy7n+L05EOp8+VFG47XzuQtjcqRzmg/4
+sDojz6ToUl3dYKCcJYyklHIiFOA8vHJ5w4LKKfVMbHjnv7FT7lTAOiAtvH2/IpYT
+y2EtLa7pdM3EuGxAKvH9UOli8NcFurZVA+gCS7Gp9tZkLHsa2anKbgxHdz0mH+vA
+Aqton5KdRuilrZuyJTemkGOgqMHOTm7CMuWMe28dM1/hEMgK0QQgAKN9LgG3aB1V
+5HjwjCGCyISmUXY7qXcYjrdlOHRaIsVG8ZLp1oPNwKus
+</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+  <saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="2.0" IssueInstant="2020-01-31T15:55:38Z" ID="id_2de40e36bd922a18c4ba96af7c5e6d4dc90750c6">
+    <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity" NameQualifier="http://localhost:8088">http://localhost:8088</saml:Issuer><ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/><ds:Reference URI="#id_2de40e36bd922a18c4ba96af7c5e6d4dc90750c6"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/><ds:DigestValue>z14LzufA65YR59jdYjHBigAB+sQNWTTaGWbsXe3hsrI=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>VoiuWCujz2jrjgufC5mwiyfKUEdIOyti9ybndJX2CuFTfjq2ONfbOuZxSChPhw8hPmZ+LIuCN/Tpdrn5Pr5fPx4Mob0LcAly7FByFvlIZXwutCx9eKQmqhxo9umDD7Kjg+x9bvHzDKwGk8wg+KeG4fOU+hvewb9M6Fu1QyDSpyCNojj91VDDsXFpA523tq25S6v0mJBISAOGrrqUXSIPdsN/7zZxERvS/uW07dZN2JJL9stOoZ2JYHICJ5iQwj0u0y0REJZgTcLJ2HGgAp8ZUXsN6tUk0Aw5hE69gvYxm4gbRVC7/SCLQ2vJm14dXndBkKOzjmRc/Z9eejjm04Iw8w==</ds:SignatureValue><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIC7TCCAdWgAwIBAgIJAPilQcSjwd+pMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNV
+BAYTAklUMB4XDTE5MDYxMTEyMzkwN1oXDTE5MDcxMTEyMzkwN1owDTELMAkGA1UE
+BhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCcBsGU+Je53Xw2
+kgjRY/25Bi93eNO96CfYu3ZYCj/VOV1DytAWpCXtLQXAG1SVaeP3Ak8tkNi+RbCW
+w0/WRTrUBEujLXjyHJHD80Dc6vuPuqJbZ1AClhIZyDIfwiMxmDRsYwf9QbEUoeX+
+jqLK1i5+DGJBlAhWxn6cWfcXYRyGYihVh87B7wAqS0d2P5E3tvMx669IL3cuV2qn
+y74l0OhK6xkYVwheb5b1XtmekBGVbiBVtz6CjTAh1d89lSOp0LVo19rCzDwI+4cO
+jEmtDL0Fw6knzm29fUI8c5PLwAHfu+OjsHUONJj/YEjeqQqpQiFUHg3CkX18hPxs
+WAZqjB7fAgMBAAGjUDBOMB0GA1UdDgQWBBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAf
+BgNVHSMEGDAWgBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAMBgNVHRMEBTADAQH/MA0G
+CSqGSIb3DQEBCwUAA4IBAQCBjICQbLfbKlDUfcm2AqsPD7crvq+jEH54Plnsj2WI
+1iTnK0WWXs0OE4RymAqsP/4mvq95e0MxPy7n+L05EOp8+VFG47XzuQtjcqRzmg/4
+sDojz6ToUl3dYKCcJYyklHIiFOA8vHJ5w4LKKfVMbHjnv7FT7lTAOiAtvH2/IpYT
+y2EtLa7pdM3EuGxAKvH9UOli8NcFurZVA+gCS7Gp9tZkLHsa2anKbgxHdz0mH+vA
+Aqton5KdRuilrZuyJTemkGOgqMHOTm7CMuWMe28dM1/hEMgK0QQgAKN9LgG3aB1V
+5HjwjCGCyISmUXY7qXcYjrdlOHRaIsVG8ZLp1oPNwKus
+</ds:X509Certificate></ds:X509Data></ds:KeyInfo></ds:Signature>
+    <saml:Subject>
+      <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient" NameQualifier="http://localhost:8088">id_ca96571f3e66c15359d4f59c0bdf5ed0dd025cfd</saml:NameID>
+      <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData Recipient="https://auth.izslt.it/cas/login?client_name=idptest" InResponseTo="_5815d22eaf804954b84ce1418f16edad3018926" NotOnOrAfter="2020-01-31T15:57:38Z"/>
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2020-01-31T15:53:38Z" NotOnOrAfter="2020-01-31T15:57:38Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>https://auth.izslt.it</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement AuthnInstant="2020-01-31T15:55:38Z" SessionIndex="id_7a3b76060b41652676680b8311e083219c91d165">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL1</saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="gender">
+        <saml:AttributeValue xsi:type="xs:string">F</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="familyName">
+        <saml:AttributeValue xsi:type="xs:string">Ricci</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="name">
+        <saml:AttributeValue xsi:type="xs:string">Eustachio</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="mobilePhone">
+        <saml:AttributeValue xsi:type="xs:string"/>
+      </saml:Attribute>
+      <saml:Attribute Name="fiscalNumber">
+        <saml:AttributeValue xsi:type="xs:string">TINIT-NNJEMM98O38H730Z</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="placeOfBirth">
+        <saml:AttributeValue xsi:type="xs:string"/>
+      </saml:Attribute>
+      <saml:Attribute Name="email">
+        <saml:AttributeValue xsi:type="xs:string">longosibilla@libero.it</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="countyOfBirth">
+        <saml:AttributeValue xsi:type="xs:string"/>
+      </saml:Attribute>
+      <saml:Attribute Name="address">
+        <saml:AttributeValue xsi:type="xs:string"/>
+      </saml:Attribute>
+      <saml:Attribute Name="dateOfBirth">
+        <saml:AttributeValue xsi:type="xs:date">1990-01-31</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="spidCode">
+        <saml:AttributeValue xsi:type="xs:string">779ec30a-36de-de1a-b783-0032689e74ba</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="digitalAddress">
+        <saml:AttributeValue xsi:type="xs:string"/>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
The issue is at the following line: provided assertion consumer service index is ignored.

https://github.com/pac4j/pac4j/blob/master/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java#L59

Looking forward for a feedback.
Regards