### PR TITLE
NullPointerException due to refresh response not returning an ID-Token

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -192,7 +192,9 @@ public class OidcAuthenticator implements Authenticator<OidcCredentials> {
         final OIDCTokens oidcTokens = tokenSuccessResponse.getOIDCTokens();
         credentials.setAccessToken(oidcTokens.getAccessToken());
         credentials.setRefreshToken(oidcTokens.getRefreshToken());
-        credentials.setIdToken(oidcTokens.getIDToken());
+        if (oidcTokens.getIDToken() != null) {
+            credentials.setIdToken(oidcTokens.getIDToken());
+        }
     }
 
     public ClientAuthentication getClientAuthentication() {


### PR DESCRIPTION
As discussed on the Mailing list, one can run into a NullPointer when refreshing, as the response doesn't need to send an ID-Token .

According to the specification [here](https://openid.net/specs/openid-connect-core-1_0.html#RefreshTokenResponse), the response isn't required to return an ID-Token and I think pac4j should reflect this.