### PR TITLE
Additional SAML enhancements

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -170,13 +170,8 @@ public class SAML2Client extends IndirectClient {
         this.authnResponseValidator = new SAML2AuthnResponseValidator(
                 this.signatureTrustEngineProvider,
                 this.decrypter,
-                this.configuration.getLogoutHandler(),
-                this.configuration.getMaximumAuthenticationLifetime(),
-                this.configuration.isWantsAssertionsSigned(),
-                this.configuration.isWantsResponsesSigned(),
                 this.replayCache,
-                this.configuration.isAllSignatureValidationDisabled(),
-                this.configuration.getUriComparator());
+                this.configuration);
         this.authnResponseValidator.setAcceptedSkew(this.configuration.getAcceptedSkew());
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -160,7 +160,8 @@ public class SAML2Client extends IndirectClient {
     protected void initSAMLLogoutResponseValidator() {
         this.logoutValidator = new SAML2LogoutValidator(this.signatureTrustEngineProvider,
             this.decrypter, this.configuration.getLogoutHandler(),
-            this.configuration.getPostLogoutURL(), this.replayCache);
+            this.configuration.getPostLogoutURL(), this.replayCache,
+            this.configuration.getUriComparator());
         this.logoutValidator.setAcceptedSkew(this.configuration.getAcceptedSkew());
     }
 
@@ -174,7 +175,8 @@ public class SAML2Client extends IndirectClient {
                 this.configuration.isWantsAssertionsSigned(),
                 this.configuration.isWantsResponsesSigned(),
                 this.replayCache,
-                this.configuration.isAllSignatureValidationDisabled());
+                this.configuration.isAllSignatureValidationDisabled(),
+                this.configuration.getUriComparator());
         this.authnResponseValidator.setAcceptedSkew(this.configuration.getAcceptedSkew());
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -1,5 +1,8 @@
 package org.pac4j.saml.config;
 
+import net.shibboleth.utilities.java.support.net.URIComparator;
+import net.shibboleth.utilities.java.support.net.impl.BasicURLComparator;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.HttpClient;
 import org.opensaml.core.xml.schema.XSAny;
 import org.opensaml.saml.common.xml.SAMLConstants;
@@ -24,6 +27,7 @@ import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
 import org.pac4j.saml.metadata.SAML2MetadataContactPerson;
 import org.pac4j.saml.metadata.SAML2MetadataGenerator;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
+import org.pac4j.saml.metadata.SAML2MetadataSigner;
 import org.pac4j.saml.metadata.SAML2MetadataUIInfo;
 import org.pac4j.saml.metadata.SAML2ServiceProviderRequestedAttribute;
 import org.pac4j.saml.metadata.keystore.SAML2FileSystemKeystoreGenerator;
@@ -71,6 +75,10 @@ public class SAML2Configuration extends BaseClientConfiguration {
     private static final Logger LOGGER = LoggerFactory.getLogger(SAML2Configuration.class);
 
     private final List<SAML2ServiceProviderRequestedAttribute> requestedServiceProviderAttributes = new ArrayList<>();
+
+    private SAML2MetadataSigner metadataSigner;
+
+    private String singleSignOutServiceUrl;
 
     private String callbackUrl;
 
@@ -159,6 +167,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
     private String attributeAsId;
 
     private Map<String, String> mappedAttributes = new LinkedHashMap<>();
+
+    private URIComparator uriComparator = new BasicURLComparator();
 
     private LogoutHandler logoutHandler;
 
@@ -582,6 +592,14 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.authnContextClassRefs = authnContextClassRefs;
     }
 
+    public URIComparator getUriComparator() {
+        return uriComparator;
+    }
+
+    public void setUriComparator(final URIComparator uriComparator) {
+        this.uriComparator = uriComparator;
+    }
+
     public String getNameIdPolicyFormat() {
         return nameIdPolicyFormat;
     }
@@ -716,6 +734,14 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.authnRequestExtensions = authnRequestExtensions;
     }
 
+    public SAML2MetadataSigner getMetadataSigner() {
+        return metadataSigner;
+    }
+
+    public void setMetadataSigner(final SAML2MetadataSigner metadataSigner) {
+        this.metadataSigner = metadataSigner;
+    }
+
     public String getAttributeAsId() {
         return attributeAsId;
     }
@@ -806,6 +832,14 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.issuerFormat = issuerFormat;
     }
 
