### PR TITLE
Parse JWT claims as `JSONObject` into individual attributes

### DIFF
--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
@@ -1,5 +1,34 @@
 package org.pac4j.jwt.credentials.authenticator;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.PlainJWT;
+import com.nimbusds.jwt.SignedJWT;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.credentials.TokenCredentials;
+import org.pac4j.core.credentials.authenticator.Authenticator;
+import org.pac4j.core.exception.CredentialsException;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.profile.ProfileHelper;
+import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.creator.AuthenticatorProfileCreator;
+import org.pac4j.core.profile.definition.ProfileDefinitionAware;
+import org.pac4j.core.profile.jwt.JwtClaims;
+import org.pac4j.core.util.Pac4jConstants;
+import org.pac4j.core.util.generator.ValueGenerator;
+import org.pac4j.jwt.config.encryption.EncryptionConfiguration;
+import org.pac4j.jwt.config.signature.SignatureConfiguration;
+import org.pac4j.jwt.profile.JwtGenerator;
+import org.pac4j.jwt.profile.JwtProfileDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Date;
@@ -7,40 +36,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.pac4j.core.context.HttpConstants;
-import org.pac4j.core.context.session.SessionStore;
-import org.pac4j.core.credentials.Credentials;
-import org.pac4j.core.profile.UserProfile;
-import org.pac4j.core.profile.definition.ProfileDefinition;
-import org.pac4j.core.util.Pac4jConstants;
-import org.pac4j.core.context.WebContext;
-import org.pac4j.core.credentials.TokenCredentials;
-import org.pac4j.core.credentials.authenticator.Authenticator;
-import org.pac4j.core.exception.CredentialsException;
-import org.pac4j.core.exception.http.HttpAction;
-import org.pac4j.core.exception.TechnicalException;
-import org.pac4j.core.profile.ProfileHelper;
-import org.pac4j.core.profile.creator.AuthenticatorProfileCreator;
-import org.pac4j.core.profile.definition.CommonProfileDefinition;
-import org.pac4j.core.profile.definition.ProfileDefinitionAware;
-import org.pac4j.core.profile.jwt.JwtClaims;
-import org.pac4j.core.util.generator.ValueGenerator;
-import org.pac4j.jwt.config.encryption.EncryptionConfiguration;
-import org.pac4j.jwt.config.signature.SignatureConfiguration;
-import org.pac4j.jwt.profile.JwtGenerator;
-import org.pac4j.jwt.profile.JwtProfile;
-import org.pac4j.jwt.profile.JwtProfileDefinition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jwt.EncryptedJWT;
-import com.nimbusds.jwt.JWT;
-import com.nimbusds.jwt.JWTParser;
-import com.nimbusds.jwt.PlainJWT;
-import com.nimbusds.jwt.SignedJWT;
-
-import static org.pac4j.core.util.CommonHelper.*;
+import static org.pac4j.core.util.CommonHelper.assertNotBlank;
+import static org.pac4j.core.util.CommonHelper.assertNotNull;
+import static org.pac4j.core.util.CommonHelper.toNiceString;
 
 /**
  * Authenticator for JWT. It creates the user profile and stores it in the credentials

--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/credentials/authenticator/JwtAuthenticator.java
@@ -29,6 +29,7 @@ import org.pac4j.jwt.config.encryption.EncryptionConfiguration;
 import org.pac4j.jwt.config.signature.SignatureConfiguration;
 import org.pac4j.jwt.profile.JwtGenerator;
 import org.pac4j.jwt.profile.JwtProfile;
+import org.pac4j.jwt.profile.JwtProfileDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,10 +87,7 @@ public class JwtAuthenticator extends ProfileDefinitionAware implements Authenti
     @Override
     protected void internalInit() {
         assertNotBlank("realmName", this.realmName);
-
-        final ProfileDefinition definition = new CommonProfileDefinition(x -> new JwtProfile());
-        definition.setRestoreProfileFromTypedId(true);
-        defaultProfileDefinition(definition);
+        defaultProfileDefinition(new JwtProfileDefinition());
 
         if (signatureConfigurations.isEmpty()) {
             logger.warn("No signature configurations have been defined: non-signed JWT will be accepted!");

--- a/pac4j-jwt/src/main/java/org/pac4j/jwt/profile/JwtProfileDefinition.java
+++ b/pac4j-jwt/src/main/java/org/pac4j/jwt/profile/JwtProfileDefinition.java
@@ -1,0 +1,40 @@
+package org.pac4j.jwt.profile;
+
+import com.nimbusds.jose.shaded.json.JSONObject;
+import org.pac4j.core.profile.AttributeLocation;
+import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.definition.CommonProfileDefinition;
+
+/**
+ * This is {@link JwtProfileDefinition}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.1.0
+ */
+public class JwtProfileDefinition extends CommonProfileDefinition {
+    private boolean keepNestedAttributes = true;
+
+    public JwtProfileDefinition() {
+        super(x -> new JwtProfile());
+        setRestoreProfileFromTypedId(true);
+    }
+
+    @Override
+    public void convertAndAdd(UserProfile profile, AttributeLocation attributeLocation, String name, Object value) {
+        if (value instanceof JSONObject) {
+            var jsonObject = (JSONObject) value;
+            jsonObject.forEach((key, objectValue) -> super.convertAndAdd(profile, attributeLocation, key, objectValue));
+            if (keepNestedAttributes) {
+                super.convertAndAdd(profile, attributeLocation, name, value);
+            }
+        } else {
+            super.convertAndAdd(profile, attributeLocation, name, value);
+        }
+    }
+
+    public void setKeepNestedAttributes(boolean keepNestedAttributes) {
+        this.keepNestedAttributes = keepNestedAttributes;
+    }
+}
+
+


### PR DESCRIPTION
Given the following JWT:

```json
{
  "iss": "https://example",
  "aud": "https://test",
  "jti": "TEST",
  "iat": 1618481574,
  "exp": 1618482174,
  "sub": "user",
  "userData": {
    "id": 1436000,
    "gender": "M"
  }
}
```

Parse the JWT and build the final user profile such that the `userData` claim is expanded into individual profile attributes for `id` and `gender`. Keep the `userData` attribute as current behavior and do not remove it from the final profile by default.

After the authentication, the final profile would be:

```
{
  "iss": "https://example",
  "aud": "https://test",
  "jti": "TEST",
  "iat": 1618481574,
  "exp": 1618482174,
  "sub": "user",
  "id" : "1436000",
  "gender" : "M",
  "userData": {              // this can be removed using setKeepNestedAttributes(false);
    "id": 1436000,
    "gender": "M"
  }
}

 