### PR TITLE
Support ServiceName in SAML2 Metadata requested attributes

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -25,7 +25,7 @@ import org.pac4j.saml.metadata.SAML2MetadataContactPerson;
 import org.pac4j.saml.metadata.SAML2MetadataGenerator;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 import org.pac4j.saml.metadata.SAML2MetadataUIInfo;
-import org.pac4j.saml.metadata.SAML2ServiceProvicerRequestedAttribute;
+import org.pac4j.saml.metadata.SAML2ServiceProviderRequestedAttribute;
 import org.pac4j.saml.metadata.keystore.SAML2FileSystemKeystoreGenerator;
 import org.pac4j.saml.metadata.keystore.SAML2HttpUrlKeystoreGenerator;
 import org.pac4j.saml.metadata.keystore.SAML2KeystoreGenerator;
@@ -70,7 +70,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SAML2Configuration.class);
 
-    private final List<SAML2ServiceProvicerRequestedAttribute> requestedServiceProviderAttributes = new ArrayList<>();
+    private final List<SAML2ServiceProviderRequestedAttribute> requestedServiceProviderAttributes = new ArrayList<>();
 
     private String callbackUrl;
 
@@ -365,7 +365,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.privateKeySize = privateKeySize;
     }
 
-    public List<SAML2ServiceProvicerRequestedAttribute> getRequestedServiceProviderAttributes() {
+    public List<SAML2ServiceProviderRequestedAttribute> getRequestedServiceProviderAttributes() {
         return requestedServiceProviderAttributes;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
@@ -34,6 +34,7 @@ import org.opensaml.saml.saml2.metadata.KeyDescriptor;
 import org.opensaml.saml.saml2.metadata.NameIDFormat;
 import org.opensaml.saml.saml2.metadata.RequestedAttribute;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.ServiceName;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
 import org.opensaml.saml.saml2.metadata.SurName;
 import org.opensaml.saml.saml2.metadata.TelephoneNumber;
@@ -105,7 +106,7 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
 
     protected String nameIdPolicyFormat = null;
 
-    protected List<SAML2ServiceProvicerRequestedAttribute> requestedAttributes = new ArrayList<>();
+    protected List<SAML2ServiceProviderRequestedAttribute> requestedAttributes = new ArrayList<>();
 
     protected SignatureSigningConfiguration defaultSignatureSigningConfiguration =
         DefaultSecurityConfigurationBootstrap.buildDefaultSignatureSigningConfiguration();
@@ -257,9 +258,10 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
             final SAMLObjectBuilder<AttributeConsumingService> attrServiceBuilder =
                 (SAMLObjectBuilder<AttributeConsumingService>) this.builderFactory
                     .getBuilder(AttributeConsumingService.DEFAULT_ELEMENT_NAME);
+
             final AttributeConsumingService attributeService =
                 attrServiceBuilder.buildObject(AttributeConsumingService.DEFAULT_ELEMENT_NAME);
-            for (final SAML2ServiceProvicerRequestedAttribute attr : this.requestedAttributes) {
+            for (final SAML2ServiceProviderRequestedAttribute attr : this.requestedAttributes) {
                 final SAMLObjectBuilder<RequestedAttribute> attrBuilder = (SAMLObjectBuilder<RequestedAttribute>) this.builderFactory
                     .getBuilder(RequestedAttribute.DEFAULT_ELEMENT_NAME);
                 final RequestedAttribute requestAttribute = attrBuilder.buildObject(RequestedAttribute.DEFAULT_ELEMENT_NAME);
@@ -269,7 +271,19 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
                 requestAttribute.setNameFormat(attr.getNameFormat());
 
                 attributeService.getRequestedAttributes().add(requestAttribute);
+
+                if (StringUtils.isNotBlank(attr.getServiceName())) {
+                    final SAMLObjectBuilder<ServiceName> serviceBuilder = (SAMLObjectBuilder<ServiceName>)
+                        this.builderFactory.getBuilder(ServiceName.DEFAULT_ELEMENT_NAME);
+                    final ServiceName serviceName = Objects.requireNonNull(serviceBuilder).buildObject();
+                    serviceName.setValue(attr.getServiceName());
+                    if (StringUtils.isNotBlank(attr.getServiceLang())) {
+                        serviceName.setXMLLang(attr.getServiceLang());
+                    }
+                    attributeService.getNames().add(serviceName);
+                }
             }
+
             spDescriptor.getAttributeConsumingServices().add(attributeService);
         }
 
@@ -554,11 +568,11 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
         this.nameIdPolicyFormat = nameIdPolicyFormat;
     }
 
-    public List<SAML2ServiceProvicerRequestedAttribute> getRequestedAttributes() {
+    public List<SAML2ServiceProviderRequestedAttribute> getRequestedAttributes() {
         return requestedAttributes;
     }
 
-    public void setRequestedAttributes(final List<SAML2ServiceProvicerRequestedAttribute> requestedAttributes) {
+    public void setRequestedAttributes(final List<SAML2ServiceProviderRequestedAttribute> requestedAttributes) {
         this.requestedAttributes = requestedAttributes;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderRequestedAttribute.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderRequestedAttribute.java
@@ -3,32 +3,50 @@ package org.pac4j.saml.metadata;
 import java.io.Serializable;
 
 /**
- * This is {@link SAML2ServiceProvicerRequestedAttribute}.
+ * This is {@link SAML2ServiceProviderRequestedAttribute}.
  *
  * @author Misagh Moayyed
  */
-public class SAML2ServiceProvicerRequestedAttribute implements Serializable {
+public class SAML2ServiceProviderRequestedAttribute implements Serializable {
     private static final long serialVersionUID = 1040516205957826527L;
 
     public String name;
     public String friendlyName;
     public String nameFormat = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri";
     public boolean isRequired;
+    private String serviceName;
+    private String serviceLang;
 
-    public SAML2ServiceProvicerRequestedAttribute() {
+    public SAML2ServiceProviderRequestedAttribute() {
     }
 
-    public SAML2ServiceProvicerRequestedAttribute(final String name, final String friendlyName) {
+    public SAML2ServiceProviderRequestedAttribute(final String name, final String friendlyName) {
         this.name = name;
         this.friendlyName = friendlyName;
     }
 
-    public SAML2ServiceProvicerRequestedAttribute(final String name, final String friendlyName,
+    public SAML2ServiceProviderRequestedAttribute(final String name, final String friendlyName,
                                                   final String nameFormat, final boolean isRequired) {
         this.name = name;
         this.friendlyName = friendlyName;
         this.nameFormat = nameFormat;
         this.isRequired = isRequired;
+    }
+
+    public String getServiceName() {
+        return serviceName;
+    }
+
+    public void setServiceName(final String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    public String getServiceLang() {
+        return serviceLang;
+    }
+
+    public void setServiceLang(final String serviceLang) {
+        this.serviceLang = serviceLang;
     }
 
     public String getName() {
@@ -65,11 +83,13 @@ public class SAML2ServiceProvicerRequestedAttribute implements Serializable {
 
     @Override
     public String toString() {
-        return "RequestedServiceProviderAttribute{" +
+        return "SAML2ServiceProviderRequestedAttribute{" +
             "name='" + name + '\'' +
             ", friendlyName='" + friendlyName + '\'' +
             ", nameFormat='" + nameFormat + '\'' +
             ", isRequired=" + isRequired +
+            ", serviceName='" + serviceName + '\'' +
+            ", serviceLang='" + serviceLang + '\'' +
             '}';
     }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolverTest.java
@@ -36,8 +36,11 @@ public class SAML2ServiceProviderMetadataResolverTest {
         config.setForceServiceProviderMetadataGeneration(true);
         config.setServiceProviderMetadataResource(serviceProviderMetadataResource);
         config.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
-        config.getRequestedServiceProviderAttributes().add(
-            new SAML2ServiceProvicerRequestedAttribute("urn:oid:1.3.6.1.4.1.5923.1.1.1.6", "eduPersonPrincipalName"));
+        SAML2ServiceProviderRequestedAttribute attribute =
+            new SAML2ServiceProviderRequestedAttribute("urn:oid:1.3.6.1.4.1.5923.1.1.1.6", "eduPersonPrincipalName");
+        attribute.setServiceLang("fr");
+        attribute.setServiceName("MySAML2ServiceProvider");
+        config.getRequestedServiceProviderAttributes().add(attribute);
         config.init();
         return config;
     }
@@ -73,7 +76,7 @@ public class SAML2ServiceProviderMetadataResolverTest {
         wireMockServer.stubFor(
             post(urlPathEqualTo("/keystore"))
                 .willReturn(aResponse().withStatus(200)));
-        
+
         try {
             wireMockServer.start();
             final SAML2Configuration configuration =


### PR DESCRIPTION
Also, fixes a typo in the class name `SAML2ServiceProvi*c*erRequestedAttribute`.