### PR TITLE
Implemented capability to use custom State validation for CSRF mitigation

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -25,6 +25,8 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.openid.connect.sdk.OIDCResponseTypeValue;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import org.pac4j.oidc.state.validator.SessionStoreStateValidator;
+import org.pac4j.oidc.state.validator.StateValidator;
 import org.pac4j.oidc.profile.creator.TokenValidator;
 
 /**
@@ -45,14 +47,14 @@ public class OidcConfiguration extends BaseClientConfiguration {
     public static final String NONCE = "nonce";
 
     public static final List<ResponseType> AUTHORIZATION_CODE_FLOWS = Collections
-            .unmodifiableList(Arrays.asList(new ResponseType(ResponseType.Value.CODE)));
+        .unmodifiableList(Arrays.asList(new ResponseType(ResponseType.Value.CODE)));
     public static final List<ResponseType> IMPLICIT_FLOWS = Collections
-            .unmodifiableList(Arrays.asList(new ResponseType(OIDCResponseTypeValue.ID_TOKEN),
-                    new ResponseType(OIDCResponseTypeValue.ID_TOKEN, ResponseType.Value.TOKEN)));
+        .unmodifiableList(Arrays.asList(new ResponseType(OIDCResponseTypeValue.ID_TOKEN),
+            new ResponseType(OIDCResponseTypeValue.ID_TOKEN, ResponseType.Value.TOKEN)));
     public static final List<ResponseType> HYBRID_CODE_FLOWS = Collections.unmodifiableList(Arrays.asList(
-            new ResponseType(ResponseType.Value.CODE, OIDCResponseTypeValue.ID_TOKEN),
-            new ResponseType(ResponseType.Value.CODE, ResponseType.Value.TOKEN),
-            new ResponseType(ResponseType.Value.CODE, OIDCResponseTypeValue.ID_TOKEN, ResponseType.Value.TOKEN)));
+        new ResponseType(ResponseType.Value.CODE, OIDCResponseTypeValue.ID_TOKEN),
+        new ResponseType(ResponseType.Value.CODE, ResponseType.Value.TOKEN),
+        new ResponseType(ResponseType.Value.CODE, OIDCResponseTypeValue.ID_TOKEN, ResponseType.Value.TOKEN)));
 
     /* default max clock skew */
     public static final int DEFAULT_MAX_CLOCK_SKEW = 30;
@@ -108,6 +110,8 @@ public class OidcConfiguration extends BaseClientConfiguration {
 
     private ValueGenerator stateGenerator = new RandomValueGenerator();
 
+    private StateValidator stateValidator = new SessionStoreStateValidator();
+
     /* checks if sessions expire with token expiration (see also `tokenExpirationAdvance`) */
     private boolean expireSessionWithToken = false;
 
@@ -143,7 +147,7 @@ public class OidcConfiguration extends BaseClientConfiguration {
             try {
                 // Download OIDC metadata
                 this.setProviderMetadata(OIDCProviderMetadata.parse(getResourceRetriever().retrieveResource(
-                        new URL(this.getDiscoveryURI())).getContent()));
+                    new URL(this.getDiscoveryURI())).getContent()));
             } catch (final IOException | ParseException e) {
                 throw new TechnicalException(e);
             }
