### PR TITLE
SAML2: improve on idp metadata resolution options

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -3,6 +3,11 @@ layout: doc
 title: Release notes&#58;
 ---
 
+**v5.0.2**:
+
+- SAML2 identity provider metadata resolver can optionally be forced to download the metadata again.
+- SAML2 identity provider metadata resolver is given the ability to support `last-modified` attributes for URLs.
+
 **v5.0.1**:
 
 - Hazelcast-based implementation for SAMLMessageStore

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -6,6 +6,7 @@ import net.shibboleth.utilities.java.support.resolver.ResolverException;
 import net.shibboleth.utilities.java.support.xml.XMLParserException;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.metadata.IterableMetadataSource;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
 import org.opensaml.saml.metadata.resolver.index.impl.RoleMetadataIndex;
@@ -18,16 +19,23 @@ import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.util.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 
 import javax.annotation.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.util.Collections;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
+ * Resolve and download idp metadata to form a metadata resolver.
+ * <p>
+ * The resolver supports proxies using {@link Proxy} when fetching metadata over URL resources.
+ *
  * @author Misagh Moayyed
  * @since 1.7
  */
@@ -37,14 +45,11 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
     protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final Resource idpMetadataResource;
-
+    private final ReentrantLock lock = new ReentrantLock();
     private String idpEntityId;
-
-    private DOMMetadataResolver idpMetadataProvider;
-
+    private MetadataResolver metadataResolver;
     private long lastModified = NO_LAST_MODIFIED;
-
-    private ReentrantLock lock = new ReentrantLock();
+    private Proxy proxy = Proxy.NO_PROXY;
 
     public SAML2IdentityProviderMetadataResolver(final SAML2Configuration configuration) {
         this(configuration.getIdentityProviderMetadataResource(), configuration.getIdentityProviderEntityId());
@@ -57,31 +62,30 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
     }
 
     public void init() {
-        this.idpMetadataProvider = buildMetadata();
-        if (idpMetadataResource instanceof FileSystemResource) {
-            hasChanged();
-        }
+        this.metadataResolver = buildMetadataResolver();
+        hasChanged();
     }
 
     @Override
