### PR TITLE
SAML2: option to disable validation of authn-instant

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -7,6 +7,8 @@ title: Release notes&#58;
 
 - SAML2 identity provider metadata resolver can optionally be forced to download the metadata again.
 - SAML2 identity provider metadata resolver is given the ability to support `last-modified` attributes for URLs.
+- SAML2 response validation can now disable the validation of `authnInstant` by assigning a zero/negative value to
+  `SAML2Configuration#configuration.setMaximumAuthenticationLifetime()`. This setting should not be using sparingly.
 
 **v5.0.1**:
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -681,11 +681,12 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
 
     private boolean isAuthnInstantValid(final SAML2MessageContext context, final Instant authnInstant) {
         var configContext = context.getConfigurationContext();
-        if (configContext.getMaximumAuthenticationLifetime() <= 0) {
+        var maximumAuthenticationLifetime = configContext.getMaximumAuthenticationLifetime();
+        if (maximumAuthenticationLifetime <= 0) {
             logger.info("Maximum authentication lifetime is set to {} with authn-instant {}. "
-                + "Validation will be disabled.", configContext.getMaximumAuthenticationLifetime(), authnInstant);
+                + "Validation will be disabled.", maximumAuthenticationLifetime, authnInstant);
             return true;
         }
-        return isDateValid(authnInstant, configContext.getMaximumAuthenticationLifetime());
+        return isDateValid(authnInstant, maximumAuthenticationLifetime);
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -681,6 +681,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
 
     private boolean isAuthnInstantValid(final SAML2MessageContext context, final Instant authnInstant) {
         var configContext = context.getConfigurationContext();
-        return isDateValid(authnInstant, configContext.getMaximumAuthenticationLifetime());
+        return configContext.getMaximumAuthenticationLifetime() <= 0 ||
+            isDateValid(authnInstant, configContext.getMaximumAuthenticationLifetime());
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -681,7 +681,11 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
 
     private boolean isAuthnInstantValid(final SAML2MessageContext context, final Instant authnInstant) {
         var configContext = context.getConfigurationContext();
-        return configContext.getMaximumAuthenticationLifetime() <= 0 ||
-            isDateValid(authnInstant, configContext.getMaximumAuthenticationLifetime());
+        if (configContext.getMaximumAuthenticationLifetime() <= 0) {
+            logger.info("Maximum authentication lifetime is set to {} with authn-instant {}. "
+                + "Validation will be disabled.", configContext.getMaximumAuthenticationLifetime(), authnInstant);
+            return true;
+        }
+        return isDateValid(authnInstant, configContext.getMaximumAuthenticationLifetime());
     }
 }


### PR DESCRIPTION
Allow for an option/convention to disable checking for authn-instant values when dealing with SAML2 responses.