### PR TITLE
Support SAML2Configuration/OidcConfiguration overrides via http request attributes

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/matching/matcher/csrf/CsrfTokenGeneratorMatcher.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/matching/matcher/csrf/CsrfTokenGeneratorMatcher.java
@@ -1,6 +1,5 @@
 package org.pac4j.core.matching.matcher.csrf;
 
-import org.apache.shiro.util.StringUtils;
 import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.Pac4jConstants;
@@ -40,12 +39,12 @@ public class CsrfTokenGeneratorMatcher implements Matcher {
         final var token = csrfTokenGenerator.get(context, sessionStore);
         context.setRequestAttribute(Pac4jConstants.CSRF_TOKEN, token);
         final var cookie = new Cookie(Pac4jConstants.CSRF_TOKEN, token);
-        if (StringUtils.hasText(domain)) {
+        if (CommonHelper.isNotBlank(domain)) {
             cookie.setDomain(domain);
         } else {
             cookie.setDomain(context.getServerName());
         }
-        if (StringUtils.hasText(path)) {
+        if (CommonHelper.isNotBlank(path)) {
             cookie.setPath(path);
         }
         if (httpOnly != null) {
@@ -57,7 +56,7 @@ public class CsrfTokenGeneratorMatcher implements Matcher {
         if (maxAge != null) {
             cookie.setMaxAge(maxAge.intValue());
         }
-        if (StringUtils.hasText(sameSitePolicy)) {
+        if (CommonHelper.isNotBlank(sameSitePolicy)) {
             cookie.setSameSitePolicy(sameSitePolicy);
         }
         context.addResponseCookie(cookie);

--- a/pac4j-core/src/main/java/org/pac4j/core/matching/matcher/csrf/CsrfTokenGeneratorMatcher.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/matching/matcher/csrf/CsrfTokenGeneratorMatcher.java
@@ -1,5 +1,6 @@
 package org.pac4j.core.matching.matcher.csrf;
 
+import org.apache.shiro.util.StringUtils;
 import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.Pac4jConstants;
@@ -39,12 +40,12 @@ public class CsrfTokenGeneratorMatcher implements Matcher {
         final var token = csrfTokenGenerator.get(context, sessionStore);
         context.setRequestAttribute(Pac4jConstants.CSRF_TOKEN, token);
         final var cookie = new Cookie(Pac4jConstants.CSRF_TOKEN, token);
-        if (domain != null) {
+        if (StringUtils.hasText(domain)) {
             cookie.setDomain(domain);
         } else {
             cookie.setDomain(context.getServerName());
         }
-        if (path != null) {
+        if (StringUtils.hasText(path)) {
             cookie.setPath(path);
         }
         if (httpOnly != null) {
@@ -56,7 +57,7 @@ public class CsrfTokenGeneratorMatcher implements Matcher {
         if (maxAge != null) {
             cookie.setMaxAge(maxAge.intValue());
         }
-        if (sameSitePolicy != null) {
+        if (StringUtils.hasText(sameSitePolicy)) {
             cookie.setSameSitePolicy(sameSitePolicy);
         }
         context.addResponseCookie(cookie);

--- a/pac4j-oidc/pom.xml
+++ b/pac4j-oidc/pom.xml
@@ -50,6 +50,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
         <!-- for testing -->
         <dependency>
             <groupId>org.pac4j</groupId>

--- a/pac4j-oidc/pom.xml
+++ b/pac4j-oidc/pom.xml
@@ -50,10 +50,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
         <!-- for testing -->
         <dependency>
             <groupId>org.pac4j</groupId>

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -47,7 +47,7 @@ public class OidcClient extends IndirectClient {
     protected void internalInit() {
         configuration.init();
 
-        defaultRedirectionActionBuilder(new OidcRedirectionActionBuilder(configuration, this));
+        defaultRedirectionActionBuilder(new OidcRedirectionActionBuilder(this));
         defaultCredentialsExtractor(new OidcExtractor(configuration, this));
         defaultAuthenticator(new OidcAuthenticator(configuration, this));
         defaultProfileCreator(new OidcProfileCreator(configuration, this));

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -41,6 +41,7 @@ import static org.pac4j.core.util.CommonHelper.*;
 public class OidcConfiguration extends BaseClientConfiguration {
 
     public static final String SCOPE = "scope";
+    public static final String CUSTOM_PARAMS = "custom_params";
     public static final String RESPONSE_TYPE = "response_type";
     public static final String RESPONSE_MODE = "response_mode";
     public static final String REDIRECT_URI = "redirect_uri";

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfigurationContext.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfigurationContext.java
@@ -1,0 +1,62 @@
+package org.pac4j.oidc.config;
+
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
+
+import java.util.Map;
+
+/**
+ * This is {@link OidcConfigurationContext}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+@SuppressWarnings("unchecked")
+public class OidcConfigurationContext {
+    private final WebContext context;
+    private final OidcConfiguration configuration;
+
+    public OidcConfigurationContext(final WebContext webContext,
+                                    final OidcConfiguration oidcConfiguration) {
+        this.context = webContext;
+        this.configuration = oidcConfiguration;
+    }
+
+    public Integer getMaxAge() {
+        return (Integer) context.getRequestAttribute(OidcConfiguration.MAX_AGE)
+            .orElse(configuration.getMaxAge());
+    }
+
+    public Boolean isForceAuthn() {
+        return context.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN)
+            .isPresent();
+    }
+
+    public Boolean isPassive() {
+        return context.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE)
+            .isPresent();
+    }
+
+    public String getScope() {
+        return (String) context.getRequestAttribute(OidcConfiguration.SCOPE).orElse("openid profile email");
+    }
+
+    public String getResponseType() {
+        return (String) context.getRequestAttribute(OidcConfiguration.RESPONSE_TYPE)
+            .orElse(configuration.getResponseType());
+    }
+
+    public String getResponseMode() {
+        return (String) context.getRequestAttribute(OidcConfiguration.RESPONSE_MODE)
+            .orElse(configuration.getResponseMode());
+    }
+
+    public Map<String, String> getCustomParams() {
+        return (Map<String, String>) context.getRequestAttribute(OidcConfiguration.CUSTOM_PARAMS)
+            .orElse(configuration.getCustomParams());
+    }
+
+    public OidcConfiguration getConfiguration() {
+        return configuration;
+    }
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -57,7 +57,6 @@ public class OidcAuthenticator implements Authenticator {
         final var _clientID = new ClientID(configuration.getClientId());
 
         if (configuration.getSecret() != null) {
-
             // check authentication methods
             final var metadataMethods = configuration.findProviderMetadata()
                     .getTokenEndpointAuthMethods();
@@ -94,11 +93,8 @@ public class OidcAuthenticator implements Authenticator {
             } else {
                 throw new TechnicalException("Unsupported client authentication method: " + chosenMethod);
             }
-
         } else {
-
             clientAuthentication = new ClientNoSecret(_clientID);
-
         }
     }
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
@@ -3,7 +3,10 @@ package org.pac4j.oidc.credentials.extractor;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.State;
-import com.nimbusds.openid.connect.sdk.*;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationResponseParser;
+import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.Credentials;
@@ -21,7 +24,11 @@ import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Extract the authorization code on the callback.

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -141,10 +141,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>${joda-time.version}</version>

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -141,6 +141,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>${joda-time.version}</version>

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -133,10 +133,10 @@ public class SAML2Client extends IndirectClient {
     protected void initSAMLProfileHandler() {
         final SAML2MessageReceiver messageReceiver;
         if (configuration.getResponseBindingType().equals(SAMLConstants.SAML2_POST_BINDING_URI)) {
-            messageReceiver = new SAML2WebSSOMessageReceiver(this.authnResponseValidator);
+            messageReceiver = new SAML2WebSSOMessageReceiver(this.authnResponseValidator, this.configuration);
         } else if (configuration.getResponseBindingType().equals(SAMLConstants.SAML2_ARTIFACT_BINDING_URI)) {
             messageReceiver = new SAML2ArtifactBindingMessageReceiver(this.authnResponseValidator,
-                    this.idpMetadataResolver, this.spMetadataResolver, this.soapPipelineProvider);
+                    this.idpMetadataResolver, this.spMetadataResolver, this.soapPipelineProvider, this.configuration);
         } else {
             throw new TechnicalException(
                     "Unsupported response binding type: " + configuration.getResponseBindingType());
@@ -155,7 +155,7 @@ public class SAML2Client extends IndirectClient {
     }
 
     protected SAML2LogoutMessageReceiver getLogoutMessageReceiver() {
-        return new SAML2LogoutMessageReceiver(this.logoutValidator);
+        return new SAML2LogoutMessageReceiver(this.logoutValidator, this.configuration);
     }
 
     protected SAML2LogoutRequestMessageSender getLogoutRequestMessageSender() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ConfigurationContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ConfigurationContext.java
@@ -1,0 +1,128 @@
+package org.pac4j.saml.context;
+
+import org.apache.commons.lang3.BooleanUtils;
+import org.opensaml.messaging.context.BaseContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.redirect.RedirectionActionBuilder;
+import org.pac4j.saml.config.SAML2Configuration;
+
+import java.util.List;
+
+/**
+ * This is {@link SAML2ConfigurationContext}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.0.0
+ */
+@SuppressWarnings("unchecked")
+public class SAML2ConfigurationContext extends BaseContext {
+    public static final String REQUEST_ATTR_AUTHN_REQUEST_BINDING_TYPE = "AuthnRequestBindingType";
+    public static final String REQUEST_ATTR_ASSERTION_CONSUMER_SERVICE_INDEX = "AssertionConsumerServiceIndex";
+    public static final String REQUEST_ATTR_ATTRIBUTE_CONSUMING_SERVICE_INDEX = "AttributeConsumingServiceIndex";
+    public static final String REQUEST_ATTR_COMPARISON_TYPE = "ComparisonType";
+    public static final String REQUEST_ATTR_NAME_ID_POLICY_FORMAT = "NameIdPolicyFormat";
+    public static final String REQUEST_ATTR_NAME_ID_POLICY_ALLOW_CREATE = "NameIdPolicyAllowCreate";
+    public static final String REQUEST_ATTR_PROVIDER_NAME = "ProviderName";
+    public static final String REQUEST_ATTR_ISSUER_FORMAT = "IssuerFormat";
+    public static final String REQUEST_ATTR_USE_NAME_QUALIFIER = "UseNameQualifier";
+    public static final String REQUEST_ATTR_AUTHN_CONTEXT_CLASS_REFS = "AuthnContextClassRefs";
+    public static final String REQUEST_ATTR_NAME_ID_ATTRIBUTE = "NameIdAttribute";
+
+    public static final String REQUEST_ATTR_WANTS_ASSERTIONS_SIGNED = "WantsAssertionsSigned";
+    public static final String REQUEST_ATTR_WANTS_RESPONSES_SIGNED = "WantsResponsesSigned";
+    public static final String REQUEST_ATTR_MAXIMUM_AUTHENTICATION_LIFETIME = "MaximumAuthenticationLifetime";
+
+    private final WebContext webContext;
+    private final SAML2Configuration configuration;
+
+    public SAML2ConfigurationContext(final WebContext webContext,
+                                     final SAML2Configuration configuration) {
+        this.webContext = webContext;
+        this.configuration = configuration;
+    }
+
+    public SAML2Configuration getSAML2Configuration() {
+        return configuration;
+    }
+
+    public String getAuthnRequestBindingType() {
+        return (String) webContext.getRequestAttribute(REQUEST_ATTR_AUTHN_REQUEST_BINDING_TYPE)
+            .orElse(configuration.getAuthnRequestBindingType());
+    }
+
+    public Integer getAssertionConsumerServiceIndex() {
+        return (Integer) webContext.getRequestAttribute(REQUEST_ATTR_ASSERTION_CONSUMER_SERVICE_INDEX)
+            .orElse(configuration.getAssertionConsumerServiceIndex());
+    }
+
+    public Integer getAttributeConsumingServiceIndex() {
+        return (Integer) webContext.getRequestAttribute(REQUEST_ATTR_ATTRIBUTE_CONSUMING_SERVICE_INDEX)
+            .orElse(configuration.getAttributeConsumingServiceIndex());
+    }
+
+    public String getComparisonType() {
+        return (String) webContext.getRequestAttribute(REQUEST_ATTR_COMPARISON_TYPE)
+            .orElse(configuration.getComparisonType());
+    }
+
+    public String getNameIdPolicyFormat() {
+        return (String) webContext.getRequestAttribute(REQUEST_ATTR_NAME_ID_POLICY_FORMAT)
+            .orElse(configuration.getNameIdPolicyFormat());
+    }
+
+    public Boolean isNameIdPolicyAllowCreate() {
+        return (Boolean) webContext.getRequestAttribute(REQUEST_ATTR_NAME_ID_POLICY_ALLOW_CREATE)
+            .orElse(BooleanUtils.toBoolean(configuration.isNameIdPolicyAllowCreate()));
+    }
+
+    public String getProviderName() {
+        return (String) webContext.getRequestAttribute(REQUEST_ATTR_PROVIDER_NAME)
+            .orElse(configuration.getProviderName());
+    }
+
+    public String getIssuerFormat() {
+        return (String) webContext.getRequestAttribute(REQUEST_ATTR_ISSUER_FORMAT)
+            .orElse(configuration.getIssuerFormat());
+    }
+
+    public Boolean isUseNameQualifier() {
+        return (Boolean) webContext.getRequestAttribute(REQUEST_ATTR_USE_NAME_QUALIFIER)
+            .orElse(BooleanUtils.toBoolean(configuration.isUseNameQualifier()));
+    }
+
+
+    public List<String> getAuthnContextClassRefs() {
+        return (List<String>) webContext.getRequestAttribute(REQUEST_ATTR_AUTHN_CONTEXT_CLASS_REFS)
+            .orElse(configuration.getAuthnContextClassRefs());
+    }
+
+    public Boolean isPassive() {
+        return webContext.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE).isPresent()
+            || BooleanUtils.toBoolean(configuration.isPassive());
+    }
+
+    public Boolean isForceAuth() {
+        return webContext.getRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN).isPresent()
+            || BooleanUtils.toBoolean(configuration.isForceAuth());
+    }
+
+    public String getNameIdAttribute() {
+        return (String) webContext.getRequestAttribute(REQUEST_ATTR_NAME_ID_ATTRIBUTE)
+            .orElse(configuration.getNameIdAttribute());
+    }
+
+    public Boolean isWantsAssertionsSigned() {
+        return (Boolean) webContext.getRequestAttribute(REQUEST_ATTR_WANTS_ASSERTIONS_SIGNED)
+            .orElse(BooleanUtils.toBoolean(configuration.isWantsAssertionsSigned()));
+    }
+
+    public Long getMaximumAuthenticationLifetime() {
+        return (Long) webContext.getRequestAttribute(REQUEST_ATTR_MAXIMUM_AUTHENTICATION_LIFETIME)
+            .orElse(configuration.getMaximumAuthenticationLifetime());
+    }
+
+    public boolean isWantsResponsesSigned() {
+        return (Boolean) webContext.getRequestAttribute(REQUEST_ATTR_WANTS_RESPONSES_SIGNED)
+            .orElse(configuration.isWantsResponsesSigned());
+    }
+}

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ContextProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ContextProvider.java
@@ -14,6 +14,7 @@ import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 import org.pac4j.saml.store.SAMLMessageStoreFactory;
@@ -38,7 +39,7 @@ import javax.xml.namespace.QName;
 public class SAML2ContextProvider implements SAMLContextProvider {
     private static final String SAML2_WEBSSO_PROFILE_URI = "urn:oasis:names:tc:SAML:2.0:profiles:SSO:browser";
 
-    protected final static Logger logger = LoggerFactory.getLogger(SAML2ContextProvider.class);
+    protected static final Logger logger = LoggerFactory.getLogger(SAML2ContextProvider.class);
 
     protected final SAML2MetadataResolver idpEntityId;
 
@@ -55,16 +56,19 @@ public class SAML2ContextProvider implements SAMLContextProvider {
     }
 
     @Override
-    public final SAML2MessageContext buildServiceProviderContext(final WebContext webContext, final SessionStore sessionStore) {
+    public final SAML2MessageContext buildServiceProviderContext(final SAML2Client client,
+                                                                 final WebContext webContext,
+                                                                 final SessionStore sessionStore) {
         final var context = new SAML2MessageContext();
+        context.setSaml2Configuration(client.getConfiguration());
         addTransportContext(webContext, sessionStore, context);
         addSPContext(context);
         return context;
     }
 
     @Override
-    public SAML2MessageContext buildContext(final WebContext webContext, final SessionStore sessionStore) {
-        final var context = buildServiceProviderContext(webContext, sessionStore);
+    public SAML2MessageContext buildContext(final SAML2Client client, final WebContext webContext, final SessionStore sessionStore) {
+        final var context = buildServiceProviderContext(client, webContext, sessionStore);
         addIDPContext(context);
         context.setWebContext(webContext);
         context.setSessionStore(sessionStore);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
@@ -23,6 +23,8 @@ import org.opensaml.soap.messaging.context.SOAP11Context;
 import org.opensaml.xmlsec.context.SecurityParametersContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.store.SAMLMessageStore;
 import org.pac4j.saml.transport.Pac4jSAMLResponse;
@@ -45,6 +47,8 @@ public class SAML2MessageContext {
 
     private MessageContext messageContext = new MessageContext();
 
+    private SAML2Configuration saml2Configuration;
+
     private WebContext webContext;
 
     private SessionStore sessionStore;
@@ -61,6 +65,16 @@ public class SAML2MessageContext {
 
     public SAML2MessageContext() {
         super();
+    }
+
+    public SAML2ConfigurationContext getConfigurationContext() {
+        CommonHelper.assertNotNull("webContext", this.webContext);
+        CommonHelper.assertNotNull("saml2Configuration", this.saml2Configuration);
+        return new SAML2ConfigurationContext(this.webContext, this.saml2Configuration);
+    }
+
+    public void setSaml2Configuration(final SAML2Configuration saml2Configuration) {
+        this.saml2Configuration = saml2Configuration;
     }
 
     public MessageContext getMessageContext() {
@@ -93,6 +107,10 @@ public class SAML2MessageContext {
 
     public final void setSubjectAssertion(final Assertion subjectAssertion) {
         this.subjectAssertion = subjectAssertion;
+    }
+
+    public SAML2Configuration getSAML2Configuration() {
+        return saml2Configuration;
     }
 
     public final SPSSODescriptor getSPSSODescriptor() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAMLContextProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAMLContextProvider.java
@@ -2,6 +2,7 @@ package org.pac4j.saml.context;
 
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.saml.client.SAML2Client;
 
 /**
  * Builds the saml context for SP and the IDP.
@@ -9,7 +10,7 @@ import org.pac4j.core.context.session.SessionStore;
  * @since 1.7
  */
 public interface SAMLContextProvider {
-    SAML2MessageContext buildServiceProviderContext(WebContext webContext, SessionStore sessionStore);
+    SAML2MessageContext buildServiceProviderContext(SAML2Client client, WebContext webContext, SessionStore sessionStore);
 
-    SAML2MessageContext buildContext(WebContext webContext, SessionStore sessionStore);
+    SAML2MessageContext buildContext(SAML2Client client, WebContext webContext, SessionStore sessionStore);
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/SAML2LogoutActionBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/SAML2LogoutActionBuilder.java
@@ -36,7 +36,10 @@ public class SAML2LogoutActionBuilder implements LogoutActionBuilder {
 
     protected final ValueGenerator stateGenerator;
 
+    protected final SAML2Client saml2Client;
+
     public SAML2LogoutActionBuilder(final SAML2Client client) {
+        this.saml2Client = client;
         this.logoutProfileHandler = client.getLogoutProfileHandler();
         this.contextProvider = client.getContextProvider();
         this.configuration = client.getConfiguration();
@@ -49,7 +52,7 @@ public class SAML2LogoutActionBuilder implements LogoutActionBuilder {
                                                        final UserProfile currentProfile, final String targetUrl) {
         if (currentProfile instanceof SAML2Profile) {
             final var saml2Profile = (SAML2Profile) currentProfile;
-            final var samlContext = this.contextProvider.buildContext(context, sessionStore);
+            final var samlContext = this.contextProvider.buildContext(this.saml2Client, context, sessionStore);
             final var relayState = this.stateGenerator.generateValue(context, sessionStore);
 
             final var logoutRequest = this.saml2LogoutRequestBuilder.build(samlContext, saml2Profile);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutMessageReceiver.java
@@ -4,6 +4,7 @@ import org.opensaml.saml.saml2.core.StatusResponseType;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContextHelper;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
@@ -25,8 +26,9 @@ public class SAML2LogoutMessageReceiver extends AbstractSAML2MessageReceiver {
 
     private static final String SAML2_SLO_PROFILE_URI = "urn:oasis:names:tc:SAML:2.0:profiles:SSO:logout";
 
-    public SAML2LogoutMessageReceiver(final SAML2ResponseValidator validator) {
-        super(validator);
+    public SAML2LogoutMessageReceiver(final SAML2ResponseValidator validator,
+                                      final SAML2Configuration saml2Configuration) {
+        super(validator, saml2Configuration);
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -11,6 +11,7 @@ import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2MessageReceiver;
@@ -28,13 +29,17 @@ import java.util.Optional;
 public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiver {
 
     protected SAML2ResponseValidator validator;
+    protected final SAML2Configuration saml2Configuration;
 
-    public AbstractSAML2MessageReceiver(final SAML2ResponseValidator validator) {
+    public AbstractSAML2MessageReceiver(final SAML2ResponseValidator validator,
+                                        final SAML2Configuration saml2Configuration) {
         this.validator = validator;
+        this.saml2Configuration = saml2Configuration;
     }
 
     @Override
     public Credentials receiveMessage(final SAML2MessageContext context) {
+        context.setSaml2Configuration(saml2Configuration);
         final var peerContext = context.getSAMLPeerEntityContext();
         final var webContext = context.getWebContext();
 
@@ -50,6 +55,8 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
 
     protected SAML2MessageContext prepareDecodedContext(final SAML2MessageContext context, final AbstractPac4jDecoder decoder) {
         final var decodedCtx = new SAML2MessageContext();
+        decodedCtx.setSaml2Configuration(saml2Configuration);
+
         decodedCtx.setMessageContext(decoder.getMessageContext());
         final var message = (SAMLObject) decoder.getMessageContext().getMessage();
         if (message == null) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectionActionBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectionActionBuilder.java
@@ -5,9 +5,9 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
-import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.profile.api.SAML2ObjectBuilder;
 import org.pac4j.saml.sso.impl.SAML2AuthnRequestBuilder;
@@ -22,20 +22,18 @@ import java.util.Optional;
  */
 public class SAML2RedirectionActionBuilder implements RedirectionActionBuilder {
 
-    protected SAML2ObjectBuilder<AuthnRequest> saml2ObjectBuilder;
-
     private final SAML2Client client;
+    protected SAML2ObjectBuilder<AuthnRequest> saml2ObjectBuilder;
 
     public SAML2RedirectionActionBuilder(final SAML2Client client) {
         CommonHelper.assertNotNull("client", client);
         this.client = client;
-        final var cfg = client.getConfiguration();
-        this.saml2ObjectBuilder = new SAML2AuthnRequestBuilder(cfg);
+        this.saml2ObjectBuilder = new SAML2AuthnRequestBuilder();
     }
 
     @Override
     public Optional<RedirectionAction> getRedirectionAction(final WebContext wc, final SessionStore sessionStore) {
-        final var context = this.client.getContextProvider().buildContext(wc, sessionStore);
+        final var context = this.client.getContextProvider().buildContext(this.client, wc, sessionStore);
         final var relayState = this.client.getStateGenerator().generateValue(wc, sessionStore);
 
         final var authnRequest = this.saml2ObjectBuilder.build(context);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingMessageReceiver.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.sso.artifact;
 import org.opensaml.saml.saml2.core.StatusResponseType;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
@@ -29,8 +30,8 @@ public class SAML2ArtifactBindingMessageReceiver extends AbstractSAML2MessageRec
 
     public SAML2ArtifactBindingMessageReceiver(final SAML2ResponseValidator validator,
             final SAML2MetadataResolver idpMetadataResolver, final SAML2MetadataResolver spMetadataResolver,
-            final SOAPPipelineProvider soapPipelineProvider) {
-        super(validator);
+            final SOAPPipelineProvider soapPipelineProvider, final SAML2Configuration saml2Configuration) {
+        super(validator, saml2Configuration);
         this.idpMetadataResolver = idpMetadataResolver;
         this.spMetadataResolver = spMetadataResolver;
         this.soapPipelineProvider = soapPipelineProvider;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageReceiver.java
@@ -3,6 +3,7 @@ package org.pac4j.saml.sso.impl;
 import org.opensaml.saml.saml2.core.StatusResponseType;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.pac4j.core.context.WebContext;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.profile.api.SAML2ResponseValidator;
@@ -20,8 +21,9 @@ public class SAML2WebSSOMessageReceiver extends AbstractSAML2MessageReceiver {
 
     private static final String SAML2_WEBSSO_PROFILE_URI = "urn:oasis:names:tc:SAML:2.0:profiles:SSO:browser";
 
-    public SAML2WebSSOMessageReceiver(final SAML2ResponseValidator validator) {
-        super(validator);
+    public SAML2WebSSOMessageReceiver(final SAML2ResponseValidator validator,
+                                      final SAML2Configuration saml2Configuration) {
+        super(validator, saml2Configuration);
     }
 
     @Override
@@ -39,7 +41,7 @@ public class SAML2WebSSOMessageReceiver extends AbstractSAML2MessageReceiver {
     }
 
     @Override
-    protected Optional<Endpoint> getEndpoint(SAML2MessageContext context, StatusResponseType response) {
+    protected Optional<Endpoint> getEndpoint(final SAML2MessageContext context, final StatusResponseType response) {
         return Optional.of(
             context.getSPAssertionConsumerService(response)
         );

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/AbstractSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/AbstractSAML2ClientTests.java
@@ -10,7 +10,7 @@ import org.springframework.core.io.FileSystemResource;
 
 import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Abstract class to test the {@link SAML2Client}.
@@ -32,11 +32,10 @@ public abstract class AbstractSAML2ClientTests implements TestsConstants {
     }
 
     protected SAML2Configuration getSaml2Configuration() {
-        final var cfg =
-                new SAML2Configuration(new FileSystemResource("target/samlKeystore.jks"),
-                        "pac4j-demo-passwd",
-                        "pac4j-demo-passwd",
-                        new ClassPathResource("testshib-providers.xml"));
+        final var cfg = new SAML2Configuration(new FileSystemResource("target/samlKeystore.jks"),
+            "pac4j-demo-passwd",
+            "pac4j-demo-passwd",
+            new ClassPathResource("testshib-providers.xml"));
 
         cfg.setMaximumAuthenticationLifetime(3600);
         cfg.setAuthnRequestBindingType(getAuthnRequestBindingType());

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -35,6 +35,15 @@ import static org.mockito.Mockito.mock;
  */
 public class SAML2LogoutValidatorTests {
     private static ExplicitSignatureTrustEngineProvider getTrustEngine() {
+        var config = getSaml2Configuration();
+
+        var idp = new SAML2IdentityProviderMetadataResolver(config);
+        idp.init();
+        var sp = new SAML2ServiceProviderMetadataResolver(config);
+        return new ExplicitSignatureTrustEngineProvider(idp, sp);
+    }
+
+    private static SAML2Configuration getSaml2Configuration() {
         final var config = new SAML2Configuration();
         config.setForceKeystoreGeneration(true);
         config.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
@@ -44,11 +53,7 @@ public class SAML2LogoutValidatorTests {
         config.setKeystorePassword("pac4j");
         config.setPrivateKeyPassword("pac4j");
         config.init();
-
-        var idp = new SAML2IdentityProviderMetadataResolver(config);
-        idp.init();
-        var sp = new SAML2ServiceProviderMetadataResolver(config);
-        return new ExplicitSignatureTrustEngineProvider(idp, sp);
+        return config;
     }
 
     private static MockWebContext getMockWebContext() {
@@ -57,6 +62,7 @@ public class SAML2LogoutValidatorTests {
 
     private static SAML2MessageContext getSaml2MessageContext(final MockWebContext webContext) {
         final var context = new SAML2MessageContext();
+        context.setSaml2Configuration(getSaml2Configuration());
 
         final var samlMessage = new MessageContext();
         final var xml = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
@@ -45,8 +45,7 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         final var messageStoreFactory = configuration.getSamlMessageStoreFactory();
         final var store = messageStoreFactory.getMessageStore(webContext, new MockSessionStore());
 
-        final var builder = new SAML2AuthnRequestBuilder(configuration);
-
+        final var builder = new SAML2AuthnRequestBuilder();
         final var context = buildContext();
 
         final var authnRequest = builder.build(context);
@@ -77,6 +76,7 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         context.getSAMLSelfMetadataContext().setRoleDescriptor(spDescriptor);
         context.getSAMLSelfEntityContext().setEntityId("entity-id");
         context.setWebContext(MockWebContext.create());
+        context.setSaml2Configuration(configuration);
         return context;
     }
 
@@ -86,14 +86,14 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         configuration.setUseNameQualifier(true);
         configuration.setNameIdPolicyFormat("sample-nameid-format");
         configuration.setNameIdPolicyAllowCreate(null);
-        final var builder = new SAML2AuthnRequestBuilder(configuration);
+        final var builder = new SAML2AuthnRequestBuilder();
         final var context = buildContext();
         assertNotNull(builder.build(context));
     }
 
     @Test
     public void testForceAuthAsRequestAttribute() {
-        final var builder = new SAML2AuthnRequestBuilder(configuration);
+        final var builder = new SAML2AuthnRequestBuilder();
         final var context = buildContext();
         context.getWebContext().setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN, true);
         assertNotNull(builder.build(context));
@@ -101,7 +101,7 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
 
     @Test
     public void testPassiveAuthAsRequestAttribute() {
-        final var builder = new SAML2AuthnRequestBuilder(configuration);
+        final var builder = new SAML2AuthnRequestBuilder();
         final var context = buildContext();
         context.getWebContext().setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE, true);
         assertNotNull(builder.build(context));

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.1.2</version>
+				<dependencies>
+					<dependency>
+						<groupId>com.puppycrawl.tools</groupId>
+						<artifactId>checkstyle</artifactId>
+						<version>8.41</version>
+					</dependency>
+				</dependencies>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                 </configuration>


### PR DESCRIPTION
This pull request extends the previous approach proposed by #1826 to allow overriding the SAML2 configuration via specific/dedicated http attributes. This is done by introducing a wrapping layer, `SAML2ConfigurationContext`, on top of the `SAML2Configuration` that looks for the http attribute and otherwise, falls back onto the default. The same technique is applied to overriding the `OidcConfiguration`.

Note that this pull request,

- Only provides a solution for SAML2 and OIDC. Other clients may be worked out in the future.
- Does not cover or suggest that every single setting in `SAML2Configuration` can be overridden per request. Only those fields/settings that are most practical or sensible to override on a per-request basis are included here, and others can be worked in the future on demand. Same goes for `OidcConfiguration`.
