### PR TITLE
Introduce the FindBest utility class

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -22,6 +22,7 @@ title: Release notes&#58;
 - Properly handle states and nonces for multiple OIDC clients
 - A profile can be renewed by its client when it's expired
 - Most web authorizers are now matchers. The default matchers are "securityHeaders,csrfToken" and the default authorizer is "csrfCheck". Use "none" for no matcher or authorizer
+- Use the `FindBest` utility class to find the best adapter, logic...
 
 **v3.8.3**:
 

--- a/pac4j-core/src/main/java/org/pac4j/core/config/Config.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/config/Config.java
@@ -3,14 +3,14 @@ package org.pac4j.core.config;
 import org.pac4j.core.authorization.authorizer.Authorizer;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.Clients;
-import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.engine.CallbackLogic;
 import org.pac4j.core.engine.LogoutLogic;
 import org.pac4j.core.engine.SecurityLogic;
 import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.core.matching.matcher.Matcher;
-import org.pac4j.core.profile.ProfileManager;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
+import org.pac4j.core.profile.factory.ProfileManagerFactory2;
 import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,8 +18,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * The default configuration with clients, authorizers, matchers, etc.
@@ -29,10 +27,12 @@ import java.util.function.Function;
  */
 public class Config {
 
+    public static final Config INSTANCE = new Config();
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Config.class);
 
-    private static Function<WebContext, ProfileManager> profileManagerFactory;
-    private static BiFunction<WebContext, SessionStore, ProfileManager> profileManagerFactory2;
+    private ProfileManagerFactory profileManagerFactory;
+    private ProfileManagerFactory2 profileManagerFactory2;
 
     protected Clients clients;
 
@@ -193,36 +193,34 @@ public class Config {
         this.logoutLogic = logoutLogic;
     }
 
