### PR TITLE
Samllogout #1570

### DIFF
--- a/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiver.java
+++ b/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiver.java
@@ -1,7 +1,10 @@
 package org.pac4j.saml.logout.impl;
 
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.ContextHelper;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
 import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
@@ -9,6 +12,8 @@ import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.transport.Pac4jHTTPPostDecoder;
 import org.pac4j.saml.transport.Pac4jHTTPRedirectDeflateDecoder;
 import org.pac4j.saml.util.Configuration;
+
+import java.util.Optional;
 
 /**
  * Receives the SAML2 logout messages.
@@ -55,7 +60,13 @@ public class SAML2LogoutMessageReceiver extends AbstractSAML2MessageReceiver {
     }
 
     @Override
+    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+        return Optional.empty();
+    }
+
+    @Override
     protected String getProfileUri() {
         return SAML2_SLO_PROFILE_URI;
     }
+
 }

--- a/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -5,7 +5,7 @@ import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
 import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.StatusResponseType;
-import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.pac4j.core.context.WebContext;
@@ -15,6 +15,8 @@ import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2MessageReceiver;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
+
+import java.util.Optional;
 
 /**
  * Receives the SAML2 messages.
@@ -42,6 +44,10 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
 
         final SAML2MessageContext decodedCtx = new SAML2MessageContext(decoder.getMessageContext());
         final SAMLObject message = decoder.getMessageContext().getMessage();
+        if (message == null) {
+            throw new SAMLException("Response from the context cannot be null");
+        }
+
         decodedCtx.setMessage(message);
         context.setMessage(message);
         decodedCtx.setSAMLMessageStore(context.getSAMLMessageStore());
@@ -57,12 +63,9 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
         decodedCtx.getSAMLBindingContext().setRelayState(relayState);
         context.getSAMLBindingContext().setRelayState(relayState);
 
-        if (decodedCtx.getMessage() == null) {
-            throw new SAMLException("Response from the context cannot be null");
-        } else if (decodedCtx.getMessage() instanceof StatusResponseType) {
+        if (decodedCtx.getMessage() instanceof StatusResponseType) {
             final StatusResponseType response = (StatusResponseType) decodedCtx.getMessage();
-            final AssertionConsumerService acsService = context.getSPAssertionConsumerService(response);
-            decodedCtx.getSAMLEndpointContext().setEndpoint(acsService);
+            getEndpoint(context, response).ifPresent(e -> decodedCtx.getSAMLEndpointContext().setEndpoint(e));
         }
 
         final EntityDescriptor metadata = context.getSAMLPeerMetadataContext().getEntityDescriptor();
@@ -87,6 +90,8 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
 
         return this.validator.validate(decodedCtx);
     }
+
+    protected abstract Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response);
 
     protected abstract AbstractPac4jDecoder getDecoder(WebContext webContext);
 

--- a/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
+++ b/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
@@ -1,6 +1,9 @@
 package org.pac4j.saml.sso.artifact;
 
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
@@ -8,9 +11,11 @@ import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.util.Configuration;
 
+import java.util.Optional;
+
 /**
  * A message receiver which fetches the actual artifact using SOAP.
- * 
+ *
  * @since 3.8.0
  */
 public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageReceiver {
@@ -43,6 +48,13 @@ public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageRec
             throw new SAMLException("Error decoding SAML message", e);
         }
         return decoder;
+    }
+
+    @Override
+    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+        return Optional.of(
+            context.getSPAssertionConsumerService(response)
+        );
     }
 
     @Override

--- a/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
+++ b/pac4j-saml-opensamlv3/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
@@ -1,12 +1,17 @@
 package org.pac4j.saml.sso.impl;
 
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
 import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.transport.Pac4jHTTPPostDecoder;
 import org.pac4j.saml.util.Configuration;
