### PR TITLE
Default samesite policy to Lax

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContextHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContextHelper.java
@@ -135,6 +135,8 @@ public final class WebContextHelper implements HttpConstants {
 
     /**
      * Custom method for adding cookie because the servlet-api version doesn't support SameSite attributes.
+     * Sets the default SameSite policy to lax which is what most browsers do if the cookie doesn't specify
+     * a SameSite policy.
      * @param cookie pac4j Cookie object
      */
     public static String createCookieHeader(Cookie cookie) {
@@ -153,17 +155,17 @@ public final class WebContextHelper implements HttpConstants {
         }
         builder.append(String.format(" Path=%s;", CommonHelper.isNotBlank(cookie.getPath()) ? cookie.getPath() : "/"));
 
-        var sameSitePolicy = cookie.getSameSitePolicy() == null ? "none" : cookie.getSameSitePolicy().toLowerCase();
+        var sameSitePolicy = cookie.getSameSitePolicy() == null ? "lax" : cookie.getSameSitePolicy().toLowerCase();
         switch (sameSitePolicy) {
             case "strict":
                 builder.append(" SameSite=Strict;");
                 break;
-            case "lax":
-                builder.append(" SameSite=Lax;");
-                break;
             case "none":
-            default:
                 builder.append(" SameSite=None;");
+                break;
+            case "lax":
+            default:
+                builder.append(" SameSite=Lax;");
                 break;
         }
         if (cookie.isSecure() || "none".equals(sameSitePolicy)) {

--- a/pac4j-core/src/test/java/org/pac4j/core/context/JEEContextTest.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/JEEContextTest.java
@@ -91,17 +91,17 @@ public final class JEEContextTest implements TestsConstants {
         final var context = new JEEContext(request, mockResponse);
         Cookie c = new Cookie("thename","thevalue");
         context.addResponseCookie(c);
-        assertEquals("thename=thevalue; Path=/; Secure; SameSite=None", mockResponse.getHeader("Set-Cookie"));
+        assertEquals("thename=thevalue; Path=/; SameSite=Lax", mockResponse.getHeader("Set-Cookie"));
     }
 
     @Test
-    public void testCookieLax() {
+    public void testCookieNone() {
         HttpServletResponse mockResponse = new MockHttpServletResponse();
         final var context = new JEEContext(request, mockResponse);
         Cookie c = new Cookie("thename","thevalue");
-        c.setSameSitePolicy("LAX");
+        c.setSameSitePolicy("NONE");
         context.addResponseCookie(c);
-        assertEquals("thename=thevalue; Path=/; SameSite=Lax", mockResponse.getHeader("Set-Cookie"));
+        assertEquals("thename=thevalue; Path=/; Secure; SameSite=None", mockResponse.getHeader("Set-Cookie"));
     }
 
     @Test
@@ -123,7 +123,7 @@ public final class JEEContextTest implements TestsConstants {
         c.setMaxAge(1000);
         context.addResponseCookie(c);
         assertTrue(mockResponse.getHeader("Set-Cookie").matches(
-            "thename=thevalue; Path=/; Max-Age=1000; Expires=.* GMT; Secure; SameSite=None"));
+            "thename=thevalue; Path=/; Max-Age=1000; Expires=.* GMT; SameSite=Lax"));
     }
 
 


### PR DESCRIPTION
This changes the default SameSite policy to lax. Chrome sets policy to Lax by default if no policy is set, but in Firefox the default is configurable via a property and I believe the `network.cookie.sameSite.laxByDefault` is false by default. IE doesn't support SameSite at all. I don't feel strongly about what the default should be but I think this document says the "standard" was recently changed to use Lax if a policy isn't specified. The standard isn't really being followed by all browsers though. 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#samesitenone_requires_secure

```
Standards related to the Cookie SameSite attribute recently changed such that:

The cookie-sending behavior if SameSite is not specified is SameSite=Lax. Previously the default was that cookies were sent for all requests.

Cookies with SameSite=None must now also specify the Secure attribute (they require a secure context/HTTPS).

```