+    public String getSingleSignOutServiceUrl() {
+        return singleSignOutServiceUrl;
+    }
+
+    public void setSingleSignOutServiceUrl(final String singleSignOutServiceUrl) {
+        this.singleSignOutServiceUrl = singleSignOutServiceUrl;
+    }
+
     public HttpClient getHttpClient() {
         if (httpClient == null) {
             httpClient = new SAML2HttpClientBuilder().build();
@@ -832,16 +866,14 @@ public class SAML2Configuration extends BaseClientConfiguration {
                 generator.setNameIdPolicyFormat(getNameIdPolicyFormat());
                 generator.setRequestedAttributes(getRequestedServiceProviderAttributes());
                 generator.setCredentialProvider(getCredentialProvider());
-
+                generator.setMetadataSigner(getMetadataSigner());
                 generator.setEntityId(getServiceProviderEntityId());
                 generator.setRequestInitiatorLocation(callbackUrl);
                 // Assertion consumer service url is the callback URL
                 generator.setAssertionConsumerServiceUrl(callbackUrl);
                 generator.setResponseBindingType(getResponseBindingType());
-                final String logoutUrl = CommonHelper.addParameter(callbackUrl,
-                    Pac4jConstants.LOGOUT_ENDPOINT_PARAMETER, "true");
-                // the logout URL is callback URL with an extra parameter
-                generator.setSingleLogoutServiceUrl(logoutUrl);
+
+                determineSingleSignOutServiceUrl(generator);
 
                 if (getBlackListedSignatureSigningAlgorithms() != null) {
                     generator.setBlackListedSignatureSigningAlgorithms(
@@ -858,6 +890,13 @@ public class SAML2Configuration extends BaseClientConfiguration {
         } catch (final Exception e) {
             throw new TechnicalException(e);
         }
+    }
+
+    protected void determineSingleSignOutServiceUrl(final BaseSAML2MetadataGenerator generator) {
+        final String url = StringUtils.defaultIfBlank(this.singleSignOutServiceUrl, callbackUrl);
+        final String logoutUrl = CommonHelper.addParameter(url, Pac4jConstants.LOGOUT_ENDPOINT_PARAMETER, "true");
+        // the logout URL is callback URL with an extra parameter
+        generator.setSingleLogoutServiceUrl(logoutUrl);
     }
 
     public SAML2MetadataGenerator getMetadataGenerator() throws Exception {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -114,7 +114,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private String spLogoutResponseBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
 
-    private List<String> authnContextClassRefs = null;
+    private List<String> authnContextClassRefs = new ArrayList<>();
 
     private String nameIdPolicyFormat = null;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -80,6 +80,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private String singleSignOutServiceUrl;
 
+    private String nameIdAttribute;
+
     private String callbackUrl;
 
     private Resource keystoreResource;
@@ -788,6 +790,14 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     public void setPostLogoutURL(final String postLogoutURL) {
         this.postLogoutURL = postLogoutURL;
+    }
+
+    public String getNameIdAttribute() {
+        return nameIdAttribute;
+    }
+
+    public void setNameIdAttribute(final String nameIdAttribute) {
+        this.nameIdAttribute = nameIdAttribute;
     }
 
     public LogoutHandler findLogoutHandler() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnContextClassRefException.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/exceptions/SAMLAuthnContextClassRefException.java
@@ -1,0 +1,23 @@
+package org.pac4j.saml.exceptions;
+
+/**
+ * This is {@link SAMLAuthnContextClassRefException}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+public class SAMLAuthnContextClassRefException extends SAMLException {
+    private static final long serialVersionUID = 8635812340829541343L;
+
+    public SAMLAuthnContextClassRefException(final String message) {
+        super(message);
+    }
+
+    public SAMLAuthnContextClassRefException(final Throwable t) {
+        super(t);
+    }
+
+    public SAMLAuthnContextClassRefException(final String message, final Throwable t) {
+        super(message, t);
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutResponseBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutResponseBuilder.java
@@ -5,7 +5,10 @@ import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.SAMLObjectBuilder;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.common.messaging.context.SAMLSelfEntityContext;
-import org.opensaml.saml.saml2.core.*;
+import org.opensaml.saml.saml2.core.Issuer;
+import org.opensaml.saml.saml2.core.LogoutResponse;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.core.impl.RequestAbstractTypeImpl;
 import org.opensaml.saml.saml2.core.impl.StatusCodeBuilder;
 import org.opensaml.saml.saml2.metadata.SingleLogoutService;
@@ -80,6 +83,10 @@ public class SAML2LogoutResponseBuilder {
         final Issuer issuer = issuerBuilder.buildObject();
         issuer.setValue(spEntityId);
         return issuer;
+    }
+
+    public void setBindingType(final String bindingType) {
+        this.bindingType = bindingType;
     }
 
     public void setIssueInstantSkewSeconds(final int issueInstantSkewSeconds) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.logout.impl;
 
+import net.shibboleth.utilities.java.support.net.URIComparator;
 import org.apache.commons.lang3.StringUtils;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.xml.SAMLConstants;
@@ -9,6 +10,7 @@ import org.opensaml.saml.saml2.core.LogoutResponse;
 import org.opensaml.saml.saml2.core.NameID;
 import org.opensaml.saml.saml2.core.SessionIndex;
 import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.exception.http.FoundAction;
@@ -22,7 +24,9 @@ import org.pac4j.saml.profile.impl.AbstractSAML2ResponseValidator;
 import org.pac4j.saml.replay.ReplayCacheProvider;
 import org.pac4j.saml.util.Configuration;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Validator for SAML logout requests/responses from the IdP.
@@ -43,10 +47,16 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
      */
     private boolean actionOnSuccess = true;
 
+    /**
+     * Expected destination endpoint when validating saml2 logout responses.
+     * If left blank, will use the SLO endpoint from metadata context.
+     */
+    private String expectedDestination;
+
     public SAML2LogoutValidator(final SAML2SignatureTrustEngineProvider engine, final Decrypter decrypter,
                                 final LogoutHandler logoutHandler, final String postLogoutURL,
-                                final ReplayCacheProvider replayCache) {
-        super(engine, decrypter, logoutHandler, replayCache);
+                                final ReplayCacheProvider replayCache, final URIComparator uriComparator) {
+        super(engine, decrypter, logoutHandler, replayCache, uriComparator);
         this.postLogoutURL = postLogoutURL;
     }
 
@@ -92,8 +102,8 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
      * Validates the SAML logout request.
      *
      * @param logoutRequest the logout request
-     * @param context the context
-     * @param engine the signature engine
+     * @param context       the context
+     * @param engine        the signature engine
      */
     protected void validateLogoutRequest(final LogoutRequest logoutRequest, final SAML2MessageContext context,
                                          final SignatureTrustEngine engine) {
@@ -139,11 +149,11 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
      * Validates the SAML logout response.
      *
      * @param logoutResponse the logout response
-     * @param context the context
-     * @param engine the signature engine
+     * @param context        the context
+     * @param engine         the signature engine
      */
     protected void validateLogoutResponse(final LogoutResponse logoutResponse, final SAML2MessageContext context,
-                                               final SignatureTrustEngine engine) {
+                                          final SignatureTrustEngine engine) {
 
         if (logger.isTraceEnabled()) {
             logger.trace("Validating logout response:\n{}", Configuration.serializeSamlObject(logoutResponse));
@@ -156,7 +166,23 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
 
         validateIssuerIfItExists(logoutResponse.getIssuer(), context);
 
-        verifyEndpoint(context.getSPSSODescriptor().getSingleLogoutServices().get(0), logoutResponse.getDestination());
+        validateDestinationEndpoint(logoutResponse, context);
+    }
+
+    protected void validateDestinationEndpoint(final LogoutResponse logoutResponse, final SAML2MessageContext context) {
+        final List<String> expected = new ArrayList<>();
+        if (StringUtils.isBlank(this.expectedDestination)) {
+            final Endpoint endpoint = Objects.requireNonNull(context.getSPSSODescriptor().getSingleLogoutServices().get(0));
+            if (endpoint.getLocation() != null) {
+                expected.add(endpoint.getLocation());
+            }
+            if (endpoint.getResponseLocation() != null) {
+                expected.add(endpoint.getResponseLocation());
+            }
+        } else {
+            expected.add(this.expectedDestination);
+        }
+        verifyEndpoint(expected, logoutResponse.getDestination());
     }
 
     public void setActionOnSuccess(final boolean actionOnSuccess) {
@@ -165,6 +191,10 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
 
     public void setPostLogoutURL(final String postLogoutURL) {
         this.postLogoutURL = postLogoutURL;
+    }
+
+    public void setExpectedDestination(final String expectedDestination) {
+        this.expectedDestination = expectedDestination;
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -208,8 +208,4 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     public String getExpectedDestination() {
         return expectedDestination;
     }
-
-    @Override
-    public final void setMaximumAuthenticationLifetime(final int maximumAuthenticationLifetime) {
-    }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -197,6 +197,18 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
         this.expectedDestination = expectedDestination;
     }
 
+    public String getPostLogoutURL() {
+        return postLogoutURL;
+    }
+
+    public boolean isActionOnSuccess() {
+        return actionOnSuccess;
+    }
+
+    public String getExpectedDestination() {
+        return expectedDestination;
+    }
+
     @Override
     public final void setMaximumAuthenticationLifetime(final int maximumAuthenticationLifetime) {
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -18,6 +18,7 @@ import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.OkAction;
 import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.impl.AbstractSAML2ResponseValidator;
@@ -124,6 +125,7 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
             nameId = decryptEncryptedId(encryptedID, decrypter);
         }
 
+        final SAML2Credentials.SAMLNameID samlNameId = SAML2Credentials.SAMLNameID.from(nameId);
         String sessionIndex = null;
         final List<SessionIndex> sessionIndexes = logoutRequest.getSessionIndexes();
         if (sessionIndexes != null && !sessionIndexes.isEmpty()) {
@@ -133,7 +135,7 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
             }
         }
 
-        final String sloKey = computeSloKey(sessionIndex, nameId);
+        final String sloKey = computeSloKey(sessionIndex, samlNameId);
         if (sloKey != null) {
             final String bindingUri = context.getSAMLBindingContext().getBindingUri();
             logger.debug("Using SLO key {} as the session index with the binding uri {}", sloKey, bindingUri);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSigner.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSigner.java
@@ -1,0 +1,49 @@
+package org.pac4j.saml.metadata;
+
+import org.opensaml.core.xml.io.MarshallingException;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.security.SecurityException;
+import org.opensaml.xmlsec.SignatureSigningParameters;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import org.opensaml.xmlsec.signature.support.SignatureException;
+import org.opensaml.xmlsec.signature.support.SignatureSupport;
+import org.pac4j.saml.crypto.CredentialProvider;
+import org.pac4j.saml.exceptions.SAMLException;
+
+/**
+ * This is {@link DefaultSAML2MetadataSigner}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+public class DefaultSAML2MetadataSigner implements SAML2MetadataSigner{
+    protected final CredentialProvider credentialProvider;
+
+    protected final String signatureAlgorithm;
+
+    protected final String signatureReferenceDigestMethod;
+
+    public DefaultSAML2MetadataSigner(final CredentialProvider credentialProvider,
+                                      final String signatureAlgorithm, final String signatureReferenceDigestMethod) {
+        this.credentialProvider = credentialProvider;
+        this.signatureAlgorithm = signatureAlgorithm;
+        this.signatureReferenceDigestMethod = signatureReferenceDigestMethod;
+    }
+
+    @Override
+    public void sign(final EntityDescriptor descriptor) {
+        final SignatureSigningParameters signingParameters = new SignatureSigningParameters();
+        signingParameters.setKeyInfoGenerator(credentialProvider.getKeyInfoGenerator());
+        signingParameters.setSigningCredential(credentialProvider.getCredential());
+        signingParameters.setSignatureAlgorithm(signatureAlgorithm);
+        signingParameters.setSignatureReferenceDigestMethod(signatureReferenceDigestMethod);
+        signingParameters.setSignatureCanonicalizationAlgorithm(
+            SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+
+        try {
+            SignatureSupport.signObject(descriptor, signingParameters);
+        } catch (final SecurityException | MarshallingException | SignatureException e) {
+            throw new SAMLException(e.getMessage(), e);
+        }
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
@@ -63,7 +63,12 @@ public class SAML2FileSystemMetadataGenerator extends BaseSAML2MetadataGenerator
             try (OutputStream spMetadataOutputStream = destination.getOutputStream()) {
                 spMetadataOutputStream.write(result.getWriter().toString().getBytes(StandardCharsets.UTF_8));
             }
-            return destination.exists();
+            if (destination.exists()) {
+                if (isSignMetadata()) {
+                    getMetadataSigner().sign(metadataResource.getFile());
+                }
+                return true;
+            }
         }
         return false;
     }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataSigner.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataSigner.java
@@ -1,0 +1,17 @@
+package org.pac4j.saml.metadata;
+
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+
+import java.io.File;
+
+/**
+ * This is {@link SAML2MetadataSigner}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+public interface SAML2MetadataSigner {
+    default void sign(final EntityDescriptor descriptor) {}
+
+    default void sign(final File metadataFile) {}
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/XMLSecSAML2MetadataSigner.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/XMLSecSAML2MetadataSigner.java
@@ -1,0 +1,50 @@
+package org.pac4j.saml.metadata;
+
+import net.shibboleth.tool.xmlsectool.XMLSecTool;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.exceptions.SAMLException;
+
+import java.io.File;
+
+/**
+ * This is {@link XMLSecSAML2MetadataSigner}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+public class XMLSecSAML2MetadataSigner implements SAML2MetadataSigner {
+    private final SAML2Configuration configuration;
+
+    public XMLSecSAML2MetadataSigner(final SAML2Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void sign(final File metadata) {
+        try {
+            final String[] args = {
+                "--sign",
+                "--referenceIdAttributeName",
+                "ID",
+                "--signatureAlgorithm",
+                SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256,
+                "--inFile",
+                metadata.getCanonicalPath(),
+                "--keystore",
+                configuration.getKeystoreResource().getFile().getCanonicalPath(),
+                "--keystorePassword",
+                configuration.getKeystorePassword(),
+                "--keyAlias",
+                configuration.getKeyStoreAlias(),
+                "--keyPassword",
+                configuration.getPrivateKeyPassword(),
+                "--outFile",
+                metadata.getCanonicalPath()
+            };
+            XMLSecTool.main(args);
+        } catch (final Exception e) {
+            throw new SAMLException(e);
+        }
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/api/SAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/api/SAML2ResponseValidator.java
@@ -20,7 +20,5 @@ public interface SAML2ResponseValidator {
      */
     Credentials validate(SAML2MessageContext context);
 
-    void setMaximumAuthenticationLifetime(int maximumAuthenticationLifetime);
-
     void setAcceptedSkew(int acceptedSkew);
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -27,7 +27,7 @@ import java.util.Optional;
  */
 public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiver {
 
-    protected final SAML2ResponseValidator validator;
+    protected SAML2ResponseValidator validator;
 
     public AbstractSAML2MessageReceiver(final SAML2ResponseValidator validator) {
         this.validator = validator;
@@ -92,6 +92,10 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
         decodedCtx.setSessionStore(context.getSessionStore());
 
         return this.validator.validate(decodedCtx);
+    }
+
+    public void setValidator(final SAML2ResponseValidator validator) {
+        this.validator = validator;
     }
 
     protected abstract Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
@@ -28,6 +28,7 @@ import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
 import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.exceptions.SAMLEndpointMismatchException;
 import org.pac4j.saml.exceptions.SAMLException;
@@ -259,10 +260,12 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         }
     }
 
-    protected String computeSloKey(final String sessionIndex, final NameID nameId) {
+    protected String computeSloKey(final String sessionIndex, final SAML2Credentials.SAMLNameID nameId) {
         if (sessionIndex != null) {
             return sessionIndex;
-        } else if (nameId != null) {
+        }
+
+        if (nameId != null) {
             return nameId.getValue();
         }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
@@ -57,8 +57,8 @@ public class SAML2CredentialsSerializationTests {
         attr.setName("pac4j");
         attr.setNameFormat("pac4j");
         attributes.add(attr);
-        final SAML2Credentials credentials = new SAML2Credentials(nameid, "example.issuer.com",
-            attributes, conditions, "session-index", contexts);
+        final SAML2Credentials credentials = new SAML2Credentials(SAML2Credentials.SAMLNameID.from(nameid), "example.issuer.com",
+            SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts);
         final byte[] data = SerializationUtils.serialize(credentials);
         final SAML2Credentials result = (SAML2Credentials) SerializationUtils.deserialize(data);
         assertNotNull(result);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
@@ -60,8 +60,9 @@ public class SAML2AuthenticatorTests {
         attributes.add(createAttribute("givenName", "urn:oid:2.5.4.42", "developer"));
         attributes.add(createAttribute("surname", "urn:oid:2.5.4.4", "security"));
 
-        final SAML2Credentials credentials = new SAML2Credentials(nameid, "example.issuer.com",
-            attributes, conditions, "session-index", contexts);
+        final SAML2Credentials credentials = new SAML2Credentials(SAML2Credentials.SAMLNameID.from(nameid),
+            "example.issuer.com",
+            SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts);
 
         final Map<String, String> mappedAttributes = new LinkedHashMap<>();
         mappedAttributes.put("urn:oid:2.16.840.1.113730.3.1.241", "mapped-display-name");

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiverTest.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.logout.impl;
 
+import net.shibboleth.utilities.java.support.net.impl.BasicURLComparator;
 import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 import org.opensaml.saml.saml2.encryption.Decrypter;
@@ -111,7 +112,8 @@ public class SAML2LogoutMessageReceiverTest {
             mock(Decrypter.class),
             mock(LogoutHandler.class),
             postLogoutUrl,
-            mock(ReplayCacheProvider.class)
+            mock(ReplayCacheProvider.class),
+            new BasicURLComparator()
         );
         return validator;
     }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -20,7 +20,7 @@ import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
 import org.pac4j.saml.metadata.SAML2ServiceProviderMetadataResolver;
 import org.pac4j.saml.replay.ReplayCacheProvider;
 import org.pac4j.saml.util.Configuration;
-import org.pac4j.saml.util.HostOnlyURIComparator;
+import org.pac4j.saml.util.ExcludingParametersURIComparator;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 
@@ -101,7 +101,7 @@ public class SAML2LogoutValidatorTests {
                 mock(LogoutHandler.class),
                 null,
                 mock(ReplayCacheProvider.class),
-                new HostOnlyURIComparator()
+                new ExcludingParametersURIComparator()
             );
             validator.setActionOnSuccess(false);
             validator.validate(context);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -1,0 +1,112 @@
+package org.pac4j.saml.logout.impl;
+
+import org.junit.Test;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.saml2.core.LogoutResponse;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.SingleLogoutService;
+import org.opensaml.saml.saml2.metadata.impl.EntityDescriptorBuilder;
+import org.opensaml.saml.saml2.metadata.impl.SPSSODescriptorBuilder;
+import org.opensaml.saml.saml2.metadata.impl.SingleLogoutServiceBuilder;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.logout.handler.LogoutHandler;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.crypto.ExplicitSignatureTrustEngineProvider;
+import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
+import org.pac4j.saml.metadata.SAML2ServiceProviderMetadataResolver;
+import org.pac4j.saml.replay.ReplayCacheProvider;
+import org.pac4j.saml.util.Configuration;
+import org.pac4j.saml.util.HostOnlyURIComparator;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+/**
+ * This is {@link SAML2LogoutValidatorTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+public class SAML2LogoutValidatorTests {
+    private static ExplicitSignatureTrustEngineProvider getTrustEngine() {
+        final SAML2Configuration config = new SAML2Configuration();
+        config.setForceKeystoreGeneration(true);
+        config.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        config.setServiceProviderMetadataResource(new FileSystemResource("target/out.xml"));
+        config.setForceServiceProviderMetadataGeneration(true);
+        config.setKeystorePath("target/keystore.jks");
+        config.setKeystorePassword("pac4j");
+        config.setPrivateKeyPassword("pac4j");
+        config.init();
+
+        SAML2IdentityProviderMetadataResolver idp = new SAML2IdentityProviderMetadataResolver(config);
+        idp.init();
+        SAML2ServiceProviderMetadataResolver sp = new SAML2ServiceProviderMetadataResolver(config);
+        return new ExplicitSignatureTrustEngineProvider(idp, sp);
+    }
+
+    private static MockWebContext getMockWebContext() {
+        return MockWebContext.create();
+    }
+
+    private static SAML2MessageContext getSaml2MessageContext(final MockWebContext webContext) {
+        final SAML2MessageContext context = new SAML2MessageContext();
+
+        final MessageContext samlMessage = new MessageContext();
+        final String xml = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+            "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+            "IssueInstant=\"" + ZonedDateTime.now(ZoneOffset.UTC)
+            + "\" Destination=\"http://sp.example.com/demo1/logout?x=1000%26y=1234\" " +
+            "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
+            "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
+            "  <samlp:Status>%n" +
+            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>%n" +
+            "  </samlp:Status>%n" +
+            "</samlp:LogoutResponse>";
+        final LogoutResponse samlResponse = (LogoutResponse) Configuration.deserializeSamlObject(xml).get();
+
+        samlMessage.setMessage(samlResponse);
+        context.setMessageContext(samlMessage);
+        final EntityDescriptor entityDescriptor = new EntityDescriptorBuilder().buildObject();
+        context.getSAMLPeerMetadataContext().setEntityDescriptor(entityDescriptor);
+        context.setWebContext(webContext);
+        context.setSessionStore(new MockSessionStore());
+
+        final SPSSODescriptor spDescriptor = new SPSSODescriptorBuilder().buildObject();
+        final SingleLogoutService logoutService = new SingleLogoutServiceBuilder().buildObject();
+        logoutService.setLocation("http://sp.example.com/demo1/logout");
+        spDescriptor.getSingleLogoutServices().add(logoutService);
+        context.getSAMLSelfMetadataContext().setRoleDescriptor(spDescriptor);
+        return context;
+    }
+
+    @Test
+    public void verifyHostComparison() {
+        try {
+            final MockWebContext webContext = getMockWebContext();
+            final SAML2MessageContext context = getSaml2MessageContext(webContext);
+            final SAML2LogoutValidator validator = new SAML2LogoutValidator(
+                getTrustEngine(),
+                mock(Decrypter.class),
+                mock(LogoutHandler.class),
+                null,
+                mock(ReplayCacheProvider.class),
+                new HostOnlyURIComparator()
+            );
+            validator.setActionOnSuccess(false);
+            validator.validate(context);
+        } catch (final Exception e) {
+            fail(e.getMessage());
+        }
+    }
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/XMLSecSAML2MetadataSignerTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/XMLSecSAML2MetadataSignerTests.java
@@ -1,0 +1,46 @@
+package org.pac4j.saml.metadata;
+
+import org.junit.Test;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.util.ConfigurationManager;
+import org.pac4j.saml.util.DefaultConfigurationManager;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This is {@link XMLSecSAML2MetadataSignerTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+public class XMLSecSAML2MetadataSignerTests {
+    @Test
+    public void verifyGeneration() throws Exception {
+        final ConfigurationManager mgr = new DefaultConfigurationManager();
+        mgr.configure();
+
+        final SAML2Configuration configuration = new SAML2Configuration();
+        configuration.setForceKeystoreGeneration(true);
+        configuration.setKeystorePath("target/keystore.jks");
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+        configuration.setSignMetadata(true);
+        configuration.setServiceProviderMetadataResource(new FileSystemResource("target/out.xml"));
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.setMetadataSigner(new XMLSecSAML2MetadataSigner(configuration));
+        configuration.init();
+
+
+        final SAML2MetadataGenerator metadataGenerator = configuration.toMetadataGenerator();
+        final EntityDescriptor entity = metadataGenerator.buildEntityDescriptor();
+        assertNotNull(entity);
+        final String metadata = metadataGenerator.getMetadata(entity);
+        assertNotNull(metadata);
+
+        metadataGenerator.storeMetadata(metadata, configuration.getServiceProviderMetadataResource(), true);
+        assertNotNull(metadataGenerator.buildMetadataResolver(configuration.getServiceProviderMetadataResource()));
+    }
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -1,21 +1,45 @@
 package org.pac4j.saml.sso.impl;
 
-import net.shibboleth.utilities.java.support.net.impl.BasicURLComparator;
+import net.shibboleth.utilities.java.support.codec.Base64Support;
+import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
+import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.junit.Test;
+import org.opensaml.core.xml.XMLObject;
+import org.opensaml.core.xml.io.UnmarshallingException;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.common.messaging.context.SAMLEndpointContext;
 import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
 import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
+import org.opensaml.saml.common.messaging.context.SAMLSelfEntityContext;
+import org.opensaml.saml.saml2.core.AuthnContext;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.core.SubjectConfirmation;
 import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.Endpoint;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
+import org.opensaml.saml.saml2.metadata.impl.AssertionConsumerServiceImpl;
+import org.opensaml.security.SecurityException;
+import org.opensaml.xmlsec.signature.Signature;
+import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.JEEContext;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.JEESessionStore;
+import org.pac4j.core.logout.handler.LogoutHandler;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.exceptions.SAMLAuthnContextClassRefException;
 import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.exceptions.SAMLSignatureValidationException;
 import org.pac4j.saml.replay.InMemoryReplayCacheProvider;
-
-import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.pac4j.saml.util.Configuration;
+import org.pac4j.saml.util.ExcludingParametersURIComparator;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -26,58 +50,82 @@ import java.nio.charset.Charset;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Collections;
-import net.shibboleth.utilities.java.support.codec.Base64Support;
-import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
-import net.shibboleth.utilities.java.support.xml.XMLParserException;
-import org.opensaml.core.xml.XMLObject;
-import org.opensaml.core.xml.io.UnmarshallingException;
-import org.opensaml.core.xml.util.XMLObjectSupport;
-import org.opensaml.saml.saml2.core.Response;
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.saml.saml2.metadata.impl.AssertionConsumerServiceImpl;
-import org.opensaml.security.SecurityException;
-import org.opensaml.xmlsec.signature.Signature;
-import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
-import org.pac4j.core.context.HttpConstants;
-import org.pac4j.core.context.JEEContext;
-import org.pac4j.core.context.WebContext;
-import org.pac4j.core.logout.handler.LogoutHandler;
-import org.pac4j.saml.exceptions.SAMLSignatureValidationException;
-import org.pac4j.saml.util.Configuration;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class SAML2DefaultResponseValidatorTests {
 
     private static final String SAMPLE_RESPONSE_FILE_NAME = "sample_authn_response.xml";
 
-    @Test
-    public void testAssertionConsumingServiceWithMultipleIDP() throws Exception {
+    private static SAML2AuthnResponseValidator createResponseValidatorWithSigningValidationOf(final SAML2Configuration saml2Configuration) {
+        final SAML2SignatureTrustEngineProvider trustEngineProvider = mock(SAML2SignatureTrustEngineProvider.class);
+        final SignatureTrustEngine engine = mock(SignatureTrustEngine.class);
+
+        try {
+            when(engine.validate(any(Signature.class), any(CriteriaSet.class))).thenReturn(true);
+        } catch (final SecurityException ex) {
+            fail();
+        }
+        when(trustEngineProvider.build()).thenReturn(engine);
+        final Decrypter decrypter = mock(Decrypter.class);
+        return new SAML2AuthnResponseValidator(
+            trustEngineProvider,
+            decrypter,
+            new InMemoryReplayCacheProvider(),
+            saml2Configuration);
+    }
+
+    protected static SAML2Configuration getSaml2Configuration(final boolean wantsAssertionsSigned, final boolean wantsResponsesSigned) {
+        final SAML2Configuration cfg =
+            new SAML2Configuration(new FileSystemResource("target/samlKeystore.jks"),
+                "pac4j-demo-passwd",
+                "pac4j-demo-passwd",
+                new ClassPathResource("testshib-providers.xml"));
+
+        cfg.setMaximumAuthenticationLifetime(3600);
+        cfg.setServiceProviderEntityId("urn:mace:saml:pac4j.org");
+        cfg.setForceServiceProviderMetadataGeneration(true);
+        cfg.setForceKeystoreGeneration(true);
+        cfg.setWantsAssertionsSigned(wantsAssertionsSigned);
+        cfg.setWantsResponsesSigned(wantsResponsesSigned);
+        cfg.setLogoutHandler(mock(LogoutHandler.class));
+        cfg.setServiceProviderMetadataResource(new FileSystemResource(new File("target", "sp-metadata.xml").getAbsolutePath()));
+        return cfg;
+    }
+
+    private static Response getResponse() throws Exception {
         final File file = new File(SAML2DefaultResponseValidatorTests.class.getClassLoader().
-                getResource(SAMPLE_RESPONSE_FILE_NAME).getFile());
+            getResource(SAMPLE_RESPONSE_FILE_NAME).getFile());
 
         final XMLObject xmlObject = XMLObjectSupport.unmarshallFromReader(
-                Configuration.getParserPool(),
-                new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
+            Configuration.getParserPool(),
+            new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
 
         final Response response = (Response) xmlObject;
         response.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
         response.getAssertions().forEach(assertion -> {
             assertion.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+            assertion.getSubject().getSubjectConfirmations().get(0).setMethod(SubjectConfirmation.METHOD_BEARER);
             assertion.getSubject().getSubjectConfirmations().get(0).
-                    getSubjectConfirmationData().setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+                getSubjectConfirmationData().setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
             assertion.getConditions().setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
             assertion.getAuthnStatements().forEach(authnStatement -> authnStatement.setAuthnInstant(
                 ZonedDateTime.now(ZoneOffset.UTC).toInstant()));
         });
+        return response;
+    }
 
-        final ByteArrayOutputStream os = new ByteArrayOutputStream();
-        XMLObjectSupport.marshallToOutputStream(xmlObject, os);
-
+    @Test
+    public void testAssertionConsumingServiceWithMultipleIDP() throws Exception {
+        final Response response = getResponse();
         // create response validator enforcing response signature
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false, true);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(false, true));
         final SAML2MessageContext context = new SAML2MessageContext();
         context.getMessageContext().setMessage(response);
+
+        final ByteArrayOutputStream os = new ByteArrayOutputStream();
+        XMLObjectSupport.marshallToOutputStream(response, os);
 
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setMethod(HttpConstants.HTTP_METHOD.POST.name());
@@ -99,9 +147,9 @@ public class SAML2DefaultResponseValidatorTests {
         context.getSAMLPeerEntityContext().setAuthenticated(true);
 
         final AssertionConsumerServiceImpl acs = new AssertionConsumerServiceImpl(
-                response.getDestination(),
-                response.getDestination(),
-                response.getDestination()) {
+            response.getDestination(),
+            response.getDestination(),
+            response.getDestination()) {
         };
         acs.setLocation("https://auth.izslt.it/cas/login?client_name=idptest");
 
@@ -115,45 +163,19 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test
     public void testDoesNotWantAssertionsSignedWithNullContext() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(false, false));
         assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(null));
-    }
-
-    private SAML2AuthnResponseValidator createResponseValidatorWithSigningValidationOf(
-        final boolean wantsAssertionsSigned, final boolean wantsResponsesSigned) {
-        final SAML2SignatureTrustEngineProvider trustEngineProvider = mock(SAML2SignatureTrustEngineProvider.class);
-        final LogoutHandler logoutHandler = mock(LogoutHandler.class);
-        final SignatureTrustEngine engine = mock(SignatureTrustEngine.class);
-
-        try {
-            when(engine.validate(any(Signature.class), any(CriteriaSet.class))).thenReturn(true);
-        } catch (final SecurityException ex) {
-            fail();
-        }
-        when(trustEngineProvider.build()).thenReturn(engine);
-        final Decrypter decrypter = mock(Decrypter.class);
-
-        return new SAML2AuthnResponseValidator(
-                trustEngineProvider,
-                decrypter,
-                logoutHandler,
-                0,
-                wantsAssertionsSigned,
-                wantsResponsesSigned,
-                new InMemoryReplayCacheProvider(),
-                false,
-                new BasicURLComparator());
     }
 
     @Test
     public void testWantsAssertionsSignedWithNullContext() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(true, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(true, false));
         assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(null));
     }
 
     @Test
     public void testDoesNotWantAssertionsSignedWithNullSPSSODescriptor() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(false, false));
         final SAML2MessageContext context = new SAML2MessageContext();
         assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
         assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(context));
@@ -161,7 +183,7 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test
     public void testWantsAssertionsSignedWithNullSPSSODescriptor() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(true, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(true, false));
         final SAML2MessageContext context = new SAML2MessageContext();
         assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
         assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
@@ -169,7 +191,7 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test
     public void testDoesNotWantAssertionsSignedWithValidSPSSODescriptor() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(false, false));
         final SAML2MessageContext context = new SAML2MessageContext();
 
         final SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
@@ -183,7 +205,7 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test
     public void testWantsAssertionsSignedWithValidSPSSODescriptor() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(true, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(true, false));
         final SAML2MessageContext context = new SAML2MessageContext();
 
         final SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
@@ -195,9 +217,37 @@ public class SAML2DefaultResponseValidatorTests {
         assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
     }
 
+
+    @Test
+    public void testAuthnContextClassRefValidation() throws Exception {
+        final SAML2Configuration saml2Configuration = getSaml2Configuration(false, false);
+        saml2Configuration.setUriComparator(new ExcludingParametersURIComparator());
+        saml2Configuration.getAuthnContextClassRefs().add(AuthnContext.PASSWORD_AUTHN_CTX);
+        saml2Configuration.getAuthnContextClassRefs().add(AuthnContext.PPT_AUTHN_CTX);
+
+        final Response response = getResponse();
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
+        final SAML2MessageContext context = new SAML2MessageContext();
+        context.getMessageContext().setMessage(response);
+
+        final SAMLSelfEntityContext samlSelfEntityContext = context.getSAMLSelfEntityContext();
+        samlSelfEntityContext.setEntityId("https://auth.izslt.it");
+        final SAMLMetadataContext samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
+        final SPSSODescriptor roleDescriptor = mock(SPSSODescriptor.class);
+        when(roleDescriptor.getWantAssertionsSigned()).thenReturn(false);
+        samlSelfMetadataContext.setRoleDescriptor(roleDescriptor);
+
+        final SAMLEndpointContext samlEndpointContext = context.getSAMLEndpointContext();
+        final Endpoint endpoint = mock(Endpoint.class);
+        when(endpoint.getLocation()).thenReturn("https://auth.izslt.it/cas/login?client_name=idptest");
+        samlEndpointContext.setEndpoint(endpoint);
+
+        assertThrows(SAMLAuthnContextClassRefException.class, () -> validator.validate(context));
+    }
+
     @Test(expected = SAMLException.class)
     public void testAuthenticatedResponseAndAssertionWithoutSignatureThrowsException() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(true, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(true, false));
         final SAML2MessageContext context = new SAML2MessageContext();
         final SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
         peerEntityContext.setAuthenticated(true);
@@ -207,7 +257,7 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test(expected = SAMLException.class)
     public void testResponseWithoutSignatureThrowsException() {
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false, false);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(false, false));
         final SAML2MessageContext context = new SAML2MessageContext();
         final SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
         peerEntityContext.setAuthenticated(false);
@@ -218,18 +268,18 @@ public class SAML2DefaultResponseValidatorTests {
 
     @Test(expected = SAMLSignatureValidationException.class)
     public void testNotSignedAuthenticatedResponseThrowsException()
-            throws FileNotFoundException, XMLParserException, UnmarshallingException {
+        throws FileNotFoundException, XMLParserException, UnmarshallingException {
         final File file = new File(SAML2DefaultResponseValidatorTests.class.getClassLoader().
-                getResource(SAMPLE_RESPONSE_FILE_NAME).getFile());
+            getResource(SAMPLE_RESPONSE_FILE_NAME).getFile());
 
         final XMLObject xmlObject = XMLObjectSupport.unmarshallFromReader(
-                Configuration.getParserPool(),
-                new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
+            Configuration.getParserPool(),
+            new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
 
         final Response response = (Response) xmlObject;
         response.setSignature(null);
 
-        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(false, true);
+        final SAML2AuthnResponseValidator validator = createResponseValidatorWithSigningValidationOf(getSaml2Configuration(false, true));
         final SAML2MessageContext context = new SAML2MessageContext();
         final SAMLPeerEntityContext peerEntityContext = new SAMLPeerEntityContext();
         peerEntityContext.setAuthenticated(true);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.sso.impl;
 
+import net.shibboleth.utilities.java.support.net.impl.BasicURLComparator;
 import org.junit.Test;
 import org.opensaml.saml.common.messaging.context.SAMLMetadataContext;
 import org.opensaml.saml.common.messaging.context.SAMLPeerEntityContext;
@@ -140,7 +141,8 @@ public class SAML2DefaultResponseValidatorTests {
                 wantsAssertionsSigned,
                 wantsResponsesSigned,
                 new InMemoryReplayCacheProvider(),
-                false);
+                false,
+                new BasicURLComparator());
     }
 
     @Test

--- a/pac4j-saml/src/test/java/org/pac4j/saml/util/ExcludingParametersURIComparator.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/util/ExcludingParametersURIComparator.java
@@ -7,12 +7,12 @@ import org.apache.http.client.utils.URIBuilder;
 import javax.annotation.Nullable;
 
 /**
- * This is {@link HostOnlyURIComparator}.
+ * This is {@link ExcludingParametersURIComparator}.
  *
  * @author Misagh Moayyed
  * @since 6.4.0
  */
-public class HostOnlyURIComparator implements URIComparator {
+public class ExcludingParametersURIComparator implements URIComparator {
     @Override
     public boolean compare(@Nullable final String destination, @Nullable final String endpoint) throws URIException {
         try {

--- a/pac4j-saml/src/test/java/org/pac4j/saml/util/HostOnlyURIComparator.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/util/HostOnlyURIComparator.java
@@ -1,0 +1,26 @@
+package org.pac4j.saml.util;
+
+import net.shibboleth.utilities.java.support.net.URIComparator;
+import net.shibboleth.utilities.java.support.net.URIException;
+import org.apache.http.client.utils.URIBuilder;
+
+import javax.annotation.Nullable;
+
+/**
+ * This is {@link HostOnlyURIComparator}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.4.0
+ */
+public class HostOnlyURIComparator implements URIComparator {
+    @Override
+    public boolean compare(@Nullable final String destination, @Nullable final String endpoint) throws URIException {
+        try {
+            final String destinationWithoutParams = new URIBuilder(destination).clearParameters().toString();
+            final String endpointWithoutParams = new URIBuilder(endpoint).clearParameters().toString();
+            return destinationWithoutParams.equalsIgnoreCase(endpointWithoutParams);
+        } catch (final Exception e) {
+            throw new URIException(e);
+        }
+    }
+}


### PR DESCRIPTION
This pull request contains the following set of changes, all of which generally improve or enhance the pac4j-saml functionality:

- Signing operations for metadata can now be done using the existing default method, or via XMLSec. Using XMLSec generally tends to work better with strict validators specially in govt-related projects.
- Additional checks to validate requests/responses.
- Ability to specify the SLO url in the configuration and metadata.
- Options to determine how to URLs should be compared when doing endpoint verifications.
- Logout validation can be given an expected destination so as to not just rely on the SLO endpoint (since the SLO endpoint usually is based on the callback URL, unless one specified a new URL which is a new option in this PR)
- Requested authentication context class refs are now checked again in SAML responses
- Test cases to verify critical areas.