+
+import java.util.Optional;
 
 /**
  * @author Misagh Moayyed
@@ -31,6 +36,13 @@ public class SAML2WebSSOMessageReceiver extends AbstractSAML2MessageReceiver {
             throw new SAMLException("Error decoding SAML message", e);
         }
         return decoder;
+    }
+
+    @Override
+    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+        return Optional.of(
+            context.getSPAssertionConsumerService(response)
+        );
     }
 
     @Override

--- a/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -41,11 +41,11 @@ public class SAML2LogoutMessageReceiverTest {
                     "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
                     "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
                     "IssueInstant=\"%s\" Destination=\"http://sp.example.com/demo1/logout\" " +
-                    "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
-                    "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
-                    "  <samlp:Status>\n" +
-                    "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
-                    "  </samlp:Status>\n" +
+                    "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
+                    "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
+                    "  <samlp:Status>%n" +
+                    "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>%n" +
+                    "  </samlp:Status>%n" +
                     "</samlp:LogoutResponse>",
                 LocalDateTime.now(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss'Z'"))
             )

--- a/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -1,20 +1,32 @@
 package org.pac4j.saml.logout.impl;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
-import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
-import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.metadata.resolver.ChainingMetadataResolver;
+import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.opensaml.saml.saml2.metadata.impl.EntityDescriptorBuilder;
 import org.opensaml.saml.saml2.metadata.impl.SPSSODescriptorBuilder;
+import org.opensaml.saml.saml2.metadata.impl.SingleLogoutServiceBuilder;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.MockWebContext;
-import org.pac4j.core.credentials.MockCredentials;
+import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.crypto.ExplicitSignatureTrustEngineProvider;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
+import org.pac4j.saml.replay.ReplayCacheProvider;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class SAML2LogoutMessageReceiverTest {
@@ -24,48 +36,54 @@ public class SAML2LogoutMessageReceiverTest {
         MockWebContext webContext = MockWebContext.create();
         webContext.setRequestMethod(HttpConstants.HTTP_METHOD.POST.name());
         webContext.setRequestContent(
-            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
-                "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
-                "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
-                "IssueInstant=\"2014-07-18T01:13:06Z\" Destination=\"http://sp.example.com/demo1/index.php?acs\" " +
-                "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
-                "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
-                "  <samlp:Status>\n" +
-                "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
-                "  </samlp:Status>\n" +
-                "</samlp:LogoutResponse>");
-
-
-        AssertionConsumerService acs = mock(AssertionConsumerService.class);
-
-        SPSSODescriptor acsDescriptor = new SPSSODescriptorBuilder().buildObject();
-        acsDescriptor.getAssertionConsumerServices().add(acs);
+            String.format(
+                "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+                    "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+                    "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+                    "IssueInstant=\"%s\" Destination=\"http://sp.example.com/demo1/logout\" " +
+                    "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
+                    "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
+                    "  <samlp:Status>\n" +
+                    "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
+                    "  </samlp:Status>\n" +
+                    "</samlp:LogoutResponse>",
+                LocalDateTime.now(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss'Z'"))
+            )
+        );
 
         SAML2MessageContext context = new SAML2MessageContext();
 
-        SAMLMetadataContext metadataContext = context
-            .getSAMLSelfEntityContext()
-            .getSubcontext(SAMLMetadataContext.class, true);
-        metadataContext.setRoleDescriptor(acsDescriptor);
-
-        EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
-        when(entityDescriptor.getEntityID()).thenReturn("idp.example.com");
-
+        EntityDescriptor entityDescriptor = new EntityDescriptorBuilder().buildObject();
         context.getSAMLPeerMetadataContext().setEntityDescriptor(entityDescriptor);
         context.setWebContext(webContext);
 
-        SAML2ResponseValidator validator = mock(SAML2ResponseValidator.class);
-        when(validator.validate(any())).thenReturn(new MockCredentials());
+        SPSSODescriptor spDescriptor = new SPSSODescriptorBuilder().buildObject();
+        SingleLogoutService logoutService = new SingleLogoutServiceBuilder().buildObject();
+        logoutService.setLocation("http://sp.example.com/demo1/logout");
+        spDescriptor.getSingleLogoutServices().add(logoutService);
+        context.getSAMLSelfMetadataContext().setRoleDescriptor(spDescriptor);
+
+        ChainingMetadataResolver metadataResolver = new ChainingMetadataResolver();
+        SAML2SignatureTrustEngineProvider engine = new ExplicitSignatureTrustEngineProvider(metadataResolver);
+
+        SAML2ResponseValidator validator = new SAML2LogoutValidator(
+            engine,
+            mock(Decrypter.class),
+            mock(LogoutHandler.class),
+            "/logoutUrl",
+            mock(ReplayCacheProvider.class)
+        );
 
         SAML2LogoutMessageReceiver unit = new SAML2LogoutMessageReceiver(validator);
         try {
             unit.receiveMessage(context);
-            assertTrue("SAML2LogoutMessageReceiver processed the logout message successfully", true);
+            fail("Should have thrown a FoundAction");
         } catch (SAMLException e) {
             e.printStackTrace();
             fail("Should not have thrown a SAML Exception");
+        } catch (FoundAction e) {
+            assertTrue("SAML2LogoutMessageReceiver processed the logout message successfully", true);
+            MatcherAssert.assertThat(e.getLocation(), is("/logoutUrl"));
         }
-
     }
-
 }

--- a/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -1,0 +1,71 @@
+package org.pac4j.saml.logout.impl;
+
+import org.junit.Test;
+import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.impl.SPSSODescriptorBuilder;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.credentials.MockCredentials;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.profile.api.SAML2ResponseValidator;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class SAML2LogoutMessageReceiverTest {
+
+    @Test
+    public void shouldAcceptLogoutResponse() {
+        MockWebContext webContext = MockWebContext.create();
+        webContext.setRequestMethod(HttpConstants.HTTP_METHOD.POST.name());
+        webContext.setRequestContent(
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+                "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+                "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+                "IssueInstant=\"2014-07-18T01:13:06Z\" Destination=\"http://sp.example.com/demo1/index.php?acs\" " +
+                "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
+                "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
+                "  <samlp:Status>\n" +
+                "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
+                "  </samlp:Status>\n" +
+                "</samlp:LogoutResponse>");
+
+
+        AssertionConsumerService acs = mock(AssertionConsumerService.class);
+
+        SPSSODescriptor acsDescriptor = new SPSSODescriptorBuilder().buildObject();
+        acsDescriptor.getAssertionConsumerServices().add(acs);
+
+        SAML2MessageContext context = new SAML2MessageContext();
+
+        SAMLMetadataContext metadataContext = context
+            .getSAMLSelfEntityContext()
+            .getSubcontext(SAMLMetadataContext.class, true);
+        metadataContext.setRoleDescriptor(acsDescriptor);
+
+        EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
+        when(entityDescriptor.getEntityID()).thenReturn("idp.example.com");
+
+        context.getSAMLPeerMetadataContext().setEntityDescriptor(entityDescriptor);
+        context.setWebContext(webContext);
+
+        SAML2ResponseValidator validator = mock(SAML2ResponseValidator.class);
+        when(validator.validate(any())).thenReturn(new MockCredentials());
+
+        SAML2LogoutMessageReceiver unit = new SAML2LogoutMessageReceiver(validator);
+        try {
+            unit.receiveMessage(context);
+            assertTrue("SAML2LogoutMessageReceiver processed the logout message successfully", true);
+        } catch (SAMLException e) {
+            e.printStackTrace();
+            fail("Should not have thrown a SAML Exception");
+        }
+
+    }
+
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiver.java
@@ -1,7 +1,10 @@
 package org.pac4j.saml.logout.impl;
 
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.ContextHelper;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
 import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
@@ -9,6 +12,8 @@ import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.transport.Pac4jHTTPPostDecoder;
 import org.pac4j.saml.transport.Pac4jHTTPRedirectDeflateDecoder;
 import org.pac4j.saml.util.Configuration;
+
+import java.util.Optional;
 
 /**
  * Receives the SAML2 logout messages.
@@ -52,6 +57,11 @@ public class SAML2LogoutMessageReceiver extends AbstractSAML2MessageReceiver {
             throw new SAMLException("Only GET or POST requests are accepted");
         }
         return decoder;
+    }
+
+    @Override
+    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+        return Optional.empty();
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
@@ -1,6 +1,9 @@
 package org.pac4j.saml.sso.artifact;
 
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
@@ -8,9 +11,11 @@ import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.util.Configuration;
 
+import java.util.Optional;
+
 /**
  * A message receiver which fetches the actual artifact using SOAP.
- * 
+ *
  * @since 3.8.0
  */
 public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageReceiver {
@@ -29,6 +34,13 @@ public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageRec
         this.idpMetadataResolver = idpMetadataResolver;
         this.spMetadataResolver = spMetadataResolver;
         this.soapPipelineProvider = soapPipelineProvider;
+    }
+
+    @Override
+    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+        return Optional.of(
+            context.getSPAssertionConsumerService(response)
+        );
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
@@ -1,12 +1,17 @@
 package org.pac4j.saml.sso.impl;
 
