### PR TITLE
API changes for ldaptive v2.

### DIFF
--- a/pac4j-config/src/main/java/org/pac4j/config/builder/LdapAuthenticatorBuilder.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/builder/LdapAuthenticatorBuilder.java
@@ -1,6 +1,6 @@
 package org.pac4j.config.builder;
 
-import org.ldaptive.pool.PooledConnectionFactoryManager;
+import org.ldaptive.ConnectionFactoryManager;
 import org.ldaptive.sasl.Mechanism;
 import org.ldaptive.sasl.QualityOfProtection;
 import org.ldaptive.sasl.SecurityStrength;
@@ -33,9 +33,9 @@ public class LdapAuthenticatorBuilder extends AbstractBuilder {
                 final org.ldaptive.auth.Authenticator ldaptiveAuthenticator = LdaptiveAuthenticatorBuilder.getAuthenticator(ldapProp);
 
                 final LdapProfileService authenticator = new LdapProfileService(ldaptiveAuthenticator, getProperty(LDAP_ATTRIBUTES, i));
-                final PooledConnectionFactoryManager pooledConnectionFactoryManager =
-                    (PooledConnectionFactoryManager) ldaptiveAuthenticator.getAuthenticationHandler();
-                authenticator.setConnectionFactory(pooledConnectionFactoryManager.getConnectionFactory());
+                final ConnectionFactoryManager connectionFactoryManager =
+                    (ConnectionFactoryManager) ldaptiveAuthenticator.getAuthenticationHandler();
+                authenticator.setConnectionFactory(connectionFactoryManager.getConnectionFactory());
                 authenticator.setUsersDn(getProperty(LDAP_USERS_DN, i));
                 if (containsProperty(LDAP_PRINCIPAL_ATTRIBUTE_ID, i)) {
                     authenticator.setUsernameAttribute(getProperty(LDAP_PRINCIPAL_ATTRIBUTE_ID, i));
@@ -108,17 +108,11 @@ public class LdapAuthenticatorBuilder extends AbstractBuilder {
         if (containsProperty(LDAP_BLOCK_WAIT_TIME, i)) {
             ldapProp.setBlockWaitTime(getPropertyAsLong(LDAP_BLOCK_WAIT_TIME, i));
         }
-        if (containsProperty(LDAP_USE_SSL, i)) {
-            ldapProp.setUseSsl(getPropertyAsBoolean(LDAP_USE_SSL, i));
-        }
         if (containsProperty(LDAP_USE_START_TLS, i)) {
             ldapProp.setUseStartTls(getPropertyAsBoolean(LDAP_USE_START_TLS, i));
         }
         if (containsProperty(LDAP_CONNECT_TIMEOUT, i)) {
             ldapProp.setConnectTimeout(getPropertyAsLong(LDAP_CONNECT_TIMEOUT, i));
-        }
-        if (containsProperty(LDAP_PROVIDER_CLASS, i)) {
-            ldapProp.setProviderClass(getProperty(LDAP_PROVIDER_CLASS, i));
         }
         if (containsProperty(LDAP_ALLOW_MULTIPLE_DNS, i)) {
             ldapProp.setAllowMultipleDns(getPropertyAsBoolean(LDAP_ALLOW_MULTIPLE_DNS, i));

--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
@@ -118,10 +118,8 @@ public interface PropertiesConstants {
     String LDAP_PRUNE_PERIOD = "ldap.prunePeriod";
     String LDAP_BLOCK_WAIT_TIME = "ldap.blockWaitTime";
     String LDAP_URL = "ldap.url";
-    String LDAP_USE_SSL = "ldap.useSsl";
     String LDAP_USE_START_TLS = "ldap.useStartTls";
     String LDAP_CONNECT_TIMEOUT = "ldap.connectTimeout";
-    String LDAP_PROVIDER_CLASS = "ldap.providerClass";
     String LDAP_ALLOW_MULTIPLE_DNS = "ldap.allowMultipleDns";
     String LDAP_BIND_DN = "ldap.bindDn";
     String LDAP_BIND_CREDENTIAL = "ldap.bindCredential";

--- a/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
+++ b/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
@@ -2,7 +2,6 @@ package org.pac4j.config.client;
 
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import org.junit.Test;
-import org.ldaptive.provider.jndi.JndiProvider;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.pac4j.cas.client.CasClient;
 import org.pac4j.cas.config.CasProtocol;
@@ -91,13 +90,11 @@ public final class PropertiesConfigFactoryTests implements TestsConstants {
 
             properties.put(LDAP_TYPE, "direct");
             properties.put(LDAP_URL, "ldap://localhost:" + ldapServer.getPort());
-            properties.put(LDAP_USE_SSL, "false");
             properties.put(LDAP_USE_START_TLS, "false");
             properties.put(LDAP_DN_FORMAT, CN + "=%s," + BASE_PEOPLE_DN);
             properties.put(LDAP_USERS_DN, BASE_PEOPLE_DN);
             properties.put(LDAP_PRINCIPAL_ATTRIBUTE_ID, CN);
             properties.put(LDAP_ATTRIBUTES, SN + "," + ROLE);
-            properties.put(LDAP_PROVIDER_CLASS, JndiProvider.class.getName());
 
             properties.put(FORMCLIENT_LOGIN_URL.concat(".2"), PAC4J_BASE_URL);
             properties.put(FORMCLIENT_AUTHENTICATOR.concat(".2"), "ldap");

--- a/pac4j-ldap/pom.xml
+++ b/pac4j-ldap/pom.xml
@@ -13,7 +13,7 @@
     <name>pac4j for LDAP</name>
 
     <properties>
-        <ldaptive.version>1.2.4</ldaptive.version>
+        <ldaptive.version>2.0.0</ldaptive.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Note that ldaptive v2 requires Java 11 so you may not be able to make use of this anytime soon. But I didn't want to throw this away.

Notable changes:
 - try/finally paradigm no longer needed for operations
 - useSsl property no longer exists; use the LDAPS:// URL scheme
 - providers no longer exist

Let me know if you have any questions.

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html