### PR TITLE
relax saml2 validation rules to skip exceptions

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProfileDefinition.java
@@ -8,7 +8,7 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.converter.Converters;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
 
-import java.util.List;
+import java.util.Arrays;
 
 /**
  * Profile definition for CAS.
@@ -40,7 +40,7 @@ public class CasProfileDefinition extends CommonProfileDefinition<CommonProfile>
         primary(FAMILY_NAME, Converters.STRING);
         primary(DISPLAY_NAME, Converters.STRING);
         primary(GENDER, Converters.STRING);
-        primary(LOCALE, new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE)));
+        primary(LOCALE, new ChainingConverter(Arrays.asList(Converters.STRING, Converters.LOCALE)));
         primary(PICTURE_URL, Converters.STRING);
         primary(PROFILE_URL, Converters.STRING);
         primary(LOCATION, Converters.STRING);

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/converter/ChainingConverterTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/converter/ChainingConverterTests.java
@@ -2,7 +2,7 @@ package org.pac4j.core.profile.converter;
 
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Locale;
 
 import static org.junit.Assert.assertNotNull;
@@ -17,10 +17,10 @@ public final class ChainingConverterTests {
 
     @Test
     public void testChain() {
-        ChainingConverter chain = new ChainingConverter(List.of(Converters.STRING, Converters.LOCALE));
+        ChainingConverter chain = new ChainingConverter(Arrays.asList(Converters.STRING, Converters.LOCALE));
         assertNotNull(chain.convert("english"));
-        assertNotNull(chain.convert(List.of("english")));
+        assertNotNull(chain.convert(Arrays.asList("english")));
         assertNotNull(chain.convert(Locale.ENGLISH));
-        assertNotNull(chain.convert(List.of(Locale.ENGLISH)));
+        assertNotNull(chain.convert(Arrays.asList(Locale.ENGLISH)));
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AppleOidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AppleOidcConfiguration.java
@@ -64,10 +64,10 @@ public class AppleOidcConfiguration extends OidcConfiguration {
         CommonHelper.assertNotNull("privateKey", privateKey);
         CommonHelper.assertNotBlank("teamID", teamID);
         if (timeout.compareTo(MAX_TIMEOUT) > 0) {
-            throw new IllegalArgumentException(String.format("timeout must not be greater then %d seconds", MAX_TIMEOUT.toSeconds()));
+            throw new IllegalArgumentException(String.format("timeout must not be greater then %d seconds", MAX_TIMEOUT.getSeconds()));
         }
         if (store == null) {
-            store = new GuavaStore<>(1000, (int) timeout.toSeconds(), TimeUnit.SECONDS);
+            store = new GuavaStore<>(1000, (int) timeout.getSeconds(), TimeUnit.SECONDS);
         }
         final OIDCProviderMetadata providerMetadata =
             new OIDCProviderMetadata(
@@ -102,7 +102,7 @@ public class AppleOidcConfiguration extends OidcConfiguration {
             .audience("https://appleid.apple.com")
             .subject(getClientId())
             .issueTime(Date.from(Instant.now()))
-            .expirationTime(Date.from(Instant.now().plusSeconds(timeout.toSeconds())))
+            .expirationTime(Date.from(Instant.now().plusSeconds(timeout.getSeconds())))
             .build();
         SignedJWT signedJWT = new SignedJWT(
             new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(privateKeyID).build(),

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/run/RunAppleClient.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/run/RunAppleClient.java
@@ -15,7 +15,6 @@ import org.pac4j.oidc.profile.apple.AppleProfile;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPrivateKey;
@@ -98,7 +97,7 @@ public class RunAppleClient extends RunClient {
             throw new TechnicalException(e);
         }
 
-        try (FileReader keyReader = new FileReader(file, StandardCharsets.UTF_8);
+        try (FileReader keyReader = new FileReader(file);
              PemReader pemReader = new PemReader(keyReader)) {
             PemObject pemObject = pemReader.readPemObject();
             byte[] content = pemObject.getContent();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -166,7 +166,8 @@ public class SAML2Client extends IndirectClient<SAML2Credentials> {
 
     protected void initSAMLLogoutResponseValidator() {
         this.logoutValidator = new SAML2LogoutValidator(this.signatureTrustEngineProvider,
-            this.decrypter, this.configuration.getLogoutHandler(), this.configuration.getPostLogoutURL(), this.replayCache);
+            this.decrypter, this.configuration.getLogoutHandler(),
+            this.configuration.getPostLogoutURL(), this.replayCache);
         this.logoutValidator.setAcceptedSkew(this.configuration.getAcceptedSkew());
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
@@ -103,7 +103,7 @@ public class SAML2MessageContext {
                 return service;
             }
         }
-        throw new SAMLException("Identity provider has no single logout service available for the selected profile"
+        throw new SAMLException("Identity provider has no single logout service available for the selected profile "
             + binding);
     }
 
@@ -114,7 +114,7 @@ public class SAML2MessageContext {
                 return service;
             }
         }
-        throw new SAMLException("Identity provider has no single sign on service available for the selected profile"
+        throw new SAMLException("Identity provider has no single sign on service available for the selected profile "
             + binding);
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -12,6 +12,7 @@ import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.OkAction;
 import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.context.SAML2MessageContext;
@@ -19,19 +20,28 @@ import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.impl.AbstractSAML2ResponseValidator;
 import org.pac4j.saml.replay.ReplayCacheProvider;
+import org.pac4j.saml.util.Configuration;
 
 import java.util.List;
 
 /**
  * Validator for SAML logout requests/responses from the IdP.
- * 
+ *
  * @author Matthieu Taggiasco
  * @author Jerome Leleu
  * @since 2.0.0
  */
 public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
 