-    public static Function<WebContext, ProfileManager> getProfileManagerFactory() {
-        return profileManagerFactory;
+    public static ProfileManagerFactory getProfileManagerFactory() {
+        return INSTANCE.profileManagerFactory;
     }
 
-    public static void setProfileManagerFactory(final String name, final Function<WebContext, ProfileManager> profileManagerFactory) {
+    public static void setProfileManagerFactory(final String name, final ProfileManagerFactory profileManagerFactory) {
         CommonHelper.assertNotNull("profileManagerFactory", profileManagerFactory);
         LOGGER.info("Setting Config.profileManagerFactory: {}", name);
-        Config.profileManagerFactory = profileManagerFactory;
+        INSTANCE.profileManagerFactory = profileManagerFactory;
     }
 
-    public static void defaultProfileManagerFactory(final String name, final Function<WebContext, ProfileManager> profileManagerFactory) {
-        if (Config.profileManagerFactory == null) {
+    public static void defaultProfileManagerFactory(final String name, final ProfileManagerFactory profileManagerFactory) {
+        if (INSTANCE.profileManagerFactory == null) {
             setProfileManagerFactory(name, profileManagerFactory);
         }
     }
 
-    public static BiFunction<WebContext, SessionStore, ProfileManager> getProfileManagerFactory2() {
-        return profileManagerFactory2;
+    public static ProfileManagerFactory2 getProfileManagerFactory2() {
+        return INSTANCE.profileManagerFactory2;
     }
 
-    public static void setProfileManagerFactory2(final String name,
-                                                 final BiFunction<WebContext, SessionStore, ProfileManager> profileManagerFactory2) {
+    public static void setProfileManagerFactory2(final String name, final ProfileManagerFactory2 profileManagerFactory2) {
         CommonHelper.assertNotNull("profileManagerFactory2", profileManagerFactory2);
         LOGGER.info("Setting Config.profileManagerFactory2: {}", name);
-        Config.profileManagerFactory2 = profileManagerFactory2;
+        INSTANCE.profileManagerFactory2 = profileManagerFactory2;
     }
 
-    public static void defaultProfileManagerFactory2(final String name,
-                                                     final BiFunction<WebContext, SessionStore, ProfileManager> profileManagerFactory2) {
-        if (Config.profileManagerFactory2 == null) {
+    public static void defaultProfileManagerFactory2(final String name, final ProfileManagerFactory2 profileManagerFactory2) {
+        if (INSTANCE.profileManagerFactory2 == null) {
             setProfileManagerFactory2(name, profileManagerFactory2);
         }
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/context/JEEContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/JEEContext.java
@@ -44,13 +44,10 @@ public class JEEContext implements WebContext {
     public JEEContext(final HttpServletRequest request, final HttpServletResponse response, final SessionStore<JEEContext> sessionStore) {
         CommonHelper.assertNotNull("request", request);
         CommonHelper.assertNotNull("response", response);
+        CommonHelper.assertNotNull("sessionStore", sessionStore);
         this.request = request;
         this.response = response;
-        if (sessionStore == null) {
-            this.sessionStore = new JEESessionStore();
-        } else {
-            this.sessionStore = sessionStore;
-        }
+        this.sessionStore = sessionStore;
     }
 
     @Override

--- a/pac4j-core/src/main/java/org/pac4j/core/context/JEEContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/JEEContext.java
@@ -31,11 +31,11 @@ public class JEEContext implements WebContext {
      * @param response the current response
      */
     public JEEContext(final HttpServletRequest request, final HttpServletResponse response) {
-        this(request, response, new JEESessionStore());
+        this(request, response, JEESessionStore.INSTANCE);
     }
 
     /**
-     * Build a JEE context from the current HTTP request and response.
+     * Build a JEE context from the current HTTP request and response and from a session store.
      *
      * @param request      the current request
      * @param response     the current response

--- a/pac4j-core/src/main/java/org/pac4j/core/context/session/JEESessionStore.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/session/JEESessionStore.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
  */
 public class JEESessionStore implements SessionStore<JEEContext> {
 
+    public static final JEESessionStore INSTANCE = new JEESessionStore();
+
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected HttpSession getHttpSession(final JEEContext context) {

--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultCallbackLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultCallbackLogic.java
@@ -33,6 +33,8 @@ import static org.pac4j.core.util.CommonHelper.*;
  */
 public class DefaultCallbackLogic<R, C extends WebContext> extends AbstractExceptionAwareLogic<R, C> implements CallbackLogic<R, C> {
 
+    public static final DefaultCallbackLogic INSTANCE = new DefaultCallbackLogic();
+
     private ClientFinder clientFinder = new DefaultCallbackClientFinder();
 
     private SavedRequestHandler savedRequestHandler = new DefaultSavedRequestHandler();

--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultLogoutLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultLogoutLogic.java
@@ -36,6 +36,8 @@ import static org.pac4j.core.util.CommonHelper.*;
  */
 public class DefaultLogoutLogic<R, C extends WebContext> extends AbstractExceptionAwareLogic<R, C> implements LogoutLogic<R, C> {
 
+    public static final DefaultLogoutLogic INSTANCE = new DefaultLogoutLogic();
+
     @Override
     public R perform(final C context, final Config config, final HttpActionAdapter<R, C> httpActionAdapter,
                      final String defaultUrl, final String inputLogoutUrlPattern, final Boolean inputLocalLogout,

--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
@@ -49,6 +49,8 @@ import static org.pac4j.core.util.CommonHelper.*;
  */
 public class DefaultSecurityLogic<R, C extends WebContext> extends AbstractExceptionAwareLogic<R, C> implements SecurityLogic<R, C> {
 
+    public static final DefaultSecurityLogic INSTANCE = new DefaultSecurityLogic();
+
     private ClientFinder clientFinder = new DefaultSecurityClientFinder();
 
     private AuthorizationChecker authorizationChecker = new DefaultAuthorizationChecker();

--- a/pac4j-core/src/main/java/org/pac4j/core/http/adapter/JEEHttpActionAdapter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/adapter/JEEHttpActionAdapter.java
@@ -1,6 +1,5 @@
 package org.pac4j.core.http.adapter;
 
-import org.pac4j.core.config.Config;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.JEEContext;
 import org.pac4j.core.exception.TechnicalException;
@@ -56,24 +55,5 @@ public class JEEHttpActionAdapter implements HttpActionAdapter<Object, JEEContex
         }
 
         throw new TechnicalException("No action provided");
-    }
-
-    /**
-     * Return the best HTTP action adapter: first, the local one if defined or the one from the config if defined
-     * or otherwise the default one.
-     *
-     * @param localAdapter a local adapter
-     * @param config the pac4j config
-     * @return the most appropriate adapter
-     */
-    public static HttpActionAdapter<Object, JEEContext> findBestAdapter(final HttpActionAdapter<Object, JEEContext> localAdapter,
-                                                                        final Config config) {
-        if (localAdapter != null) {
-            return localAdapter;
-        } else if (config.getHttpActionAdapter() != null) {
-            return config.getHttpActionAdapter();
-        } else {
-            return INSTANCE;
-        }
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
@@ -3,8 +3,7 @@ package org.pac4j.core.profile.definition;
 import org.pac4j.core.context.Pac4jConstants;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.converter.Converters;
-
-import java.util.function.Function;
+import org.pac4j.core.profile.factory.ProfileFactory;
 
 /**
  * Profile definition with the common attributes.
@@ -41,7 +40,7 @@ public class CommonProfileDefinition<P extends CommonProfile> extends ProfileDef
         primary(Pac4jConstants.USERNAME, Converters.STRING);
     }
 
-    public CommonProfileDefinition(final Function<Object[], P> profileFactory) {
+    public CommonProfileDefinition(final ProfileFactory<P> profileFactory) {
         this();
         setProfileFactory(profileFactory);
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -3,6 +3,7 @@ package org.pac4j.core.profile.definition;
 import org.pac4j.core.profile.AttributeLocation;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.converter.AttributeConverter;
+import org.pac4j.core.profile.factory.ProfileFactory;
 import org.pac4j.core.util.CommonHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,7 +15,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Define a profile (its class and attributes).
@@ -34,7 +34,7 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
 
     private final Map<String, AttributeConverter<? extends Object>> converters = new HashMap<>();
 
-    protected Function<Object[], P> newProfile = parameters -> (P) new CommonProfile();
+    protected ProfileFactory<P> newProfile = parameters -> (P) new CommonProfile();
 
     /**
      * Return the new built profile.
@@ -102,7 +102,7 @@ public abstract class ProfileDefinition<P extends CommonProfile> {
      *
      * @param profileFactory the way to build the profile
      */
-    protected void setProfileFactory(final Function<Object[], P> profileFactory) {
+    protected void setProfileFactory(final ProfileFactory<P> profileFactory) {
         CommonHelper.assertNotNull("profileFactory", profileFactory);
         this.newProfile = profileFactory;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/DefaultProfileManagerFactory.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/DefaultProfileManagerFactory.java
@@ -1,0 +1,20 @@
+package org.pac4j.core.profile.factory;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.ProfileManager;
+
+/**
+ * The default {@link ProfileManagerFactory}.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.0
+ */
+public class DefaultProfileManagerFactory implements ProfileManagerFactory {
+
+    public static final DefaultProfileManagerFactory INSTANCE = new DefaultProfileManagerFactory();
+
+    @Override
+    public ProfileManager apply(final WebContext context) {
+        return new ProfileManager(context);
+    }
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/DefaultProfileManagerFactory2.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/DefaultProfileManagerFactory2.java
@@ -1,0 +1,21 @@
+package org.pac4j.core.profile.factory;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.profile.ProfileManager;
+
+/**
+ * The default {@link ProfileManagerFactory2}.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.0
+ */
+public class DefaultProfileManagerFactory2 implements ProfileManagerFactory2 {
+
+    public static final DefaultProfileManagerFactory2 INSTANCE = new DefaultProfileManagerFactory2();
+
+    @Override
+    public ProfileManager apply(final WebContext context, final SessionStore store) {
+        return new ProfileManager(context, store);
+    }
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileFactory.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileFactory.java
@@ -1,0 +1,14 @@
+package org.pac4j.core.profile.factory;
+
+import org.pac4j.core.profile.UserProfile;
+
+import java.util.function.Function;
+
+/**
+ * A profile factory.
+ *
+ * @author Jerome LELEU
+ * @since 1.0.0
+ */
+public interface ProfileFactory<P extends UserProfile> extends Function<Object[], P> {
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactory.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactory.java
@@ -1,0 +1,15 @@
+package org.pac4j.core.profile.factory;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.ProfileManager;
+
+import java.util.function.Function;
+
+/**
+ * A {@link ProfileManager} factory based on the {@link WebContext}.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.0
+ */
+public interface ProfileManagerFactory extends Function<WebContext, ProfileManager> {
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactory2.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactory2.java
@@ -1,0 +1,16 @@
+package org.pac4j.core.profile.factory;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.profile.ProfileManager;
+
+import java.util.function.BiFunction;
+
+/**
+ * A {@link ProfileManager} factory based on the {@link WebContext} and on the {@link SessionStore}.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.0
+ */
+public interface ProfileManagerFactory2 extends BiFunction<WebContext, SessionStore, ProfileManager> {
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactory2Aware.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactory2Aware.java
@@ -5,8 +5,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.util.CommonHelper;
-
-import java.util.function.BiFunction;
+import org.pac4j.core.util.FindBest;
 
 /**
  * For classes that can set the profile manager factory.
@@ -16,26 +15,18 @@ import java.util.function.BiFunction;
  */
 public class ProfileManagerFactory2Aware<C extends WebContext> {
 
-    private static final BiFunction<WebContext, SessionStore<WebContext>, ProfileManager> DEFAULT_PROFILE_MANAGER_FACTORY2 =
-        (webContext, sessionStore)-> new ProfileManager(webContext, sessionStore);
-
-    private BiFunction<C, SessionStore<C>, ProfileManager> profileManagerFactory2;
+    private ProfileManagerFactory2 profileManagerFactory2;
 
     protected ProfileManager getProfileManager(final C context, final SessionStore<C> sessionStore) {
-        if (profileManagerFactory2 != null) {
-            return profileManagerFactory2.apply(context, sessionStore);
-        } else if (Config.getProfileManagerFactory2() != null) {
-            return Config.getProfileManagerFactory2().apply(context, sessionStore);
-        } else {
-            return DEFAULT_PROFILE_MANAGER_FACTORY2.apply(context, (SessionStore<WebContext>) sessionStore);
-        }
+        return FindBest.profileManagerFactory2(this.profileManagerFactory2, Config.INSTANCE, DefaultProfileManagerFactory2.INSTANCE)
+            .apply(context, sessionStore);
     }
 
-    public BiFunction<C, SessionStore<C>, ProfileManager> getProfileManagerFactory2() {
+    public ProfileManagerFactory2 getProfileManagerFactory2() {
         return profileManagerFactory2;
     }
 
-    public void setProfileManagerFactory2(final BiFunction<C, SessionStore<C>, ProfileManager> factory) {
+    public void setProfileManagerFactory2(final ProfileManagerFactory2 factory) {
         CommonHelper.assertNotNull("factory", factory);
         this.profileManagerFactory2 = factory;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactoryAware.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/factory/ProfileManagerFactoryAware.java
@@ -4,8 +4,7 @@ import org.pac4j.core.config.Config;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.util.CommonHelper;
-
-import java.util.function.Function;
+import org.pac4j.core.util.FindBest;
 
 /**
  * For classes that can set the profile manager factory.
@@ -15,26 +14,18 @@ import java.util.function.Function;
  */
 public class ProfileManagerFactoryAware<C extends WebContext> {
 
-    private static final Function<WebContext, ProfileManager> DEFAULT_PROFILE_MANAGER_FACTORY =
-        webContext -> new ProfileManager(webContext);
-
-    private Function<C, ProfileManager> profileManagerFactory;
+    private ProfileManagerFactory profileManagerFactory;
 
     protected ProfileManager getProfileManager(final C context) {
-        if (profileManagerFactory != null) {
-            return profileManagerFactory.apply(context);
-        } else if (Config.getProfileManagerFactory() != null) {
-            return Config.getProfileManagerFactory().apply(context);
-        } else {
-            return DEFAULT_PROFILE_MANAGER_FACTORY.apply(context);
-        }
+        return FindBest.profileManagerFactory(this.profileManagerFactory, Config.INSTANCE, DefaultProfileManagerFactory.INSTANCE)
+            .apply(context);
     }
 
-    public Function<C, ProfileManager> getProfileManagerFactory() {
+    public ProfileManagerFactory getProfileManagerFactory() {
         return profileManagerFactory;
     }
 
-    public void setProfileManagerFactory(final Function<C, ProfileManager> factory) {
+    public void setProfileManagerFactory(final ProfileManagerFactory factory) {
         CommonHelper.assertNotNull("factory", factory);
         this.profileManagerFactory = factory;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/service/InMemoryProfileService.java
@@ -2,13 +2,13 @@ package org.pac4j.core.profile.service;
 
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.profile.factory.ProfileFactory;
 import org.pac4j.core.util.CommonHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -21,13 +21,13 @@ import java.util.stream.Collectors;
 public class InMemoryProfileService<U extends CommonProfile> extends AbstractProfileService<U>  {
 
     public Map<String,Map<String,Object>> profiles;
-    public Function<Object[], U> profileFactory;
+    public ProfileFactory<U> profileFactory;
 
-    public InMemoryProfileService(final Function<Object[], U> profileFactory) {
+    public InMemoryProfileService(final ProfileFactory<U> profileFactory) {
         this(new HashMap<>(), profileFactory);
     }
 
-    public InMemoryProfileService(final Map<String,Map<String,Object>> profiles, final Function<Object[], U> profileFactory) {
+    public InMemoryProfileService(final Map<String,Map<String,Object>> profiles, final ProfileFactory<U> profileFactory) {
         this.profiles = profiles;
         this.profileFactory = profileFactory;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/util/FindBest.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/FindBest.java
@@ -20,8 +20,8 @@ import org.pac4j.core.profile.factory.ProfileManagerFactory2;
  */
 public class FindBest {
 
-    public static HttpActionAdapter adapter(final HttpActionAdapter localAdapter, final Config config,
-                                            final HttpActionAdapter defaultAdapter) {
+    public static HttpActionAdapter httpActionAdapter(final HttpActionAdapter localAdapter, final Config config,
+                                                      final HttpActionAdapter defaultAdapter) {
         if (localAdapter != null) {
             return localAdapter;
         } else if (config != null && config.getHttpActionAdapter() != null) {

--- a/pac4j-core/src/main/java/org/pac4j/core/util/FindBest.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/FindBest.java
@@ -1,0 +1,104 @@
+package org.pac4j.core.util;
+
+import org.pac4j.core.config.Config;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.engine.CallbackLogic;
+import org.pac4j.core.engine.LogoutLogic;
+import org.pac4j.core.engine.SecurityLogic;
+import org.pac4j.core.http.adapter.HttpActionAdapter;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
+import org.pac4j.core.profile.factory.ProfileManagerFactory2;
+
+/**
+ * Utility class to find the best adapter, logic... in the following order:
+ * 1) the local one
+ * 2) the one from the config
+ * 3) the default one (must not be null).
+ *
+ * @author Jerome LELEU
+ * @since 4.0.0
+ */
+public class FindBest {
+
+    public static HttpActionAdapter adapter(final HttpActionAdapter localAdapter, final Config config,
+                                            final HttpActionAdapter defaultAdapter) {
+        if (localAdapter != null) {
+            return localAdapter;
+        } else if (config != null && config.getHttpActionAdapter() != null) {
+            return config.getHttpActionAdapter();
+        } else {
+            CommonHelper.assertNotNull("defaultAdapter", defaultAdapter);
+            return defaultAdapter;
+        }
+    }
+
+    public static SessionStore sessionStore(final SessionStore localSessionStore, final Config config,
+                                            final SessionStore defaultSessionStore) {
+        if (localSessionStore != null) {
+            return localSessionStore;
+        } else if (config != null && config.getSessionStore() != null) {
+            return config.getSessionStore();
+        } else {
+            CommonHelper.assertNotNull("defaultSessionStore", defaultSessionStore);
+            return defaultSessionStore;
+        }
+    }
+
+    public static ProfileManagerFactory profileManagerFactory(final ProfileManagerFactory localProfileManagerFactory, final Config config,
+                                                              final ProfileManagerFactory defaultProfileManagerFactory) {
+        if (localProfileManagerFactory != null) {
+            return localProfileManagerFactory;
+        } else if (config != null && config.getProfileManagerFactory() != null) {
+            return config.getProfileManagerFactory();
+        } else {
+            CommonHelper.assertNotNull("defaultProfileManagerFactory", defaultProfileManagerFactory);
+            return defaultProfileManagerFactory;
+        }
+    }
+
+    public static ProfileManagerFactory2 profileManagerFactory2(final ProfileManagerFactory2 localProfileManagerFactory2,
+                                                                final Config config,
+                                                                final ProfileManagerFactory2 defaultProfileManagerFactory2) {
+        if (localProfileManagerFactory2 != null) {
+            return localProfileManagerFactory2;
+        } else if (config != null && config.getProfileManagerFactory2() != null) {
+            return config.getProfileManagerFactory2();
+        } else {
+            CommonHelper.assertNotNull("defaultProfileManagerFactory2", defaultProfileManagerFactory2);
+            return defaultProfileManagerFactory2;
+        }
+    }
+
+    public static SecurityLogic securityLogic(final SecurityLogic localLogic, final Config config, final SecurityLogic defaultLogic) {
+        if (localLogic != null) {
+            return localLogic;
+        } else if (config != null && config.getSecurityLogic() != null) {
+            return config.getSecurityLogic();
+        } else {
+            CommonHelper.assertNotNull("defaultLogic", defaultLogic);
+            return defaultLogic;
+        }
+    }
+
+    public static CallbackLogic callbackLogic(final CallbackLogic localLogic, final Config config, final CallbackLogic defaultLogic) {
+        if (localLogic != null) {
+            return localLogic;
+        } else if (config != null && config.getCallbackLogic() != null) {
+            return config.getCallbackLogic();
+        } else {
+            CommonHelper.assertNotNull("defaultLogic", defaultLogic);
+            return defaultLogic;
+        }
+    }
+
+    public static LogoutLogic logoutLogic(final LogoutLogic localLogic, final Config config, final LogoutLogic defaultLogic) {
+        if (localLogic != null) {
+            return localLogic;
+        } else if (config != null && config.getLogoutLogic() != null) {
+            return config.getLogoutLogic();
+        } else {
+            CommonHelper.assertNotNull("defaultLogic", defaultLogic);
+            return defaultLogic;
+        }
+    }
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/config/HasBeenCancelledFactory.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/config/HasBeenCancelledFactory.java
@@ -1,0 +1,14 @@
+package org.pac4j.oauth.config;
+
+import org.pac4j.core.context.WebContext;
+
+import java.util.function.Function;
+
+/**
+ * A factory to define if an OAuth login process has been cancelled.
+ *
+ * @author Jerome LELEU
+ * @since 4.0.0
+ */
+public interface HasBeenCancelledFactory extends Function<WebContext, Boolean> {
+}

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuthConfiguration.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/config/OAuthConfiguration.java
@@ -9,8 +9,6 @@ import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.InitializableObject;
 import org.pac4j.oauth.profile.definition.OAuthProfileDefinition;
 
-import java.util.function.Function;
-
 /**
  * The base OAuth configuration.
  *
@@ -33,7 +31,7 @@ public abstract class OAuthConfiguration<S extends OAuthService, T extends Token
 
     protected String scope;
 
-    protected Function<WebContext, Boolean> hasBeenCancelledFactory = ctx -> false;
+    protected HasBeenCancelledFactory hasBeenCancelledFactory = ctx -> false;
 
     protected OAuthProfileDefinition profileDefinition;
 
@@ -89,11 +87,11 @@ public abstract class OAuthConfiguration<S extends OAuthService, T extends Token
         this.scope = scope;
     }
 
-    public Function<WebContext, Boolean> getHasBeenCancelledFactory() {
+    public HasBeenCancelledFactory getHasBeenCancelledFactory() {
         return hasBeenCancelledFactory;
     }
 
-    public void setHasBeenCancelledFactory(final Function<WebContext, Boolean> hasBeenCancelledFactory) {
+    public void setHasBeenCancelledFactory(final HasBeenCancelledFactory hasBeenCancelledFactory) {
         this.hasBeenCancelledFactory = hasBeenCancelledFactory;
     }
 

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/definition/OAuth10ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/definition/OAuth10ProfileDefinition.java
@@ -1,10 +1,9 @@
 package org.pac4j.oauth.profile.definition;
 
 import com.github.scribejava.core.model.OAuth1Token;
+import org.pac4j.core.profile.factory.ProfileFactory;
 import org.pac4j.oauth.config.OAuth10Configuration;
 import org.pac4j.oauth.profile.OAuth10Profile;
-
-import java.util.function.Function;
 
 /**
  * OAuth 1.0 profile definition.
@@ -19,7 +18,7 @@ public abstract class OAuth10ProfileDefinition<P extends OAuth10Profile>
         super();
     }
 
-    public OAuth10ProfileDefinition(final Function<Object[], P> profileFactory) {
+    public OAuth10ProfileDefinition(final ProfileFactory<P> profileFactory) {
         super(profileFactory);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/definition/OAuth20ProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/definition/OAuth20ProfileDefinition.java
@@ -1,10 +1,9 @@
 package org.pac4j.oauth.profile.definition;
 
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import org.pac4j.core.profile.factory.ProfileFactory;
 import org.pac4j.oauth.config.OAuth20Configuration;
 import org.pac4j.oauth.profile.OAuth20Profile;
-
-import java.util.function.Function;
 
 /**
  * OAuth 2.0 profile definition.
@@ -19,7 +18,7 @@ public abstract class OAuth20ProfileDefinition<P extends OAuth20Profile, C exten
         super();
     }
 
-    public OAuth20ProfileDefinition(final Function<Object[], P> profileFactory) {
+    public OAuth20ProfileDefinition(final ProfileFactory<P> profileFactory) {
         super(profileFactory);
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/definition/OAuthProfileDefinition.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/definition/OAuthProfileDefinition.java
@@ -4,9 +4,9 @@ import com.github.scribejava.core.model.Token;
 import com.github.scribejava.core.model.Verb;
 import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.profile.factory.ProfileFactory;
 import org.pac4j.oauth.config.OAuthConfiguration;
 
-import java.util.function.Function;
 import org.pac4j.core.exception.TechnicalException;
 
 /**
@@ -22,7 +22,7 @@ public abstract class OAuthProfileDefinition<P extends CommonProfile, T extends 
         super();
     }
 
-    public OAuthProfileDefinition(final Function<Object[], P> profileFactory) {
+    public OAuthProfileDefinition(final ProfileFactory<P> profileFactory) {
         super(profileFactory);
     }
 
@@ -51,10 +51,10 @@ public abstract class OAuthProfileDefinition<P extends CommonProfile, T extends 
      * @return the returned profile
      */
     public abstract P extractUserProfile(String body);
-    
+
     /**
      * Throws a {@link TechnicalException} to indicate that user profile extraction has failed.
-     * 
+     *
      * @param body the request body that the user profile should be have been extracted from
      * @param missingNode the name of a JSON node that was found missing. may be omitted
      */
@@ -62,25 +62,25 @@ public abstract class OAuthProfileDefinition<P extends CommonProfile, T extends 
         logger.error("Unable to extract user profile as no JSON node '{}' was found in body: {}", missingNode, body);
         throw new TechnicalException("No JSON node '" + missingNode + "' to extract user profile from");
     }
-    
+
     /**
      * Throws a {@link TechnicalException} to indicate that user profile extraction has failed.
-     * 
+     *
      * @param body the request body that the user profile should have been extracted from
      */
     protected void raiseProfileExtractionJsonError(String body) {
         logger.error("Unable to extract user profile as no JSON node was found in body: {}", body);
         throw new TechnicalException("No JSON node to extract user profile from");
     }
-    
+
     /**
      * Throws a {@link TechnicalException} to indicate that user profile extraction has failed.
-     * 
+     *
      * @param body the request body that the user profile should have been extracted from
      */
     protected void raiseProfileExtractionError(String body) {
         logger.error("Unable to extract user profile from body: {}", body);
         throw new TechnicalException("Unable to extract user profile");
     }
-    
+
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfileDefinition.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfileDefinition.java
@@ -5,11 +5,11 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
+import org.pac4j.core.profile.factory.ProfileFactory;
 import org.pac4j.core.profile.jwt.JwtClaims;
 import org.pac4j.oidc.profile.converter.OidcLongTimeConverter;
 
 import java.util.Arrays;
-import java.util.function.Function;
 
 /**
  * This class defines the attributes of the OpenID Connect profile: http://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
@@ -82,7 +82,7 @@ public class OidcProfileDefinition<P extends OidcProfile> extends CommonProfileD
         secondary(TOKEN_EXPIRATION_ADVANCE, Converters.INTEGER);
     }
 
-    public OidcProfileDefinition(final Function<Object[], P> profileFactory) {
+    public OidcProfileDefinition(final ProfileFactory<P> profileFactory) {
         this();
         setProfileFactory(profileFactory);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<commons-codec.version>1.14</commons-codec.version>
 		<commons-io.version>2.6</commons-io.version>
 		<guava.version>28.2-jre</guava.version>
-		<nimbus-jose-jwt.version>8.5</nimbus-jose-jwt.version>
+		<nimbus-jose-jwt.version>8.5.1</nimbus-jose-jwt.version>
 		<spring.version>5.2.3.RELEASE</spring.version>
 		<spring.security.version>5.2.1.RELEASE</spring.security.version>
 		<shiro.version>1.5.0</shiro.version>


### PR DESCRIPTION
To always have the same behavior across all ways to retrieve a component:
1) first take the provided component if not null
2) or use the one from the configuration
3) or fallback to a default one.

This PR also introduces some factories to avoid direct usage of the `Function` or `BiFunction` interfaces.
