### PR TITLE
Fix for expired profiles when lifetime isn't used.  issue #1679

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -11,7 +11,7 @@ import org.pac4j.oidc.client.OidcClient;
 import java.net.URI;
 import java.text.ParseException;
 import java.time.Instant;
-import java.util.*;
+import java.util.Date;
 
 /**
  * <p>This class is the user profile for sites using OpenID Connect protocol.</p>
@@ -103,8 +103,21 @@ public class OidcProfile extends AbstractJwtProfile {
     public void setAccessToken(final AccessToken accessToken) {
         addAttribute(OidcProfileDefinition.ACCESS_TOKEN, accessToken);
         if (accessToken != null) {
-            addAttribute(OidcProfileDefinition.EXPIRATION,
+            if (accessToken.getLifetime() != 0) {
+                addAttribute(OidcProfileDefinition.EXPIRATION,
                     Date.from(Instant.now().plusSeconds(accessToken.getLifetime())));
+            } else {
+                Date exp;
+                try {
+                    exp = JWTParser.parse(accessToken.getValue()).getJWTClaimsSet().getExpirationTime();
+                } catch (ParseException e) {
+                    exp = null;
+                }
+                if (exp != null) {
+                    addAttribute(OidcProfileDefinition.EXPIRATION,
+                        exp);
+                }
+            }
         }
     }
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java
@@ -1,5 +1,7 @@
 package org.pac4j.oidc.profile;
 
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -8,6 +10,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.pac4j.core.util.JavaSerializationHelper;
 import org.pac4j.core.util.TestsConstants;
+
+import java.time.Instant;
+import java.util.Date;
 
 import static org.junit.Assert.*;
 
@@ -178,5 +183,23 @@ public final class OidcProfileTests implements TestsConstants {
         profile.setAccessToken(token);
         profile.setTokenExpirationAdvance(3600); // 1 hour
         assertTrue(profile.isExpired());
+    }
+
+    /**
+     * Test experation based on access token exp date.
+     */
+    @Test
+    public void testAccessTokenExpiration(){
+
+        final OidcProfile profile = new OidcProfile();
+        profile.setAccessToken(new BearerAccessToken(ID_TOKEN));
+
+        assertTrue(profile.isExpired());
+
+        JWTClaimsSet cs = new JWTClaimsSet.Builder().expirationTime(Date.from(Instant.now().plusSeconds(30))).build();
+
+        profile.setAccessToken(new BearerAccessToken(new PlainJWT(cs).serialize()));
+
+        assertFalse(profile.isExpired());
     }
 }


### PR DESCRIPTION
(cherry picked from commit a6813063f3fbab31c486d5c6a1b632db67db72bc)

# Conflicts:
#	pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html