### PR TITLE
Add an option to tolerate missing SAML response `Destination` attribute

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -133,6 +133,13 @@ By SAML specification, the authentication request must not contain a NameQualifi
 cfg.setUseNameQualifier(true);
 ```
 
+The SAML specification suggests that responses should have a value set for the `Destination` attribute. For security reasons, *pac4j* will check for its presence. You can change this behavior if needed:
+
+```java
+// force support of missing `Destination` attribute
+cfg.setResponseDestinationAttributeMandatory(false);
+```
+
 To allow the authentication request sent to the identity provider to specify an attribute consuming index:
 
 ```java

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -6,6 +6,7 @@ title: Release notes&#58;
 **v5.0.1**:
 
 - Hazelcast-based implementation for SAMLMessageStore
+- Added an option to tolerate missing SAML response `Destination` attribute.
 
 **v5.0.0** (see: [what's new in pac4j v5?](/blog/what_s_new_in_pac4j_v5.html)):
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -152,6 +152,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private boolean allSignatureValidationDisabled = false;
 
+    private boolean responseDestinationAttributeMandatory = true;
+
     private String keyStoreAlias;
 
     private String keyStoreType;
@@ -703,6 +705,18 @@ public class SAML2Configuration extends BaseClientConfiguration {
      */
     public void setAllSignatureValidationDisabled(final boolean allSignatureValidationDisabled) {
         this.allSignatureValidationDisabled = allSignatureValidationDisabled;
+    }
+
+    /**
+     * SAML specification states the Response `Destination` attribute is optional.
+     * Providing a value is recommended to prevent malicious forwarding of responses to unintended recipients.
+     */
+    public void setResponseDestinationAttributeMandatory(final boolean mandatory) {
+        this.responseDestinationAttributeMandatory = mandatory;
+    }
+
+    public boolean isResponseDestinationAttributeMandatory() {
+        return responseDestinationAttributeMandatory;
     }
 
     public int getAttributeConsumingServiceIndex() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -181,7 +181,9 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
         } else {
             expected.add(this.expectedDestination);
         }
-        verifyEndpoint(expected, logoutResponse.getDestination());
+
+        final boolean isDestinationMandatory = context.getSAML2Configuration().isResponseDestinationAttributeMandatory();
+        verifyEndpoint(expected, logoutResponse.getDestination(), isDestinationMandatory);
     }
 
     public void setActionOnSuccess(final boolean actionOnSuccess) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
@@ -196,7 +196,14 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
         return isDateValid;
     }
 
-    protected void verifyEndpoint(final List<String> endpoints, final String destination) {
+    protected void verifyEndpoint(final List<String> endpoints, final String destination, final boolean isDestinationMandatory) {
+        if (destination == null && !isDestinationMandatory) {
+            return;
+        }
+        if (destination == null) {
+            throw new SAMLEndpointMismatchException("SAML configuration does not allow response Destination to be null");
+        }
+
         final var verified = endpoints.stream()
             .allMatch(endpoint -> compareEndpoints(destination, endpoint));
         if (!verified) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -236,7 +236,10 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
         if (endpoint.getResponseLocation() != null) {
             expected.add(endpoint.getResponseLocation());
         }
-        verifyEndpoint(expected, response.getDestination());
+
+        final boolean isDestinationMandatory = context.getSAML2Configuration().isResponseDestinationAttributeMandatory();
+        verifyEndpoint(expected, response.getDestination(), isDestinationMandatory);
+
         if (request != null) {
             verifyRequest(request, context);
         }


### PR DESCRIPTION
The Response `Destination` attribute is optional according to the SAML protocol specification.
(Paragraph 3.2.2, line 1554: https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)
For security reasons it is expected to be provided but this behavior can be turned off through the `SAML2Configuration`.