-    public final MetadataResolver resolve() {
-        if (idpMetadataResource instanceof FileSystemResource && lock.tryLock()) {
+    public final MetadataResolver resolve(final boolean force) {
+        if (lock.tryLock()) {
             try {
-                if (hasChanged()) {
-                    this.idpMetadataProvider = buildMetadata();
+                var reload = force || hasChanged();
+                if (reload) {
+                    this.metadataResolver = buildMetadataResolver();
                 }
             } finally {
                 lock.unlock();
             }
         }
-        return idpMetadataProvider;
+        return metadataResolver;
     }
 
-    protected boolean hasChanged() {
+    boolean hasChanged() {
         long newLastModified;
         try {
             newLastModified = this.idpMetadataResource.lastModified();
-        } catch (final IOException e) {
+        } catch (final Exception e) {
             newLastModified = NO_LAST_MODIFIED;
         }
         final var hasChanged = lastModified != newLastModified;
@@ -90,50 +94,72 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
         return hasChanged;
     }
 
-    protected DOMMetadataResolver buildMetadata() {
-        try {
-            final DOMMetadataResolver resolver;
-            try (var in = this.idpMetadataResource.getInputStream()) {
-                final var inCommonMDDoc = Configuration.getParserPool().parse(in);
-                final var metadataRoot = inCommonMDDoc.getDocumentElement();
-                resolver = new DOMMetadataResolver(metadataRoot);
-                resolver.setIndexes(Collections.singleton(new RoleMetadataIndex()));
-                resolver.setParserPool(Configuration.getParserPool());
-                resolver.setFailFastInitialization(true);
-                resolver.setRequireValidMetadata(true);
-                resolver.setId(resolver.getClass().getCanonicalName());
-                resolver.initialize();
-            } catch (final FileNotFoundException e) {
-                if (logger.isDebugEnabled()) {
-                    logger.error(e.getMessage(), e);
-                }
-                throw new TechnicalException("Error loading idp Metadata: " + e.getMessage());
+    protected MetadataResolver buildMetadataResolver() {
+        var resolver = initializeMetadataResolver();
+        determineIdentityProviderEntityId(resolver);
+        return resolver;
+    }
+
+    public long getLastModified() {
+        return lastModified;
+    }
+
+    /**
+     * If no idpEntityId declared, select first EntityDescriptor entityId as our IDP.
+     *
+     * @param resolver metadata resolver
+     */
+    private void determineIdentityProviderEntityId(final IterableMetadataSource resolver) {
+        if (this.idpEntityId == null) {
+            var it = resolver.iterator();
+            if (it.hasNext()) {
+                var entityDescriptor = it.next();
+                this.idpEntityId = entityDescriptor.getEntityID();
             }
-            // If no idpEntityId declared, select first EntityDescriptor entityId as our IDP entityId
-            if (this.idpEntityId == null) {
-                final var it = resolver.iterator();
-
-                while (it.hasNext()) {
-                    final var entityDescriptor = it.next();
-                    if (this.idpEntityId == null) {
-                        this.idpEntityId = entityDescriptor.getEntityID();
-                    }
-                }
-            }
-
-            if (this.idpEntityId == null) {
-                throw new SAMLException("No idp entityId found");
-            }
-
-            return resolver;
-
-        } catch (final ComponentInitializationException e) {
-            throw new SAMLException("Error initializing idpMetadataProvider", e);
-        } catch (final XMLParserException e) {
-            throw new TechnicalException("Error parsing idp Metadata", e);
-        } catch (final IOException e) {
-            throw new TechnicalException("Error getting idp Metadata resource", e);
         }
+
+        if (this.idpEntityId == null) {
+            throw new SAMLException("No idp entityId found");
+        }
+    }
+
+    private DOMMetadataResolver initializeMetadataResolver() {
+        try (var in = getMetadataResourceInputStream()) {
+            var parsedInput = Configuration.getParserPool().parse(in);
+            var metadataRoot = parsedInput.getDocumentElement();
+            var resolver = new DOMMetadataResolver(metadataRoot);
+            resolver.setIndexes(Collections.singleton(new RoleMetadataIndex()));
+            resolver.setParserPool(Configuration.getParserPool());
+            resolver.setFailFastInitialization(true);
+            resolver.setRequireValidMetadata(true);
+            resolver.setId(resolver.getClass().getCanonicalName());
+            resolver.initialize();
+            return resolver;
+        } catch (final FileNotFoundException e) {
+            throw new TechnicalException("Error loading idp metadata", e);
+        } catch (final ComponentInitializationException e) {
+            throw new TechnicalException("Error initializing idp metadata resolver", e);
+        } catch (final XMLParserException e) {
+            throw new TechnicalException("Error parsing idp metadata", e);
+        } catch (final IOException e) {
+            throw new TechnicalException("Error getting idp metadata resource", e);
+        }
+    }
+
+    protected InputStream getMetadataResourceInputStream() throws IOException {
+        if (this.idpMetadataResource instanceof UrlResource) {
+            var con = idpMetadataResource.getURL().openConnection(proxy);
+            try {
+                return con.getInputStream();
+            } catch (final Exception e) {
+                if (con instanceof HttpURLConnection) {
+                    ((HttpURLConnection) con).disconnect();
+                }
+                throw new TechnicalException("Error getting idp metadata resource", e);
+            }
+        }
+
+        return this.idpMetadataResource.getInputStream();
     }
 
     @Override
@@ -163,5 +189,9 @@ public class SAML2IdentityProviderMetadataResolver implements SAML2MetadataResol
         } catch (final ResolverException e) {
             throw new SAMLException("Error initializing idpMetadataProvider", e);
         }
+    }
+
+    public void setProxy(final Proxy proxy) {
+        this.proxy = proxy;
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataResolver.java
@@ -10,7 +10,11 @@ import org.opensaml.saml.metadata.resolver.MetadataResolver;
  * @since 1.7
  */
 public interface SAML2MetadataResolver {
-    MetadataResolver resolve();
+    MetadataResolver resolve(boolean force);
+
+    default MetadataResolver resolve() {
+        return resolve(false);
+    }
 
     String getEntityId();
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -52,7 +52,7 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
     }
 
     @Override
-    public final MetadataResolver resolve() {
+    public final MetadataResolver resolve(final boolean force) {
         return this.metadataResolver;
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/store/HazelcastSAMLMessageStoreTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/store/HazelcastSAMLMessageStoreTests.java
@@ -2,7 +2,6 @@ package org.pac4j.saml.store;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import com.hazelcast.core.HazelcastInstance;

--- a/pac4j-saml/src/test/resources/expired-idp-metadata.xml
+++ b/pac4j-saml/src/test/resources/expired-idp-metadata.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<md:EntityDescriptor cacheDuration="PT60S" entityID="urn:app.e2ma.net" validUntil="2013-03-22T23:00:00Z" xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata">
+    <md:SPSSODescriptor AuthnRequestsSigned="false" WantAssertionsSigned="false" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:KeyInfo><ds:X509Data><ds:X509Certificate>MIIDUjCCArugAwIBAgIJAJZgTIliYAkVMA0GCSqGSIb3DQEBBQUAMHoxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJUTjESMBAGA1UEBxMJTmFzaHZpbGxlMRMwEQYDVQQKEwpFbW1hLCBJbmMuMRQwEgYDVQQLEwtFbmdpbmVlcmluZzEfMB0GCSqGSIb3DQEJARYQam1vY2tAbXllbW1hLmNvbTAeFw0xNzA1MDgxODQ3MzNaFw0yNzA1MDgxODQ3MzNaMHoxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJUTjESMBAGA1UEBxMJTmFzaHZpbGxlMRMwEQYDVQQKEwpFbW1hLCBJbmMuMRQwEgYDVQQLEwtFbmdpbmVlcmluZzEfMB0GCSqGSIb3DQEJARYQam1vY2tAbXllbW1hLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA1WK2gRBuq1QXcMDU3Dy5BUIxVfeNV/+bM4MwW4Eqgta1IdbUSMY+lsVfhGESdkV03psZxLCuO40MHO2Jz8UXf2EZEKeZ6NvRBOnb1mb0JAYLA0RaIFCPObwZWysbx8QQG1lb+5tsfuXhD6qUDse0+lAKuXt7t/Mbo60WxmEshV8CAwEAAaOB3zCB3DAdBgNVHQ4EFgQUxZua3o+Fd7amzPywh9PrBx8ZJuUwgawGA1UdIwSBpDCBoYAUxZua3o+Fd7amzPywh9PrBx8ZJuWhfqR8MHoxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJUTjESMBAGA1UEBxMJTmFzaHZpbGxlMRMwEQYDVQQKEwpFbW1hLCBJbmMuMRQwEgYDVQQLEwtFbmdpbmVlcmluZzEfMB0GCSqGSIb3DQEJARYQam1vY2tAbXllbW1hLmNvbYIJAJZgTIliYAkVMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAX1oEkteXJwv1I7gnYSdFxoptUBo4vxRgguR1EyC5//mi463VJmDKQ6NjDSUaJpNEguGcJ2qXSfOcMiVcCt1rnrPPAnjD/2oZZvKUKfefNHYXRFNw2KUhORPolhglGe5ef+IyZW+WeQM5CJxdTMIMxdAMkxbNt9pAGu1o2YN9K7k=</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor>
+        <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://app2.e2ma.net/app2/sso/request_logout/"/>
+        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>
+        <md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://app.e2ma.net/app2/sso/assert_identity/" index="1"/>
+    </md:SPSSODescriptor>
+    <md:Organization>
+        <md:OrganizationName xml:lang="en-US">emma</md:OrganizationName>
+        <md:OrganizationDisplayName xml:lang="en-US">Emma, Inc.</md:OrganizationDisplayName>
+        <md:OrganizationURL xml:lang="en-US">https://help.myemma.com/s/</md:OrganizationURL>
+    </md:Organization>
+</md:EntityDescriptor>


### PR DESCRIPTION
This patch:

1. Allows the API to force the resolution and download of SAML2 idp metadata. (The only to do that is now to deconstruct the SAML2 client and reinitialize it)
2. Allow "last-modified" attributes for both file-system and URL-based metadata resources.
3. Support proxies for idp metadata URL resources

There is also some internal cleanup where the `SAML2IdentityProviderMetadataResolver` is broken down into smaller pieces/methods for easier review and extensions.

This patch should remain compatible with previous versions, both for behavior and API.

If possible, it would be great to backport this into 4.x and I can certainly either cherry-pick or post a PR if a 4.x patch can be released at some point.
