### PR TITLE
pac4j-saml: Define dedicated class for SAML2 profile definitions

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -3,7 +3,6 @@ package org.pac4j.saml.credentials.authenticator;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.credentials.authenticator.Authenticator;
-import org.pac4j.core.profile.definition.CommonProfileDefinition;
 import org.pac4j.core.profile.definition.ProfileDefinitionAware;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.credentials.SAML2Credentials;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -8,6 +8,7 @@ import org.pac4j.core.profile.definition.ProfileDefinitionAware;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.profile.SAML2Profile;
+import org.pac4j.saml.profile.SAML2ProfileDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +59,7 @@ public class SAML2Authenticator extends ProfileDefinitionAware implements Authen
 
     @Override
     protected void internalInit() {
-        defaultProfileDefinition(new CommonProfileDefinition(x -> new SAML2Profile()));
+        defaultProfileDefinition(new SAML2ProfileDefinition());
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2ProfileDefinition.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2ProfileDefinition.java
@@ -1,0 +1,18 @@
+package org.pac4j.saml.profile;
+
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
+
+/**
+ * This is the dedicated class to hold the profile definition
+ * for SAML2, when building the final user profile.
+ *
+ * @see SAML2Profile
+ * @see org.pac4j.saml.credentials.authenticator.SAML2Authenticator
+ * @author Misagh Moayyed
+ * @version 5.0.0
+ */
+public class SAML2ProfileDefinition extends CommonProfileDefinition {
+    public SAML2ProfileDefinition() {
+        super(parameters -> new SAML2Profile());
+    }
+}


### PR DESCRIPTION
This pull request mainly refactors the saml2 profile definition construct into a dedicated class. The intention is to make this component more obvious and discoverable for extensions, in javadocs and from an API point of view vs what exists now as a lambda expression. It should make it easier to extend this class for custom functionality, while keeping certain sane default in the future, as we add support for certain attribute profiles (such as the eduPerson schema)