### PR TITLE
pac4j-saml: ensure parent paths exists for keystores

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGenerator.java
@@ -83,7 +83,8 @@ public class SAML2FileSystemKeystoreGenerator extends BaseSAML2KeystoreGenerator
         validate();
 
         final File keystoreFile = saml2Configuration.getKeystoreResource().getFile();
-        if (!keystoreFile.getParentFile().exists() && !keystoreFile.getParentFile().mkdirs()) {
+        final File parentFile = keystoreFile.getParentFile();
+        if (parentFile != null && !parentFile.exists() && !parentFile.mkdirs()) {
             logger.warn("Could not construct the directory structure for keystore: {}", keystoreFile.getCanonicalPath());
         }
         final char[] password = saml2Configuration.getKeystorePassword().toCharArray();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGenerator.java
@@ -83,6 +83,9 @@ public class SAML2FileSystemKeystoreGenerator extends BaseSAML2KeystoreGenerator
         validate();
 
         final File keystoreFile = saml2Configuration.getKeystoreResource().getFile();
+        if (!keystoreFile.getParentFile().exists() && !keystoreFile.getParentFile().mkdirs()) {
+            logger.warn("Could not construct the directory structure for keystore: {}", keystoreFile.getCanonicalPath());
+        }
         final char[] password = saml2Configuration.getKeystorePassword().toCharArray();
         try (OutputStream fos = new FileOutputStream(keystoreFile.getCanonicalPath())) {
             ks.store(fos, password);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGeneratorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGeneratorTests.java
@@ -1,9 +1,7 @@
 package org.pac4j.saml.metadata.keystore;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.crypto.CredentialProvider;

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGeneratorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGeneratorTests.java
@@ -1,5 +1,9 @@
 package org.pac4j.saml.metadata.keystore;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.Test;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.crypto.CredentialProvider;
@@ -17,6 +21,29 @@ import static org.junit.Assert.*;
  * @author Misagh Moayyed
  */
 public class SAML2FileSystemKeystoreGeneratorTests {
+
+    @Test
+    public void verifyKeystoreGenForNewDirectory() throws Exception {
+        final ConfigurationManager mgr = new DefaultConfigurationManager();
+        mgr.configure();
+
+        final SAML2Configuration configuration = new SAML2Configuration();
+        configuration.setForceKeystoreGeneration(true);
+
+        final String path = RandomStringUtils.randomAlphabetic(4);
+        configuration.setKeystorePath(String.format("%s/%s/keystore.jks", FileUtils.getTempDirectoryPath(), path));
+
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+        configuration.setServiceProviderMetadataResource(new FileSystemResource("target/out.xml"));
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.init();
+
+        final SAML2KeystoreGenerator generator =
+            new SAML2FileSystemKeystoreGenerator(configuration);
+        generator.generate();
+        assertTrue(configuration.getKeystoreResource().getFile().exists());
+    }
 
     @Test
     public void verifyKeystoreGeneration() throws Exception {


### PR DESCRIPTION
When creating the saml2 keystore, make sure the parent paths exist before the keystore is created.