### PR TITLE
Log error description when OIDCAuthenticator gets a bad token response

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -178,7 +178,8 @@ public class OidcAuthenticator implements Authenticator {
 
         final var response = OIDCTokenResponseParser.parse(httpResponse);
         if (response instanceof TokenErrorResponse) {
-            throw new TechnicalException("Bad token response, error=" + ((TokenErrorResponse) response).getErrorObject());
+            final var errorObject = ((TokenErrorResponse) response).getErrorObject();
+            throw new TechnicalException("Bad token response, error=" + errorObject.getCode() +", description=" + errorObject.getDescription());
         }
         logger.debug("Token response successful");
         final var tokenSuccessResponse = (OIDCTokenResponse) response;

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -179,7 +179,8 @@ public class OidcAuthenticator implements Authenticator {
         final var response = OIDCTokenResponseParser.parse(httpResponse);
         if (response instanceof TokenErrorResponse) {
             final var errorObject = ((TokenErrorResponse) response).getErrorObject();
-            throw new TechnicalException("Bad token response, error=" + errorObject.getCode() +", description=" + errorObject.getDescription());
+            throw new TechnicalException("Bad token response, error=" + errorObject.getCode() +"," +
+                " description=" + errorObject.getDescription());
         }
         logger.debug("Token response successful");
         final var tokenSuccessResponse = (OIDCTokenResponse) response;


### PR DESCRIPTION
The description texts holds some very valuable information to debug these kinds of errors.