### PR TITLE
Allow forced/passive authn to be defined per request

### DIFF
--- a/documentation/docs/clients/cas.md
+++ b/documentation/docs/clients/cas.md
@@ -78,6 +78,8 @@ You can also set various parameters:
 {:.striped}
 
 
+Furthermore, `renew` or `gateway` authentication requests can also be controlled on a per-request basis based on the presence of HTTP attributes defined in `RedirectionActionBuilder#ATTRIBUTE_FORCE_AUTHN` and `RedirectionActionBuilder#ATTRIBUTE_PASSIVE`.
+
 ### b) CAS configuration
 
 Assuming your callback URL is `http://localhost:8080/callback`, the CAS server will be called by default via `https://mycasserver/login?service=http://localhost:8080/callback?client_name=CasClient`.

--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -90,6 +90,8 @@ cfg.setForceAuth(true);
 cfg.setPassive(true);
 ```
 
+Furthermore, forced/passive authentication requests can also be controlled on a per-request basis based on the presence of HTTP attributes defined in `RedirectionActionBuilder#ATTRIBUTE_FORCE_AUTHN` and `RedirectionActionBuilder#ATTRIBUTE_PASSIVE`.
+
 You can define the binding type for the authentication request via the `setAuthnRequestBindingType` method and the binding type for the SP logout request via the `setSpLogoutRequestBindingType` method:
 
 ```java

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -29,6 +29,7 @@ title: Release notes&#58;
 - SAML2 requested authentication context class refs are now checked and enforced again in SAML responses.
 - The presence of `NameID` elements in SAML2 responses is now made optional, if the `SAML2Configuration` is configured to build the final credential using a SAML2 attribute found in the assertion. If the attribute is not found or is undefined, `NameID` is expected as the default.
 - Handle the "same site policy" in cookies (default: `lax`). Renamed `ContextHelper` as `WebContextHelper`
+- Authentication requests for protocols that support forced/passive authentication can now be modified on a per-request basis using pre-defined HTTP attributes to control the type of authentication request sent to the provider.
 
 **v4.4.0**:
 - For SAML IdP metadata defined as files, the metadata are reloaded if the file is changed

--- a/pac4j-cas/src/main/java/org/pac4j/cas/redirect/CasRedirectionActionBuilder.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/redirect/CasRedirectionActionBuilder.java
@@ -41,8 +41,13 @@ public class CasRedirectionActionBuilder implements RedirectionActionBuilder {
     public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
         var computeLoginUrl = configuration.computeFinalLoginUrl(context);
         final var computedCallbackUrl = client.computeFinalCallbackUrl(context);
+
+        final var renew = configuration.isRenew()
+            || context.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN).isPresent();
+        final var gateway = configuration.isRenew()
+            || context.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE).isPresent();
         final var redirectionUrl = CommonUtils.constructRedirectUrl(computeLoginUrl, getServiceParameter(),
-                computedCallbackUrl, configuration.isRenew(), configuration.isGateway(), configuration.getMethod());
+                computedCallbackUrl, renew, gateway, configuration.getMethod());
         logger.debug("redirectionUrl: {}", redirectionUrl);
         return Optional.of(HttpActionHelper.buildRedirectUrlAction(context, redirectionUrl));
     }

--- a/pac4j-cas/src/main/java/org/pac4j/cas/redirect/CasRedirectionActionBuilder.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/redirect/CasRedirectionActionBuilder.java
@@ -44,7 +44,7 @@ public class CasRedirectionActionBuilder implements RedirectionActionBuilder {
 
         final var renew = configuration.isRenew()
             || context.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN).isPresent();
-        final var gateway = configuration.isRenew()
+        final var gateway = configuration.isGateway()
             || context.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE).isPresent();
         final var redirectionUrl = CommonUtils.constructRedirectUrl(computeLoginUrl, getServiceParameter(),
                 computedCallbackUrl, renew, gateway, configuration.getMethod());

--- a/pac4j-cas/src/test/java/org/pac4j/cas/redirect/CasRedirectionActionBuilderTest.java
+++ b/pac4j-cas/src/test/java/org/pac4j/cas/redirect/CasRedirectionActionBuilderTest.java
@@ -7,6 +7,7 @@ import org.pac4j.cas.config.CasProtocol;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.TestsConstants;
 
 import static org.junit.Assert.*;
@@ -26,6 +27,26 @@ public final class CasRedirectionActionBuilderTest implements TestsConstants {
         assertTrue(action instanceof FoundAction);
         assertEquals(LOGIN_URL + "?service=http%3A%2F%2Fwww.pac4j.org%2Ftest.html%3Fclient_name%3DCasClient",
             ((FoundAction) action).getLocation());
+    }
+
+    @Test
+    public void testRedirectGatewayAttribute() {
+        final var builder = newBuilder(new CasConfiguration());
+        final var context = MockWebContext.create();
+        context.setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE, true);
+        final var action = builder.getRedirectionAction(context, new MockSessionStore()).get();
+        assertTrue(action instanceof FoundAction);
+        assertTrue(((FoundAction) action).getLocation().contains("gateway=true"));
+    }
+
+    @Test
+    public void testRedirectRenewAttribute() {
+        final var builder = newBuilder(new CasConfiguration());
+        final var context = MockWebContext.create();
+        context.setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN, true);
+        final var action = builder.getRedirectionAction(context, new MockSessionStore()).get();
+        assertTrue(action instanceof FoundAction);
+        assertTrue(((FoundAction) action).getLocation().contains("renew=true"));
     }
 
     @Test

--- a/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectionActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectionActionBuilder.java
@@ -15,8 +15,20 @@ import java.util.Optional;
 @FunctionalInterface
 public interface RedirectionActionBuilder {
 
+    /**
+     * Attribute name typically expected as an http request attribute
+     * that controls whether authentication should be forced.
+     * This will get translated to the appropriate protocol
+     * for each relevant builder.
+     */
     String ATTRIBUTE_FORCE_AUTHN = "ForceAuthn";
 
+    /**
+     * Attribute name typically expected as an http request attribute
+     * that controls whether authentication should be passive.
+     * This will get translated to the appropriate protocol
+     * for each relevant builder.
+     */
     String ATTRIBUTE_PASSIVE = "Passive";
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectionActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectionActionBuilder.java
@@ -15,6 +15,10 @@ import java.util.Optional;
 @FunctionalInterface
 public interface RedirectionActionBuilder {
 
+    String ATTRIBUTE_FORCE_AUTHN = "ForceAuthn";
+
+    String ATTRIBUTE_PASSIVE = "Passive";
+
     /**
      * Return the appropriate "redirection" action.
      *

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -47,6 +47,7 @@ public class OidcConfiguration extends BaseClientConfiguration {
     public static final String CLIENT_ID = "client_id";
     public static final String STATE = "state";
     public static final String MAX_AGE = "max_age";
+    public static final String PROMPT = "prompt";
     public static final String NONCE = "nonce";
     public static final String CODE_CHALLENGE = "code_challenge";
     public static final String CODE_CHALLENGE_METHOD = "code_challenge_method";

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -97,9 +97,9 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private String serviceProviderEntityId;
 
-    private int maximumAuthenticationLifetime = 3600;
+    private long maximumAuthenticationLifetime = 3600;
 
-    private int acceptedSkew = 300;
+    private long acceptedSkew = 300;
 
     private boolean forceAuth = false;
 
@@ -412,11 +412,11 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.forceKeystoreGeneration = forceKeystoreGeneration;
     }
 
-    public int getAcceptedSkew() {
+    public long getAcceptedSkew() {
         return acceptedSkew;
     }
 
-    public void setAcceptedSkew(final int acceptedSkew) {
+    public void setAcceptedSkew(final long acceptedSkew) {
         this.acceptedSkew = acceptedSkew;
     }
 
@@ -609,11 +609,11 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.nameIdPolicyFormat = nameIdPolicyFormat;
     }
 
-    public int getMaximumAuthenticationLifetime() {
+    public long getMaximumAuthenticationLifetime() {
         return maximumAuthenticationLifetime;
     }
 
-    public void setMaximumAuthenticationLifetime(final int maximumAuthenticationLifetime) {
+    public void setMaximumAuthenticationLifetime(final long maximumAuthenticationLifetime) {
         this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/api/SAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/api/SAML2ResponseValidator.java
@@ -20,5 +20,5 @@ public interface SAML2ResponseValidator {
      */
     Credentials validate(SAML2MessageContext context);
 
-    void setAcceptedSkew(int acceptedSkew);
+    void setAcceptedSkew(long acceptedSkew);
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
@@ -68,7 +68,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
     protected final ReplayCacheProvider replayCache;
 
     /* maximum skew in seconds between SP and IDP clocks */
-    protected int acceptedSkew = 120;
+    protected long acceptedSkew = 120;
 
     protected AbstractSAML2ResponseValidator(final SAML2SignatureTrustEngineProvider signatureTrustEngineProvider,
                                              final Decrypter decrypter, final LogoutHandler logoutHandler,
@@ -182,7 +182,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         return isDateValid(issueInstant, 0);
     }
 
-    protected boolean isDateValid(final Instant issueInstant, final int interval) {
+    protected boolean isDateValid(final Instant issueInstant, final long interval) {
         final var now = ZonedDateTime.now(ZoneOffset.UTC);
         final var before = now.plusSeconds(acceptedSkew);
         final var after = now.minusSeconds(acceptedSkew + interval);
@@ -272,7 +272,7 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
     }
 
     @Override
-    public final void setAcceptedSkew(final int acceptedSkew) {
+    public final void setAcceptedSkew(final long acceptedSkew) {
         this.acceptedSkew = acceptedSkew;
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -23,6 +23,7 @@ import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.RequestedAttribute;
 import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.profile.api.SAML2ObjectBuilder;
@@ -107,8 +108,11 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         request.setIssuer(getIssuer(selfContext.getEntityId()));
         request.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(this.issueInstantSkewSeconds).toInstant());
         request.setVersion(SAMLVersion.VERSION_20);
-        request.setIsPassive(this.configuration.isPassive());
-        request.setForceAuthn(this.configuration.isForceAuth());
+
+        request.setIsPassive(this.configuration.isPassive()
+            || context.getWebContext().getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE).isPresent());
+        request.setForceAuthn(this.configuration.isForceAuth()
+            || context.getWebContext().getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN).isPresent());
 
         if (StringUtils.isNotBlank(this.configuration.getProviderName())) {
             request.setProviderName(this.configuration.getProviderName());

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
@@ -10,6 +10,7 @@ import org.opensaml.saml.saml2.metadata.SingleSignOnService;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.saml.client.AbstractSAML2ClientTests;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.config.SAML2Configuration;
@@ -87,6 +88,22 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         configuration.setNameIdPolicyAllowCreate(null);
         final var builder = new SAML2AuthnRequestBuilder(configuration);
         final var context = buildContext();
+        assertNotNull(builder.build(context));
+    }
+
+    @Test
+    public void testForceAuthAsRequestAttribute() {
+        final var builder = new SAML2AuthnRequestBuilder(configuration);
+        final var context = buildContext();
+        context.getWebContext().setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN, true);
+        assertNotNull(builder.build(context));
+    }
+
+    @Test
+    public void testPassiveAuthAsRequestAttribute() {
+        final var builder = new SAML2AuthnRequestBuilder(configuration);
+        final var context = buildContext();
+        context.getWebContext().setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE, true);
         assertNotNull(builder.build(context));
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
@@ -75,6 +75,7 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         context.getSAMLPeerMetadataContext().setRoleDescriptor(idpDescriptor);
         context.getSAMLSelfMetadataContext().setRoleDescriptor(spDescriptor);
         context.getSAMLSelfEntityContext().setEntityId("entity-id");
+        context.setWebContext(MockWebContext.create());
         return context;
     }
 


### PR DESCRIPTION
This pull request modifies the authentication request builders to support forced/passive authentication requests on demand. This is handled for SAML2, CAS and OIDC protocols, and is generally controlled via distinct http request attributes that get translated to the appropriate flags for each protocol.