@@ -368,6 +372,15 @@ public class OidcConfiguration extends BaseClientConfiguration {
     public void setStateGenerator(final ValueGenerator stateGenerator) {
         CommonHelper.assertNotNull("stateGenerator", stateGenerator);
         this.stateGenerator = stateGenerator;
+    }
+
+    public StateValidator getStateValidator() {
+        return stateValidator;
+    }
+
+    public void setStateValidator(StateValidator stateValidator, ValueGenerator stateGenerator) {
+        CommonHelper.assertNotNull("stateValidator", stateValidator);
+        this.stateValidator = stateValidator;
     }
 
     public LogoutHandler findLogoutHandler() {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -378,7 +378,7 @@ public class OidcConfiguration extends BaseClientConfiguration {
         return stateValidator;
     }
 
-    public void setStateValidator(StateValidator stateValidator, ValueGenerator stateGenerator) {
+    public void setStateValidator(StateValidator stateValidator) {
         CommonHelper.assertNotNull("stateValidator", stateValidator);
         this.stateValidator = stateValidator;
     }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/state/validator/SessionStoreStateValidator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/state/validator/SessionStoreStateValidator.java
@@ -1,0 +1,28 @@
+package org.pac4j.oidc.state.validator;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.oidc.client.OidcClient;
+
+/**
+ * SessionStoreStateValidator
+ *
+ * Equality checks the {@link State} against the {@link State} stored in the {@link org.pac4j.core.context.session.SessionStore}
+ *
+ * @author Martin Hansen
+ * @since 4.0.3
+ */
+public class SessionStoreStateValidator implements StateValidator {
+
+    @Override
+    public void validate(State state, OidcClient client, WebContext webContext) {
+        if (state == null) {
+            throw new TechnicalException("Missing state parameter");
+        }
+        if (!state.equals(webContext.getSessionStore().get(webContext, client.getStateSessionAttributeName()).orElse(null))) {
+            throw new TechnicalException("State parameter is different from the one sent in authentication request. "
+                + "Session expired or possible threat of cross-site request forgery");
+        }
+    }
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/state/validator/StateValidator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/state/validator/StateValidator.java
@@ -1,0 +1,16 @@
+package org.pac4j.oidc.state.validator;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.oidc.client.OidcClient;
+
+/**
+ * StateValidator validates the {@link State}, such as for CSRF mitigation
+ *
+ * @author Martin Hansen
+ * @since 4.0.3
+ */
+public interface StateValidator {
+
+    void validate(State state, OidcClient client, WebContext webContext);
+}

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/validator/state/SessionStoreStateValidatorTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/validator/state/SessionStoreStateValidatorTest.java
@@ -1,0 +1,74 @@
+package org.pac4j.oidc.validator.state;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.Test;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.state.validator.SessionStoreStateValidator;
+import org.pac4j.oidc.state.validator.StateValidator;
+
+import static org.junit.Assert.fail;
+
+/**
+ * General test cases for {@link SessionStoreStateValidator}.
+ *
+ * @author Martin Hansen
+ * @since  4.0.3
+ */
+public final class SessionStoreStateValidatorTest implements TestsConstants {
+
+    private final OidcClient<OidcConfiguration> client = new OidcClient<>();
+
+    @Test
+    public void testValidState() {
+        final State state = new State();
+        final MockWebContext context = MockWebContext.create();
+
+        context.getSessionStore().set(context, client.getStateSessionAttributeName(), state);
+
+        final StateValidator target = new SessionStoreStateValidator();
+
+        target.validate(state, client, context);
+    }
+
+    @Test(expected = TechnicalException.class)
+    public void testNullState() {
+        final State state = null;
+        final MockWebContext context = MockWebContext.create();
+
+        final StateValidator target = new SessionStoreStateValidator();
+
+        target.validate(state, client, context);
+
+        fail();
+    }
+
+    @Test(expected = TechnicalException.class)
+    public void testStateNotInSessionStore() {
+        final State state = new State();
+        final MockWebContext context = MockWebContext.create();
+
+        final StateValidator target = new SessionStoreStateValidator();
+
+        target.validate(state, client, context);
+
+        fail();
+    }
+
+    @Test(expected = TechnicalException.class)
+    public void testStateInSessionStoreNotSame() {
+        final State state = new State();
+        final MockWebContext context = MockWebContext.create();
+
+        context.getSessionStore().set(context, client.getStateSessionAttributeName(), new State());
+
+        final StateValidator target = new SessionStoreStateValidator();
+
+        target.validate(state, client, context);
+
+        fail();
+    }
+}


### PR DESCRIPTION
Added a `StateValidator` interface, that we set in the `OidcConfiguration`, and the `OidcExtractor` will then use to validate the state of a callback request.

In a perfect world, i would have implemented it as a CSRF mitigation strategy instead. An interface that had both `generateState` and `validateState` methods, but i have chosen this simplistic extension to have backwards compatibility, in the least intrusive manner.

I can implement the other version if you'd like, but with some more if-cases in the `OidcRedirectionActionBuilder.addStateAndNonceParameters()` methods, without breaking compatibility. The code in general would seem more muddy in my opinion though, with that approach.

I have also thought about implementing a `enableCSRFMitigation(stateGenerator, stateValidator)` method in the `OidcConfiguration` class. A method that sets the `withState` property, and both `stateGenerator` and `stateValidator`, also you call if that's something we would like.

Example usage (with a HMAC stateless validator)
https://gist.github.com/martinhansen/3c5d64d0dbe1a610fdb9ec9113e04053

dev group thread:
https://groups.google.com/forum/?fromgroups#!topic/pac4j-dev/bIwjRNBe-eg