### PR TITLE
[4.4.x] Align used signature algorithm with provided

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/keystore/BaseSAML2KeystoreGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/keystore/BaseSAML2KeystoreGenerator.java
@@ -4,15 +4,14 @@ import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Encoding;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.DERBitString;
-import org.bouncycastle.asn1.DERNull;
 import org.bouncycastle.asn1.DERSequence;
-import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.asn1.x509.TBSCertificate;
 import org.bouncycastle.asn1.x509.Time;
 import org.bouncycastle.asn1.x509.V3TBSCertificateGenerator;
+import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
 import org.joda.time.DateTime;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.config.SAML2Configuration;
@@ -79,10 +78,10 @@ public abstract class BaseSAML2KeystoreGenerator implements SAML2KeystoreGenerat
             kpg.initialize(saml2Configuration.getPrivateKeySize());
             final KeyPair kp = kpg.genKeyPair();
 
-            final AlgorithmIdentifier sigAlgID = new AlgorithmIdentifier(PKCSObjectIdentifiers.sha1WithRSAEncryption, DERNull.INSTANCE);
+            final String sigAlg = saml2Configuration.getCertificateSignatureAlg();
+            final AlgorithmIdentifier sigAlgID = new DefaultSignatureAlgorithmIdentifierFinder().find(sigAlg);
             final String dn = InetAddress.getLocalHost().getHostName();
-            final X509Certificate certificate = createSelfSignedCert(new X500Name("CN=" + dn),
-                saml2Configuration.getCertificateSignatureAlg(), sigAlgID, kp);
+            final X509Certificate certificate = createSelfSignedCert(new X500Name("CN=" + dn), sigAlg, sigAlgID, kp);
 
             final char[] keyPassword = saml2Configuration.getPrivateKeyPassword().toCharArray();
             final PrivateKey signingKey = kp.getPrivate();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGeneratorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2FileSystemKeystoreGeneratorTests.java
@@ -24,6 +24,7 @@ public class SAML2FileSystemKeystoreGeneratorTests {
         mgr.configure();
 
         final SAML2Configuration configuration = new SAML2Configuration();
+        configuration.setCertificateSignatureAlg("SHA256withRSA");
         configuration.setForceKeystoreGeneration(true);
         configuration.setKeystorePath("target/keystore.jks");
         configuration.setKeystorePassword("pac4j");

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2HttpUrlKeystoreGeneratorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/keystore/SAML2HttpUrlKeystoreGeneratorTests.java
@@ -27,7 +27,7 @@ public class SAML2HttpUrlKeystoreGeneratorTests {
     public void verifyKeystoreGeneration() throws Exception {
         final ConfigurationManager mgr = new DefaultConfigurationManager();
         mgr.configure();
-        
+
         final WireMockServer wireMockServer = new WireMockServer(8085);
         try {
             wireMockServer.stubFor(
@@ -48,6 +48,7 @@ public class SAML2HttpUrlKeystoreGeneratorTests {
             wireMockServer.start();
 
             final SAML2Configuration configuration = new SAML2Configuration();
+            configuration.setCertificateSignatureAlg("SHA256withRSA");
             configuration.setForceKeystoreGeneration(true);
             configuration.setKeystoreResourceUrl("http://localhost:8085/keystore");
             configuration.setKeystorePassword("pac4j");
@@ -55,7 +56,7 @@ public class SAML2HttpUrlKeystoreGeneratorTests {
             configuration.setServiceProviderMetadataResource(new FileSystemResource("target/out.xml"));
             configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
             configuration.init();
-           
+
             final CredentialProvider provider = new KeyStoreCredentialProvider(configuration);
             assertNotNull(provider.getCredentialResolver());
             assertNotNull(provider.getCredential());


### PR DESCRIPTION
Current implementation throws an exception if you set `setCertificateSignatureAlg` explicitly as it is not aligned with the hardcoded one used for `createSelfSignedCert`.