### PR TITLE
Chain attribute converters for special converters

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
@@ -3,12 +3,7 @@ package org.pac4j.cas.profile;
 import org.jasig.cas.client.authentication.AttributePrincipal;
 import org.pac4j.cas.client.CasProxyReceptor;
 import org.pac4j.core.profile.UserProfile;
-import org.pac4j.core.profile.converter.ChainingConverter;
-import org.pac4j.core.util.Pac4jConstants;
-import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
-
-import java.util.List;
 
 /**
  * Profile definition for CAS.
@@ -32,19 +27,5 @@ public class CasProfileDefinition extends CommonProfileDefinition {
         } else {
             return super.newProfile(parameters);
         }
-    }
-
-    @Override
-    protected void configurePrimaryAttributes() {
-        primary(EMAIL, Converters.STRING);
-        primary(FIRST_NAME, Converters.STRING);
-        primary(FAMILY_NAME, Converters.STRING);
-        primary(DISPLAY_NAME, Converters.STRING);
-        primary(GENDER, Converters.STRING);
-        primary(LOCALE, new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE)));
-        primary(PICTURE_URL, Converters.STRING);
-        primary(PROFILE_URL, Converters.STRING);
-        primary(LOCATION, Converters.STRING);
-        primary(Pac4jConstants.USERNAME, Converters.STRING);
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
@@ -1,8 +1,11 @@
 package org.pac4j.core.profile.definition;
 
+import org.pac4j.core.profile.converter.ChainingConverter;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.factory.ProfileFactory;
+
+import java.util.List;
 
 /**
  * Profile definition with the common attributes.
@@ -31,10 +34,10 @@ public class CommonProfileDefinition extends ProfileDefinition {
         primary(FIRST_NAME, Converters.STRING);
         primary(FAMILY_NAME, Converters.STRING);
         primary(DISPLAY_NAME, Converters.STRING);
-        primary(GENDER, Converters.GENDER);
-        primary(LOCALE, Converters.LOCALE);
-        primary(PICTURE_URL, Converters.URL);
-        primary(PROFILE_URL, Converters.URL);
+        primary(GENDER, new ChainingConverter(List.of(Converters.STRING, Converters.GENDER)));
+        primary(LOCALE, new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE)));
+        primary(PICTURE_URL, new ChainingConverter(List.of(Converters.STRING, Converters.URL)));
+        primary(PROFILE_URL, new ChainingConverter(List.of(Converters.STRING, Converters.URL)));
         primary(LOCATION, Converters.STRING);
         primary(Pac4jConstants.USERNAME, Converters.STRING);
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/CommonProfileDefinition.java
@@ -34,10 +34,10 @@ public class CommonProfileDefinition extends ProfileDefinition {
         primary(FIRST_NAME, Converters.STRING);
         primary(FAMILY_NAME, Converters.STRING);
         primary(DISPLAY_NAME, Converters.STRING);
-        primary(GENDER, new ChainingConverter(List.of(Converters.STRING, Converters.GENDER)));
-        primary(LOCALE, new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE)));
-        primary(PICTURE_URL, new ChainingConverter(List.of(Converters.STRING, Converters.URL)));
-        primary(PROFILE_URL, new ChainingConverter(List.of(Converters.STRING, Converters.URL)));
+        primary(GENDER, new ChainingConverter(List.of(Converters.GENDER, Converters.STRING)));
+        primary(LOCALE, new ChainingConverter(List.of(Converters.LOCALE, Converters.STRING)));
+        primary(PICTURE_URL, new ChainingConverter(List.of(Converters.URL, Converters.STRING)));
+        primary(PROFILE_URL, new ChainingConverter(List.of(Converters.URL, Converters.STRING)));
         primary(LOCATION, Converters.STRING);
         primary(Pac4jConstants.USERNAME, Converters.STRING);
     }


### PR DESCRIPTION
Chain attribute converters for a number of *special* attributes, to allow both the native/simple type as a String and the specialized type via the converter. The special converter runs first in the chain, and if it fails, the simpler String converter is used to pick up the attribute anyway.

This change should apply to all profile definitions for all protocols. Today, if a SAML2 IdP sends an attribute for `gender`, the converter fails to pick it up if it cannot recognize its values.