+import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
 import org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
 import org.pac4j.saml.transport.Pac4jHTTPPostDecoder;
 import org.pac4j.saml.util.Configuration;
+
+import java.util.Optional;
 
 /**
  * @author Misagh Moayyed
@@ -31,6 +36,13 @@ public class SAML2WebSSOMessageReceiver extends AbstractSAML2MessageReceiver {
             throw new SAMLException("Error decoding SAML message", e);
         }
         return decoder;
+    }
+
+    @Override
+    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+        return Optional.of(
+            context.getSPAssertionConsumerService(response)
+        );
     }
 
     @Override

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -41,11 +41,11 @@ public class SAML2LogoutMessageReceiverTest {
                     "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
                     "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
                     "IssueInstant=\"%s\" Destination=\"http://sp.example.com/demo1/logout\" " +
-                    "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
-                    "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
-                    "  <samlp:Status>\n" +
-                    "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
-                    "  </samlp:Status>\n" +
+                    "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
+                    "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
+                    "  <samlp:Status>%n" +
+                    "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>%n" +
+                    "  </samlp:Status>%n" +
                     "</samlp:LogoutResponse>",
                 LocalDateTime.now(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss'Z'"))
             )

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -1,0 +1,71 @@
+package org.pac4j.saml.logout.impl;
+
+import org.junit.Test;
+import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
+import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.impl.SPSSODescriptorBuilder;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.credentials.MockCredentials;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.profile.api.SAML2ResponseValidator;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class SAML2LogoutMessageReceiverTest {
+
+    @Test
+    public void shouldAcceptLogoutResponse() {
+        MockWebContext webContext = MockWebContext.create();
+        webContext.setRequestMethod(HttpConstants.HTTP_METHOD.POST.name());
+        webContext.setRequestContent(
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+                "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+                "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+                "IssueInstant=\"2014-07-18T01:13:06Z\" Destination=\"http://sp.example.com/demo1/index.php?acs\" " +
+                "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
+                "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
+                "  <samlp:Status>\n" +
+                "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
+                "  </samlp:Status>\n" +
+                "</samlp:LogoutResponse>");
+
+
+        AssertionConsumerService acs = mock(AssertionConsumerService.class);
+
+        SPSSODescriptor acsDescriptor = new SPSSODescriptorBuilder().buildObject();
+        acsDescriptor.getAssertionConsumerServices().add(acs);
+
+        SAML2MessageContext context = new SAML2MessageContext();
+
+        SAMLMetadataContext metadataContext = context
+            .getSAMLSelfEntityContext()
+            .getSubcontext(SAMLMetadataContext.class, true);
+        metadataContext.setRoleDescriptor(acsDescriptor);
+
+        EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
+        when(entityDescriptor.getEntityID()).thenReturn("idp.example.com");
+
+        context.getSAMLPeerMetadataContext().setEntityDescriptor(entityDescriptor);
+        context.setWebContext(webContext);
+
+        SAML2ResponseValidator validator = mock(SAML2ResponseValidator.class);
+        when(validator.validate(any())).thenReturn(new MockCredentials());
+
+        SAML2LogoutMessageReceiver unit = new SAML2LogoutMessageReceiver(validator);
+        try {
+            unit.receiveMessage(context);
+            assertTrue("SAML2LogoutMessageReceiver processed the logout message successfully", true);
+        } catch (SAMLException e) {
+            e.printStackTrace();
+            fail("Should not have thrown a SAML Exception");
+        }
+
+    }
+
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -1,20 +1,32 @@
 package org.pac4j.saml.logout.impl;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Test;
-import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
-import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
+import org.opensaml.saml.metadata.resolver.ChainingMetadataResolver;
+import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.opensaml.saml.saml2.metadata.impl.EntityDescriptorBuilder;
 import org.opensaml.saml.saml2.metadata.impl.SPSSODescriptorBuilder;
+import org.opensaml.saml.saml2.metadata.impl.SingleLogoutServiceBuilder;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.MockWebContext;
-import org.pac4j.core.credentials.MockCredentials;
+import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.crypto.ExplicitSignatureTrustEngineProvider;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
+import org.pac4j.saml.replay.ReplayCacheProvider;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class SAML2LogoutMessageReceiverTest {
@@ -24,48 +36,55 @@ public class SAML2LogoutMessageReceiverTest {
         MockWebContext webContext = MockWebContext.create();
         webContext.setRequestMethod(HttpConstants.HTTP_METHOD.POST.name());
         webContext.setRequestContent(
-            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
-                "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
-                "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
-                "IssueInstant=\"2014-07-18T01:13:06Z\" Destination=\"http://sp.example.com/demo1/index.php?acs\" " +
-                "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
-                "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
-                "  <samlp:Status>\n" +
-                "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
-                "  </samlp:Status>\n" +
-                "</samlp:LogoutResponse>");
-
-
-        AssertionConsumerService acs = mock(AssertionConsumerService.class);
-
-        SPSSODescriptor acsDescriptor = new SPSSODescriptorBuilder().buildObject();
-        acsDescriptor.getAssertionConsumerServices().add(acs);
+            String.format(
+                "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+                    "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+                    "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+                    "IssueInstant=\"%s\" Destination=\"http://sp.example.com/demo1/logout\" " +
+                    "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">\n" +
+                    "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>\n" +
+                    "  <samlp:Status>\n" +
+                    "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>\n" +
+                    "  </samlp:Status>\n" +
+                    "</samlp:LogoutResponse>",
+                LocalDateTime.now(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss'Z'"))
+            )
+        );
 
         SAML2MessageContext context = new SAML2MessageContext();
 
-        SAMLMetadataContext metadataContext = context
-            .getSAMLSelfEntityContext()
-            .getSubcontext(SAMLMetadataContext.class, true);
-        metadataContext.setRoleDescriptor(acsDescriptor);
-
-        EntityDescriptor entityDescriptor = mock(EntityDescriptor.class);
-        when(entityDescriptor.getEntityID()).thenReturn("idp.example.com");
-
+        EntityDescriptor entityDescriptor = new EntityDescriptorBuilder().buildObject();
         context.getSAMLPeerMetadataContext().setEntityDescriptor(entityDescriptor);
         context.setWebContext(webContext);
 
-        SAML2ResponseValidator validator = mock(SAML2ResponseValidator.class);
-        when(validator.validate(any())).thenReturn(new MockCredentials());
+        SPSSODescriptor spDescriptor = new SPSSODescriptorBuilder().buildObject();
+        SingleLogoutService logoutService = new SingleLogoutServiceBuilder().buildObject();
+        logoutService.setLocation("http://sp.example.com/demo1/logout");
+        spDescriptor.getSingleLogoutServices().add(logoutService);
+        context.getSAMLSelfMetadataContext().setRoleDescriptor(spDescriptor);
+
+        ChainingMetadataResolver metadataResolver = new ChainingMetadataResolver();
+        SAML2SignatureTrustEngineProvider engine = new ExplicitSignatureTrustEngineProvider(metadataResolver);
+
+        SAML2ResponseValidator validator = new SAML2LogoutValidator(
+            engine,
+            mock(Decrypter.class),
+            mock(LogoutHandler.class),
+            "/logoutUrl",
+            mock(ReplayCacheProvider.class)
+        );
 
         SAML2LogoutMessageReceiver unit = new SAML2LogoutMessageReceiver(validator);
         try {
             unit.receiveMessage(context);
-            assertTrue("SAML2LogoutMessageReceiver processed the logout message successfully", true);
+            fail("Should have thrown a FoundAction");
         } catch (SAMLException e) {
             e.printStackTrace();
             fail("Should not have thrown a SAML Exception");
+        } catch (FoundAction e) {
+            assertTrue("SAML2LogoutMessageReceiver processed the logout message successfully", true);
+            MatcherAssert.assertThat(e.getLocation(), is("/logoutUrl"));
         }
-
     }
 
 }


### PR DESCRIPTION
Further to the class cast exception (issue #1570) in AbstractSAML2MessageReciever, the abstract receiver is still attempting to resolve an endpoint as if it were dealing with a request to an ACS.

This causes an exception where the URL of a logout request is not found in the list of configured ACS endpoints.

`Caused by: org.pac4j.saml.exceptions.SAMLException: Assertion consumer service with destination http://test.sp:9000/callback?client_name=SAML2Client&logoutendpoint=true could not be found for spDescriptor org.opensaml.saml.saml2.metadata.impl.SPSSODescriptorImpl@433f19c9
	at org.pac4j.saml.context.SAML2MessageContext.getSPAssertionConsumerService(SAML2MessageContext.java:126)
	at org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver.receiveMessage(AbstractSAML2MessageReceiver.java:64)
	at org.pac4j.saml.logout.impl.SAML2LogoutProfileHandler.receive(SAML2LogoutProfileHandler.java:36)
	at org.pac4j.saml.credentials.extractor.SAML2CredentialsExtractor.extract(SAML2CredentialsExtractor.java:59)
	at org.pac4j.core.client.BaseClient.retrieveCredentials(BaseClient.java:66)
	at org.pac4j.core.client.IndirectClient.getCredentials(IndirectClient.java:143)
	at org.pac4j.core.engine.DefaultCallbackLogic.perform(DefaultCallbackLogic.java:85)
	at org.pac4j.play.CallbackController.lambda$callback$0(CallbackController.java:54)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	... 8 common frames omitted`
