### PR TITLE
Avoid casting to LinkedHashMap for profile manager

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java
@@ -115,14 +115,10 @@ public class ProfileManager<U extends UserProfile> {
     protected LinkedHashMap<String, U> retrieveAll(final boolean readFromSession) {
         final LinkedHashMap<String, U> profiles = new LinkedHashMap<>();
         this.context.getRequestAttribute(Pac4jConstants.USER_PROFILES)
-            .ifPresent(requestAttribute -> {
-                profiles.putAll((LinkedHashMap<String, U>) requestAttribute);
-            });
+            .ifPresent(requestAttribute -> profiles.putAll((Map<String, U>) requestAttribute));
         if (readFromSession) {
             this.sessionStore.get(this.context, Pac4jConstants.USER_PROFILES)
-                .ifPresent(sessionAttribute -> {
-                    profiles.putAll((LinkedHashMap<String, U>) sessionAttribute);
-                });
+                .ifPresent(sessionAttribute -> profiles.putAll((Map<String, U>) sessionAttribute));
         }
 
         removeOrRenewExpiredProfiles(profiles, readFromSession);

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileManagerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/ProfileManagerTests.java
@@ -9,7 +9,9 @@ import org.pac4j.core.util.Pac4jConstants;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.*;
@@ -35,7 +37,7 @@ public final class ProfileManagerTests {
 
     private ProfileManager profileManager;
 
-    private LinkedHashMap<String, CommonProfile> profiles;
+    private Map<String, CommonProfile> profiles;
 
     @Before
     public void setUp() {
@@ -50,7 +52,7 @@ public final class ProfileManagerTests {
         profile3.setClientName(CLIENT1);
         context = MockWebContext.create();
         profileManager = new ProfileManager(context);
-        profiles = new LinkedHashMap<>();
+        profiles = new TreeMap<>();
     }
 
     @Test


### PR DESCRIPTION
Removes the expectation that profiles stored in session/request must be managed via a LinkedHashMap. Instead, any `Map` should be OK and it should be up to the caller to decide what `Map` type should be used.