### PR TITLE
Allow classpath resources for SAML2 SP metadata

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -41,7 +41,6 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
-import org.springframework.core.io.WritableResource;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -505,12 +504,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
     }
 
     public void setServiceProviderMetadataPath(final String path) {
-        final var resource = mapPathToResource(path);
-        if (!(resource instanceof WritableResource)) {
-            throw new TechnicalException(path + " must be a writable resource");
-        } else {
-            this.serviceProviderMetadataResource = (WritableResource) resource;
-        }
+        this.serviceProviderMetadataResource = mapPathToResource(path);
     }
 
     public Resource getServiceProviderMetadataResource() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
@@ -34,7 +34,7 @@ public class SAML2FileSystemMetadataGenerator extends BaseSAML2MetadataGenerator
             return false;
         }
         if (!(metadataResource instanceof WritableResource)) {
-            logger.error("Unable to store metadata, as resource is not writable");
+            logger.warn("Unable to store metadata, as resource is not writable");
             return false;
         }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -37,11 +37,14 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
     protected MetadataResolver prepareServiceProviderMetadata() {
         try {
             final var metadataGenerator = configuration.toMetadataGenerator();
-            final var entity = metadataGenerator.buildEntityDescriptor();
-            final var metadata = metadataGenerator.getMetadata(entity);
-            metadataGenerator.storeMetadata(metadata,
-                configuration.getServiceProviderMetadataResource(),
-                configuration.isForceServiceProviderMetadataGeneration());
+            if (!configuration.getServiceProviderMetadataResource().exists()
+                || configuration.isForceServiceProviderMetadataGeneration()) {
+                final var entity = metadataGenerator.buildEntityDescriptor();
+                final var metadata = metadataGenerator.getMetadata(entity);
+                metadataGenerator.storeMetadata(metadata,
+                    configuration.getServiceProviderMetadataResource(),
+                    configuration.isForceServiceProviderMetadataGeneration());
+            }
             return metadataGenerator.buildMetadataResolver(configuration.getServiceProviderMetadataResource());
         } catch (final Exception e) {
             throw new SAMLException("Unable to generate metadata for service provider", e);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolverTest.java
@@ -54,6 +54,14 @@ public class SAML2ServiceProviderMetadataResolverTest {
     }
 
     @Test
+    public void resolveServiceProviderMetadataViaExistingClasspath() {
+        final var configuration =
+            initializeConfiguration(new ClassPathResource("sample-sp-metadata.xml"), "target/keystore.jks");
+        final SAML2MetadataResolver metadataResolver = new SAML2ServiceProviderMetadataResolver(configuration);
+        assertNotNull(metadataResolver.resolve());
+    }
+
+    @Test
     public void resolveServiceProviderMetadataViaUrl() throws Exception {
         final var restBody = IOUtils.toString(
             new ClassPathResource("sample-sp-metadata.xml").getInputStream(), StandardCharsets.UTF_8);


### PR DESCRIPTION
As the title suggests, this pull request:

- Allows classpath resources to be used for the SAML2 SP metadata
- If SP metadata already exists, it will be reused/resolved; no need to reconstruct it in memory first.