-    private String postLogoutURL;
+    private final String postLogoutURL;
+
+    /**
+     * When set to false, will cause the validator
+     * to not throw back exceptions and expect adaptations of those exceptions
+     * when the response is successfully validated. Instead, the validator should successfully
+     * move on without throwing {@link OkAction}.
+     */
+    private boolean actionOnSuccess = true;
 
     public SAML2LogoutValidator(final SAML2SignatureTrustEngineProvider engine, final Decrypter decrypter,
                                 final LogoutHandler logoutHandler, final String postLogoutURL, final ReplayCacheProvider replayCache) {
@@ -47,31 +57,34 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     @Override
     public Credentials validate(final SAML2MessageContext context) {
         final SAMLObject message = (SAMLObject) context.getMessageContext().getMessage();
-
         // IDP-initiated
         if (message instanceof LogoutRequest) {
             final LogoutRequest logoutRequest = (LogoutRequest) message;
             final SignatureTrustEngine engine = this.signatureTrustEngineProvider.build();
             validateLogoutRequest(logoutRequest, context, engine);
-
             return null;
-
         } else if (message instanceof LogoutResponse) {
             // SP-initiated
             final LogoutResponse logoutResponse = (LogoutResponse) message;
             final SignatureTrustEngine engine = this.signatureTrustEngineProvider.build();
             validateLogoutResponse(logoutResponse, context, engine);
 
-            if (StringUtils.isNotBlank(postLogoutURL)){
-                // if custom post logout URL is present then redirect to it
-                throw new FoundAction(postLogoutURL);
-            } else {
-                // nothing to reply to the logout response
-                throw new OkAction("");
+            final HttpAction action = handlePostLogoutResponse(context);
+            if (action != null) {
+                throw action;
             }
-        } else {
-            throw new SAMLException("Must be a LogoutRequest or LogoutResponse type");
+            return null;
         }
+        throw new SAMLException("SAML message must be a LogoutRequest or LogoutResponse type");
+    }
+
+    protected HttpAction handlePostLogoutResponse(final SAML2MessageContext context) {
+        if (StringUtils.isNotBlank(postLogoutURL)) {
+            // if custom post logout URL is present then redirect to it
+            return new FoundAction(postLogoutURL);
+        }
+        // nothing to reply to the logout response
+        return this.actionOnSuccess ? new OkAction("") : null;
     }
 
     /**
@@ -82,8 +95,11 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
      * @param engine the signature engine
      */
     protected void validateLogoutRequest(final LogoutRequest logoutRequest, final SAML2MessageContext context,
-                                               final SignatureTrustEngine engine) {
+                                         final SignatureTrustEngine engine) {
 
+        if (logger.isTraceEnabled()) {
+            logger.trace("Validating logout request:\n{}", Configuration.serializeSamlObject(logoutRequest));
+        }
         validateSignatureIfItExists(logoutRequest.getSignature(), context, engine);
 
         // don't check because of CAS v5
@@ -109,6 +125,7 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
         final String sloKey = computeSloKey(sessionIndex, nameId);
         if (sloKey != null) {
             final String bindingUri = context.getSAMLBindingContext().getBindingUri();
+            logger.debug("Using SLO key {} as the session index with the binding uri {}", sloKey, bindingUri);
             if (SAMLConstants.SAML2_SOAP11_BINDING_URI.equals(bindingUri)) {
                 logoutHandler.destroySessionBack(context.getWebContext(), sloKey);
             } else {
@@ -127,6 +144,9 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     protected void validateLogoutResponse(final LogoutResponse logoutResponse, final SAML2MessageContext context,
                                                final SignatureTrustEngine engine) {
 
+        if (logger.isTraceEnabled()) {
+            logger.trace("Validating logout response:\n{}", Configuration.serializeSamlObject(logoutResponse));
+        }
         validateSuccess(logoutResponse.getStatus());
 
         validateSignatureIfItExists(logoutResponse.getSignature(), context, engine);
@@ -136,6 +156,10 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
         validateIssuerIfItExists(logoutResponse.getIssuer(), context);
 
         verifyEndpoint(context.getSPSSODescriptor().getSingleLogoutServices().get(0), logoutResponse.getDestination());
+    }
+
+    public void setActionOnSuccess(final boolean actionOnSuccess) {
+        this.actionOnSuccess = actionOnSuccess;
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
@@ -109,6 +109,9 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
             final String entityId = context.getSAMLPeerEntityContext().getEntityId();
             validateSignature(signature, entityId, engine);
             context.getSAMLPeerEntityContext().setAuthenticated(true);
+            logger.debug("Successfully validated signature for entity id {}", entityId);
+        } else {
+            logger.debug("Cannot locate a signature from the message; skipping validation");
         }
     }
 
@@ -122,8 +125,10 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
     protected void validateSignature(final Signature signature, final String idpEntityId,
                                      final SignatureTrustEngine trustEngine) {
 
+
         final SAMLSignatureProfileValidator validator = new SAMLSignatureProfileValidator();
         try {
+            logger.debug("Validating profile signature for entity id {}", idpEntityId);
             validator.validate(signature);
         } catch (final SignatureException e) {
             throw new SAMLSignatureValidationException("SAMLSignatureProfileValidator failed to validate signature", e);
@@ -136,6 +141,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         criteriaSet.add(new EntityIdCriterion(idpEntityId));
         final boolean valid;
         try {
+            logger.debug("Validating signature via trust engine for entity id {}", idpEntityId);
             valid = trustEngine.validate(signature, criteriaSet);
         } catch (final SecurityException e) {
             throw new SAMLSignatureValidationException("An error occurred during signature validation", e);
@@ -163,6 +169,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         }
 
         final String entityId = context.getSAMLPeerEntityContext().getEntityId();
+        logger.debug("Comparing issuer {} against {}", issuer.getValue(), entityId);
         if (entityId == null || !entityId.equals(issuer.getValue())) {
             throw new SAMLIssuerException("Issuer " + issuer.getValue() + " does not match idp entityId " + entityId);
         }
@@ -242,6 +249,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         }
 
         try {
+            logger.debug("Decrypting name id {}", encryptedId);
             final NameID decryptedId = (NameID) decrypter.decrypt(encryptedId);
             return decryptedId;
         } catch (final DecryptionException e) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/Configuration.java
@@ -74,7 +74,7 @@ public final class Configuration {
         final ServiceLoader<ConfigurationManager> configurationManagers = ServiceLoader.load(ConfigurationManager.class);
         final List<ConfigurationManager> configurationManagerList = new ArrayList();
         configurationManagers.forEach(configurationManagerList::add);
-        if (configurationManagerList.size() > 0) {
+        if (!configurationManagerList.isEmpty()) {
             configurationManagerList.sort(Configuration::compareManagers);
             configurationManagerList.get(0).configure();
         }
@@ -117,7 +117,7 @@ public final class Configuration {
         }
         return writer;
     }
-    
+
     public static Optional<XMLObject> deserializeSamlObject(final String obj) {
         try ( StringReader reader = new StringReader(obj)) {
             return Optional.of(XMLObjectSupport.unmarshallFromReader(Configuration.getParserPool(), reader));


### PR DESCRIPTION
This pull request,

- Relaxes the `SAML2LogoutValidator` to not throw back exceptions with an extra option, in scenarios where the logout response is successfully validated. By default, the general expectation is that such exceptions/actions need to be caught and adapted. This PR provides an option to remove the catch requirement, but does keep the default behavior.

- This is purely for extensions of pac4j SAML. On the CAS side, we will need to do some minor work to actually catch such exceptions and adapt them accordingly.

- This PR also fixes a few issues where JDK9+ APIs were used to build pac4j v4.

I will also post a separate pull request for master/v5 mostly cherry-picking from here.