### PR TITLE
Fix `OidcConfigurationContext` that should read scope from `OidcConfiguration`

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfigurationContext.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfigurationContext.java
@@ -4,6 +4,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * This is {@link OidcConfigurationContext}.
@@ -38,7 +39,9 @@ public class OidcConfigurationContext {
     }
 
     public String getScope() {
-        return (String) context.getRequestAttribute(OidcConfiguration.SCOPE).orElse("openid profile email");
+        return (String) context.getRequestAttribute(OidcConfiguration.SCOPE)
+            .or(() -> Optional.ofNullable(configuration.getScope()))
+            .orElse("openid profile email");
     }
 
     public String getResponseType() {

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/config/OidcConfigurationContextTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/config/OidcConfigurationContextTest.java
@@ -1,0 +1,49 @@
+package org.pac4j.oidc.config;
+
+import org.junit.Test;
+import org.pac4j.core.context.MockWebContext;
+
+import static org.junit.Assert.assertEquals;
+
+public class OidcConfigurationContextTest {
+    @Test
+    public void shouldResolveScopeWhenOverriddenFromRequest() {
+        var webContext = MockWebContext.create();
+        webContext.setRequestAttribute(OidcConfiguration.SCOPE, "openid profile email phone");
+
+        var oidcConfiguration = new OidcConfiguration();
+
+        var oidcConfigurationContext = new OidcConfigurationContext(webContext, oidcConfiguration);
+
+        var result = oidcConfigurationContext.getScope();
+
+        assertEquals("openid profile email phone", result);
+    }
+
+    @Test
+    public void shouldResolveScopeWhenConfiguredProgrammatically() {
+        var webContext = MockWebContext.create();
+
+        var oidcConfiguration = new OidcConfiguration();
+        oidcConfiguration.setScope("openid profile email products");
+
+        var oidcConfigurationContext = new OidcConfigurationContext(webContext, oidcConfiguration);
+
+        var result = oidcConfigurationContext.getScope();
+
+        assertEquals("openid profile email products", result);
+    }
+
+    @Test
+    public void shouldResolveScopeFromDefaultValues() {
+        var webContext = MockWebContext.create();
+
+        var oidcConfiguration = new OidcConfiguration();
+
+        var oidcConfigurationContext = new OidcConfigurationContext(webContext, oidcConfiguration);
+
+        var result = oidcConfigurationContext.getScope();
+
+        assertEquals("openid profile email", result);
+    }
+}


### PR DESCRIPTION
Since version 5.0.0 (PR #1836), the scope value defined on `OidcConfiguration` is not considered anymore when computing the redirect URL.