### PR TITLE
Remove unused dependency to cryptacular

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -21,7 +21,6 @@
         <!-- The dependency to commons-collections 3.2.2 is explicitly made to replace 3.2.1 (vulnerable) used by
         velocity 1.7. It can be removed as soon as velocity 1.7 is not used anymore-->
         <commons-collections.version>20040616</commons-collections.version>
-        <cryptacular.version>1.2.4</cryptacular.version>
         <xalan.version>2.7.2</xalan.version>
         <!-- This version is used to override the version xmlsectool depends on. it should be compatible -->
         <httpcore.version>4.4.13</httpcore.version>
@@ -114,17 +113,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.cryptacular</groupId>
-            <artifactId>cryptacular</artifactId>
-            <version>${cryptacular.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                    <groupId>org.bouncycastle</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>net.shibboleth.tool</groupId>


### PR DESCRIPTION
This dependency appears unused: It was unused when it was added in https://github.com/pac4j/pac4j/commit/6178f28136b55e4fe78ef749621276db993bf4d1, and seems to have remained unused since, despite being updated several times. `mvn clean verify` passes with this change. No relevant looking mentions on users or developers mailing list either.

I discovered this when I investigated a dependency scanner's complaints about an outdated transitive dependency, and thought I can submit what I used it to confirm this is unused.

I'm not subscribing to a new mailing list of a library I'm not even using to discuss this first, sorry. Please close this PR if that is unacceptable.