### PR TITLE
Chain converters for locale claim

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
@@ -3,9 +3,12 @@ package org.pac4j.cas.profile;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.pac4j.cas.client.CasProxyReceptor;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.converter.ChainingConverter;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
+
+import java.util.List;
 
 /**
  * Profile definition for CAS.
@@ -38,7 +41,7 @@ public class CasProfileDefinition extends CommonProfileDefinition {
         primary(FAMILY_NAME, Converters.STRING);
         primary(DISPLAY_NAME, Converters.STRING);
         primary(GENDER, Converters.STRING);
-        primary(LOCALE, Converters.STRING);
+        primary(LOCALE, new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE)));
         primary(PICTURE_URL, Converters.STRING);
         primary(PROFILE_URL, Converters.STRING);
         primary(LOCATION, Converters.STRING);

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/converter/ChainingConverter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/converter/ChainingConverter.java
@@ -7,6 +7,7 @@ import java.util.Objects;
  * This is {@link ChainingConverter}.
  *
  * @author Misagh Moayyed
+ * @since 4.3.0
  */
 public class ChainingConverter implements AttributeConverter {
     private final List<AttributeConverter> converters;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/converter/ChainingConverter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/converter/ChainingConverter.java
@@ -7,7 +7,6 @@ import java.util.Objects;
  * This is {@link ChainingConverter}.
  *
  * @author Misagh Moayyed
- * @since 6.4.0
  */
 public class ChainingConverter implements AttributeConverter {
     private final List<AttributeConverter> converters;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/converter/ChainingConverter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/converter/ChainingConverter.java
@@ -1,0 +1,26 @@
+package org.pac4j.core.profile.converter;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This is {@link ChainingConverter}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+public class ChainingConverter implements AttributeConverter {
+    private final List<AttributeConverter> converters;
+
+    public ChainingConverter(final List<AttributeConverter> converters) {
+        this.converters = converters;
+    }
+
+    @Override
+    public Object convert(final Object o) {
+        return converters.stream().map(c -> c.convert(o))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+    }
+}

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/converter/ChainingConverterTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/converter/ChainingConverterTests.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertNotNull;
  * This class tests the {@link ChainingConverterTests} class.
  *
  * @author Misagh Moayyed
- * @since 1.1.0
+ * @since 4.3.0
  */
 public final class ChainingConverterTests {
 

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/converter/ChainingConverterTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/converter/ChainingConverterTests.java
@@ -1,0 +1,26 @@
+package org.pac4j.core.profile.converter;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This class tests the {@link ChainingConverterTests} class.
+ *
+ * @author Misagh Moayyed
+ * @since 1.1.0
+ */
+public final class ChainingConverterTests {
+
+    @Test
+    public void testChain() {
+        ChainingConverter chain = new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE));
+        assertNotNull(chain.convert("english"));
+        assertNotNull(chain.convert(List.of("english")));
+        assertNotNull(chain.convert(Locale.ENGLISH));
+        assertNotNull(chain.convert(List.of(Locale.ENGLISH)));
+    }
+}


### PR DESCRIPTION
Allow attribute converters to be chained together, and allow a chain for the locale primary attribute for the CasProfileDefinition.

The chain allows this test to pass:

```java
ChainingConverter chain = new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE));
assertNotNull(chain.convert("english"));
assertNotNull(chain.convert(List.of("english")));
assertNotNull(chain.convert(Locale.ENGLISH));
assertNotNull(chain.convert(List.of(Locale.ENGLISH)));
```

This should be ported back to the 4.x branch. (Can cherry pick)