### PR TITLE
Allow a class with a byte array member to be serialized

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/JavaSerializationHelper.java
@@ -26,7 +26,7 @@ public class JavaSerializationHelper {
         trustedPackages = new HashSet<>();
         trustedPackages.addAll(Arrays.asList("java.", "javax.", "[Ljava.lang.String", "org.pac4j.", "[Lorg.pac4j.",
                 "com.github.scribejava.", "org.opensaml.", "com.nimbusds.", "[Lcom.nimbusds.", "org.joda.", "net.minidev.json.",
-                "org.bson.types.", "[Ljava.lang.StackTraceElement"));
+                "org.bson.types.", "[Ljava.lang.StackTraceElement", "[B"));
         trustedClasses = new HashSet<>();
     }
 


### PR DESCRIPTION
I did not add tests because, currently, the test suites does not have a test for every single trusted package so I assume you don't want that.

See: https://github.com/pac4j/play-pac4j/issues/340

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html