### PR TITLE
Support custom params for callback url resolvers

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/client/CasClient.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/client/CasClient.java
@@ -4,6 +4,7 @@ import org.pac4j.cas.authorization.DefaultCasAuthorizationGenerator;
 import org.pac4j.cas.config.CasConfiguration;
 import org.pac4j.cas.credentials.authenticator.CasAuthenticator;
 import org.pac4j.cas.credentials.extractor.TicketAndLogoutRequestExtractor;
+import org.pac4j.core.client.ConfigurableClient;
 import org.pac4j.core.http.callback.CallbackUrlResolver;
 import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.cas.redirect.CasRedirectionActionBuilder;
@@ -32,7 +33,7 @@ import org.pac4j.core.util.CommonHelper;
  * @author Jerome Leleu
  * @since 1.4.0
  */
-public class CasClient extends IndirectClient<TokenCredentials> {
+public class CasClient extends IndirectClient<TokenCredentials> implements ConfigurableClient<CasConfiguration> {
 
     private CasConfiguration configuration = new CasConfiguration();
 
@@ -57,7 +58,7 @@ public class CasClient extends IndirectClient<TokenCredentials> {
 
     @Override
     protected CallbackUrlResolver newDefaultCallbackUrlResolver() {
-        return new QueryParameterCallbackUrlResolver(configuration.getCustomParams());
+        return new QueryParameterCallbackUrlResolver(configuration);
     }
 
     @Override

--- a/pac4j-cas/src/main/java/org/pac4j/cas/config/CasConfiguration.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/config/CasConfiguration.java
@@ -15,8 +15,7 @@ import org.pac4j.core.util.CommonHelper;
 
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
-import java.util.HashMap;
-import java.util.Map;
+
 
 /**
  * CAS configuration.
@@ -65,9 +64,6 @@ public class CasConfiguration extends BaseClientConfiguration {
     private UrlResolver urlResolver;
 
     private String postLogoutUrlParameter = SERVICE_PARAMETER;
-
-    /* Map containing user defined parameters */
-    private Map<String, String> customParams = new HashMap<>();
 
     private String method;
 
@@ -272,14 +268,6 @@ public class CasConfiguration extends BaseClientConfiguration {
         this.prefixUrl = prefixUrl;
     }
 
-    public Map<String, String> getCustomParams() {
-        return customParams;
-    }
-
-    public void setCustomParams(final Map<String, String> customParams) {
-        this.customParams = customParams;
-    }
-    
     public long getTimeTolerance() {
         return timeTolerance;
     }
@@ -388,10 +376,6 @@ public class CasConfiguration extends BaseClientConfiguration {
         this.urlResolver = urlResolver;
     }
 
-    public void addCustomParam(final String name, final String value) {
-        this.customParams.put(name, value);
-    }
-
     public String getMethod() {
         return method;
     }
@@ -419,10 +403,10 @@ public class CasConfiguration extends BaseClientConfiguration {
     @Override
     public String toString() {
         return CommonHelper.toNiceString(this.getClass(), "loginUrl", this.loginUrl, "prefixUrl", this.prefixUrl, "restUrl", this.restUrl,
-                "protocol", this.protocol, "renew", this.renew, "gateway", this.gateway, "encoding", this.encoding,
-                "logoutHandler", this.logoutHandler, "acceptAnyProxy", this.acceptAnyProxy, "allowedProxyChains", this.allowedProxyChains,
-                "proxyReceptor", this.proxyReceptor, "timeTolerance", this.timeTolerance, "postLogoutUrlParameter",
-                this.postLogoutUrlParameter, "defaultTicketValidator", this.defaultTicketValidator, "urlResolver", this.urlResolver,
-                "method", this.method, "privateKeyPath", this.privateKeyPath, "privateKeyAlgorithm", this.privateKeyAlgorithm);
+            "protocol", this.protocol, "renew", this.renew, "gateway", this.gateway, "encoding", this.encoding,
+            "logoutHandler", this.logoutHandler, "acceptAnyProxy", this.acceptAnyProxy, "allowedProxyChains", this.allowedProxyChains,
+            "proxyReceptor", this.proxyReceptor, "timeTolerance", this.timeTolerance, "postLogoutUrlParameter",
+            this.postLogoutUrlParameter, "defaultTicketValidator", this.defaultTicketValidator, "urlResolver", this.urlResolver,
+            "method", this.method, "privateKeyPath", this.privateKeyPath, "privateKeyAlgorithm", this.privateKeyAlgorithm);
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/client/ConfigurableClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/ConfigurableClient.java
@@ -1,0 +1,21 @@
+package org.pac4j.core.client;
+
+import org.pac4j.core.client.config.BaseClientConfiguration;
+
+/**
+ * Allowing clients to be aware of their configuration and
+ * report it back to callers. Any client that wishes
+ * to expose a configuration object should implement this interface.
+ *
+ * @author Misagh Moayyed
+ * @since 4.0.4
+ */
+@FunctionalInterface
+public interface ConfigurableClient<C extends BaseClientConfiguration> {
+    /**
+     * Gets configuration.
+     *
+     * @return the configuration
+     */
+    C getConfiguration();
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/client/config/BaseClientConfiguration.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/config/BaseClientConfiguration.java
@@ -2,6 +2,9 @@ package org.pac4j.core.client.config;
 
 import org.pac4j.core.util.InitializableObject;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Base parent class for all client configurations
  * to hold common fields or to be used as a common parent
@@ -11,4 +14,19 @@ import org.pac4j.core.util.InitializableObject;
  * @since 4.0.1
  */
 public abstract class BaseClientConfiguration extends InitializableObject {
+
+    /* Map containing user defined parameters */
+    private Map<String, String> customParams = new HashMap<>();
+
+    public Map<String, String> getCustomParams() {
+        return customParams;
+    }
+
+    public void setCustomParams(final Map<String, String> customParams) {
+        this.customParams = customParams;
+    }
+
+    public void addCustomParam(final String name, final String value) {
+        this.customParams.put(name, value);
+    }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/http/callback/BaseCallbackUrlResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/callback/BaseCallbackUrlResolver.java
@@ -1,0 +1,60 @@
+package org.pac4j.core.http.callback;
+
+import org.pac4j.core.client.config.BaseClientConfiguration;
+import org.pac4j.core.util.CommonHelper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is {@link BaseCallbackUrlResolver}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.3.0
+ */
+public abstract class BaseCallbackUrlResolver implements CallbackUrlResolver {
+    /**
+     * The Custom params.
+     */
+    protected Map<String, String> customParams = new HashMap<>();
+
+    /**
+     * Instantiates a new Base callback url resolver.
+     */
+    protected BaseCallbackUrlResolver() {
+    }
+
+    /**
+     * Instantiates a new Base callback url resolver.
+     *
+     * @param config the config
+     */
+    protected BaseCallbackUrlResolver(final BaseClientConfiguration config) {
+        if (config.getCustomParams() != null) {
+            this.customParams = config.getCustomParams();
+        }
+    }
+
+    /**
+     * Instantiates a new Base callback url resolver.
+     *
+     * @param customParams the custom params
+     */
+    protected BaseCallbackUrlResolver(final Map<String, String> customParams) {
+        this.customParams = customParams;
+    }
+
+    /**
+     * Add custom params to the url.
+     *
+     * @param url the url
+     * @return the url
+     */
+    protected String computeUrlCustomParams(final String url) {
+        String newUrl = url;
+        for (final Map.Entry<String, String> entry : this.customParams.entrySet()) {
+            newUrl = CommonHelper.addParameter(newUrl, entry.getKey(), entry.getValue());
+        }
+        return newUrl;
+    }
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/http/callback/NoParameterCallbackUrlResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/callback/NoParameterCallbackUrlResolver.java
@@ -1,7 +1,9 @@
 package org.pac4j.core.http.callback;
 
+import org.pac4j.core.client.config.BaseClientConfiguration;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.http.url.UrlResolver;
+import java.util.Map;
 
 /**
  * No name is added to the callback URL to be able to distinguish the client, so it doesn't match.
@@ -9,11 +11,22 @@ import org.pac4j.core.http.url.UrlResolver;
  * @author Jerome Leleu
  * @since 3.0.0
  */
-public class NoParameterCallbackUrlResolver implements CallbackUrlResolver {
+public class NoParameterCallbackUrlResolver extends BaseCallbackUrlResolver {
+    public NoParameterCallbackUrlResolver() {
+    }
+
+    public NoParameterCallbackUrlResolver(final BaseClientConfiguration config) {
+        super(config);
+    }
+
+    public NoParameterCallbackUrlResolver(final Map<String, String> customParams) {
+        super(customParams);
+    }
 
     @Override
     public String compute(final UrlResolver urlResolver, final String url, final String clientName, final WebContext context) {
-        return urlResolver.compute(url, context);
+        final String newUrl = urlResolver.compute(url, context);
+        return computeUrlCustomParams(newUrl);
     }
 
     @Override

--- a/pac4j-core/src/main/java/org/pac4j/core/http/callback/PathParameterCallbackUrlResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/callback/PathParameterCallbackUrlResolver.java
@@ -1,8 +1,11 @@
 package org.pac4j.core.http.callback;
 
+import org.pac4j.core.client.config.BaseClientConfiguration;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.util.CommonHelper;
+
+import java.util.Map;
 
 /**
  * The client name is added to the path of the callback URL.
@@ -10,7 +13,18 @@ import org.pac4j.core.util.CommonHelper;
  * @author Jerome Leleu
  * @since 3.0.0
  */
-public class PathParameterCallbackUrlResolver implements CallbackUrlResolver {
+public class PathParameterCallbackUrlResolver extends BaseCallbackUrlResolver {
+
+    public PathParameterCallbackUrlResolver() {
+    }
+
+    public PathParameterCallbackUrlResolver(final BaseClientConfiguration config) {
+        super(config);
+    }
+
+    public PathParameterCallbackUrlResolver(final Map<String, String> customParams) {
+        super(customParams);
+    }
 
     @Override
     public String compute(final UrlResolver urlResolver, final String url, final String clientName, final WebContext context) {
@@ -21,7 +35,7 @@ public class PathParameterCallbackUrlResolver implements CallbackUrlResolver {
             }
             newUrl += clientName;
         }
-        return newUrl;
+        return computeUrlCustomParams(newUrl);
     }
 
     @Override

--- a/pac4j-core/src/main/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolver.java
@@ -1,11 +1,11 @@
 package org.pac4j.core.http.callback;
 
-import org.pac4j.core.util.Pac4jConstants;
+import org.pac4j.core.client.config.BaseClientConfiguration;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.http.url.UrlResolver;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.core.util.Pac4jConstants;
 
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -14,16 +14,18 @@ import java.util.Map;
  * @author Jerome Leleu
  * @since 3.0.0
  */
-public class QueryParameterCallbackUrlResolver implements CallbackUrlResolver {
+public class QueryParameterCallbackUrlResolver extends BaseCallbackUrlResolver {
     private String clientNameParameter = Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER;
-
-    private Map<String, String> customParams = new HashMap<>();
 
     public QueryParameterCallbackUrlResolver() {
     }
 
+    public QueryParameterCallbackUrlResolver(final BaseClientConfiguration config) {
+        super(config);
+    }
+
     public QueryParameterCallbackUrlResolver(final Map<String, String> customParams) {
-        this.customParams = customParams;
+        super(customParams);
     }
 
     @Override
@@ -32,10 +34,7 @@ public class QueryParameterCallbackUrlResolver implements CallbackUrlResolver {
         if (newUrl != null && !newUrl.contains(this.clientNameParameter + '=')) {
             newUrl = CommonHelper.addParameter(newUrl, this.clientNameParameter, clientName);
         }
-        for (final Map.Entry<String, String> entry : this.customParams.entrySet()) {
-            newUrl = CommonHelper.addParameter(newUrl, entry.getKey(), entry.getValue());
-        }
-        return newUrl;
+        return computeUrlCustomParams(newUrl);
     }
 
     @Override

--- a/pac4j-core/src/test/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolverTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolverTests.java
@@ -4,13 +4,12 @@ import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.pac4j.core.client.config.BaseClientConfiguration;
 import org.pac4j.core.context.MockWebContext;
-import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.http.url.DefaultUrlResolver;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.util.TestsConstants;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests {@link QueryParameterCallbackUrlResolver}.
@@ -33,8 +32,7 @@ public final class QueryParameterCallbackUrlResolverTests implements TestsConsta
     @Test
     public void testParamsFromConfig() {
         final BaseClientConfiguration clientConfiguration = mock(BaseClientConfiguration.class);
-        doReturn(ImmutableMap.of("TestParam", "testValue")).when(clientConfiguration).getCustomParams();
-
+        when(clientConfiguration.getCustomParams()).thenReturn(ImmutableMap.of("TestParam", "testValue"));
         final String url = new QueryParameterCallbackUrlResolver(clientConfiguration)
             .compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());
         assertEquals(CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER
@@ -44,7 +42,7 @@ public final class QueryParameterCallbackUrlResolverTests implements TestsConsta
     @Test
     public void testParamsFromConfigNull() {
         final BaseClientConfiguration clientConfiguration = mock(BaseClientConfiguration.class);
-        doReturn(null).when(clientConfiguration).getCustomParams();
+        when(clientConfiguration.getCustomParams()).thenReturn(null);
 
         final String url = new QueryParameterCallbackUrlResolver(clientConfiguration)
             .compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());

--- a/pac4j-core/src/test/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolverTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/http/callback/QueryParameterCallbackUrlResolverTests.java
@@ -2,12 +2,15 @@ package org.pac4j.core.http.callback;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
+import org.pac4j.core.client.config.BaseClientConfiguration;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.http.url.DefaultUrlResolver;
 import org.pac4j.core.util.TestsConstants;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 /**
  * Tests {@link QueryParameterCallbackUrlResolver}.
@@ -26,6 +29,29 @@ public final class QueryParameterCallbackUrlResolverTests implements TestsConsta
         assertEquals(CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER
             + '=' + CLIENT_NAME + "&param1=value&param2=value2", url);
     }
+
+    @Test
+    public void testParamsFromConfig() {
+        final BaseClientConfiguration clientConfiguration = mock(BaseClientConfiguration.class);
+        doReturn(ImmutableMap.of("TestParam", "testValue")).when(clientConfiguration).getCustomParams();
+
+        final String url = new QueryParameterCallbackUrlResolver(clientConfiguration)
+            .compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());
+        assertEquals(CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER
+            + '=' + CLIENT_NAME + "&TestParam=testValue", url);
+    }
+
+    @Test
+    public void testParamsFromConfigNull() {
+        final BaseClientConfiguration clientConfiguration = mock(BaseClientConfiguration.class);
+        doReturn(null).when(clientConfiguration).getCustomParams();
+
+        final String url = new QueryParameterCallbackUrlResolver(clientConfiguration)
+            .compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());
+        assertEquals(CALLBACK_URL +'?' + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER
+            + '=' + CLIENT_NAME, url);
+    }
+
     @Test
     public void testCompute() {
         final String url = resolver.compute(new DefaultUrlResolver(), CALLBACK_URL, CLIENT_NAME, MockWebContext.create());

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/OAuth10Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/OAuth10Client.java
@@ -1,5 +1,6 @@
 package org.pac4j.oauth.client;
 
+import org.pac4j.core.client.ConfigurableClient;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.config.OAuth10Configuration;
@@ -15,7 +16,7 @@ import org.pac4j.oauth.redirect.OAuth10RedirectionActionBuilder;
  * @author Jerome Leleu
  * @since 2.0.0
  */
-public class OAuth10Client extends IndirectClient<OAuth10Credentials> {
+public class OAuth10Client extends IndirectClient<OAuth10Credentials> implements ConfigurableClient<OAuth10Configuration> {
 
     protected OAuth10Configuration configuration = new OAuth10Configuration();
 

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/OAuth20Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/OAuth20Client.java
@@ -1,5 +1,6 @@
 package org.pac4j.oauth.client;
 
+import org.pac4j.core.client.ConfigurableClient;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oauth.config.OAuth20Configuration;
@@ -15,7 +16,8 @@ import org.pac4j.oauth.redirect.OAuth20RedirectionActionBuilder;
  * @author Jerome Leleu
  * @since 2.0.0
  */
-public class OAuth20Client extends IndirectClient<OAuth20Credentials> {
+public class OAuth20Client extends IndirectClient<OAuth20Credentials>
+    implements ConfigurableClient<OAuth20Configuration> {
 
     protected OAuth20Configuration configuration = new OAuth20Configuration();
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -1,6 +1,7 @@
 package org.pac4j.oidc.client;
 
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import org.pac4j.core.client.ConfigurableClient;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.profile.UserProfile;
@@ -26,7 +27,8 @@ import java.util.Optional;
  * @author Jerome Leleu
  * @since 1.7.0
  */
-public class OidcClient<V extends OidcConfiguration> extends IndirectClient<OidcCredentials> {
+public class OidcClient<V extends OidcConfiguration> extends IndirectClient<OidcCredentials>
+    implements ConfigurableClient<OidcConfiguration> {
 
     private V configuration = null;
 

--- a/pac4j-openid/src/main/java/org/pac4j/openid/client/YahooOpenIdClient.java
+++ b/pac4j-openid/src/main/java/org/pac4j/openid/client/YahooOpenIdClient.java
@@ -17,7 +17,7 @@ import org.pac4j.openid.redirect.YahooRedirectionActionBuilder;
  */
 public class YahooOpenIdClient extends IndirectClient<OpenIdCredentials> {
 
-    public final static String DISCOVERY_INFORMATION = "discoveryInformation";
+    public static final String DISCOVERY_INFORMATION = "discoveryInformation";
 
     private ConsumerManager consumerManager;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -9,6 +9,7 @@ import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.pac4j.core.client.ConfigurableClient;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.exception.TechnicalException;
@@ -61,7 +62,7 @@ import java.util.List;
  * @author Jerome Leleu
  * @since 1.5.0
  */
-public class SAML2Client extends IndirectClient<SAML2Credentials> {
+public class SAML2Client extends IndirectClient<SAML2Credentials> implements ConfigurableClient<SAML2Configuration> {
 
     protected SAMLContextProvider contextProvider;
 


### PR DESCRIPTION
## Problem

At run time and after the client initialization phase, consider the following snippet:

```java
client.getConfiguration().addCustomParam("name", "value");
```

Using this setup, if a client builds a redirect action later to calculate the callback url, the custom parameter is not recognized and added to the url. While custom parameters typically are set up during the initialization phase, they can also be dynamically updated/managed to dictate certain behavior to the identity provider. The present functionality is rather limiting, because in certain scenarios, custom parameters are unknown until much later in the execution sequence.

## Proposal

This pull request allows callback url resolvers to be aware of changes applied to custom parameters. 

Concretely,

- Moves the custom params collection to the parent `BaseConfiguration` class, allowing all support clients to take advantage of custom params.
- Supporting clients are now asked to implement `ConfigurableClient` to indicate that they expose a configuration object. 
- A parent `BaseCallbackUrlResolver.java` is now added that allows its children to compute the final url based on given custom params.

For this to properly work, all callback url resolvers are expected to initialize using a reference to the config object they expose. 

For example,

```java
        var configurableClient = ConfigurableClient.class.cast(client);

        switch (props.getCallbackUrlType()) {
            case PATH_PARAMETER:
                client.setCallbackUrlResolver(new PathParameterCallbackUrlResolver(configurableClient.getConfiguration()));
                break;
            case NONE:
                client.setCallbackUrlResolver(new NoParameterCallbackUrlResolver(configurableClient.getConfiguration()));
                break;
            case QUERY_PARAMETER:
            default:
                client.setCallbackUrlResolver(new QueryParameterCallbackUrlResolver(configurableClient.getConfiguration()));
        }
```

cc: @astohn