### PR TITLE
Enhancements to SAML2 authn requests

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
@@ -102,14 +102,7 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
             encoder.prepareContext();
             encoder.encode();
 
-            final SAMLMessageStore messageStorage = context.getSAMLMessageStore();
-            if (messageStorage != null) {
-                if (request instanceof RequestAbstractType) {
-                    messageStorage.set(((RequestAbstractType) request).getID(), request);
-                } else if (request instanceof StatusResponseType) {
-                    messageStorage.set(((StatusResponseType) request).getID(), request);
-                }
-            }
+            storeMessage(context, request);
             logProtocolMessage(request);
         } catch (final MarshallingException e) {
             throw new SAMLException("Error marshalling saml message", e);
@@ -117,6 +110,17 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
             throw new SAMLException("Error encoding saml message", e);
         } catch (final ComponentInitializationException e) {
             throw new SAMLException("Error initializing saml encoder", e);
+        }
+    }
+
+    protected void storeMessage(final SAML2MessageContext context, final T request) {
+        final SAMLMessageStore messageStorage = context.getSAMLMessageStore();
+        if (messageStorage != null) {
+            if (request instanceof RequestAbstractType) {
+                messageStorage.set(((RequestAbstractType) request).getID(), request);
+            } else if (request instanceof StatusResponseType) {
+                messageStorage.set(((StatusResponseType) request).getID(), request);
+            }
         }
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/AbstractSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/AbstractSAML2ClientTests.java
@@ -2,6 +2,7 @@ package org.pac4j.saml.client;
 
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.metadata.SAML2ServiceProviderRequestedAttribute;
 import org.pac4j.saml.store.HttpSessionStoreFactory;
 import org.pac4j.saml.util.Configuration;
 import org.springframework.core.io.ClassPathResource;
@@ -44,6 +45,13 @@ public abstract class AbstractSAML2ClientTests implements TestsConstants {
         cfg.setForceKeystoreGeneration(true);
         cfg.setServiceProviderMetadataResource(new FileSystemResource(new File("target", "sp-metadata.xml").getAbsolutePath()));
         cfg.setSamlMessageStoreFactory(new HttpSessionStoreFactory());
+
+        final SAML2ServiceProviderRequestedAttribute attribute =
+            new SAML2ServiceProviderRequestedAttribute("urn:oid:1.3.6.1.4.1.5923.1.1.1.6", "eduPersonPrincipalName");
+        attribute.setServiceLang("fr");
+        attribute.setServiceName("MySAML2ServiceProvider");
+        cfg.getRequestedServiceProviderAttributes().add(attribute);
+
         return cfg;
     }
 


### PR DESCRIPTION
- Allow specification of required attributes as extensions
- Move message storage functionality into a protected method for extensions, if necessary.
- Update tests