### PR TITLE
added nullchecks for optional <Conditions> attributes (NPE fix)

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -46,17 +46,17 @@ public class SAML2Credentials extends Credentials {
         this.sessionIndex = sessionIndex;
         this.attributes = samlAttributes;
         
-		if (conditions != null) {
-			this.conditions = new SAMLConditions();
-			
-			if (conditions.getNotBefore() != null) {
-				this.conditions.setNotBefore(ZonedDateTime.ofInstant(conditions.getNotBefore(), ZoneOffset.UTC));
-			}
+        if (conditions != null) {
+            this.conditions = new SAMLConditions();
+            
+            if (conditions.getNotBefore() != null) {
+                this.conditions.setNotBefore(ZonedDateTime.ofInstant(conditions.getNotBefore(), ZoneOffset.UTC));
+            }
 
-			if (conditions.getNotOnOrAfter() != null) {
-				this.conditions.setNotOnOrAfter(ZonedDateTime.ofInstant(conditions.getNotOnOrAfter(), ZoneOffset.UTC));
-			}
-		}
+            if (conditions.getNotOnOrAfter() != null) {
+                this.conditions.setNotOnOrAfter(ZonedDateTime.ofInstant(conditions.getNotOnOrAfter(), ZoneOffset.UTC));
+            }
+        }
 
         this.authnContexts = authnContexts;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -46,9 +46,6 @@ public class SAML2Credentials extends Credentials {
         this.sessionIndex = sessionIndex;
         this.attributes = samlAttributes;
         
-		// <Conditions> are optional elements in SAML2 assertions, so if NotBefore or
-		// NotOnOrAfter are not included, they are null here and using them in
-		// ZonedDateTime.ofInstant() causes an NPE.
 		if (conditions != null) {
 			this.conditions = new SAMLConditions();
 			

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -45,9 +45,22 @@ public class SAML2Credentials extends Credentials {
         this.issuerId = issuerId;
         this.sessionIndex = sessionIndex;
         this.attributes = samlAttributes;
-        this.conditions = new SAMLConditions();
-        this.conditions.setNotBefore(ZonedDateTime.ofInstant(conditions.getNotBefore(), ZoneOffset.UTC));
-        this.conditions.setNotOnOrAfter(ZonedDateTime.ofInstant(conditions.getNotOnOrAfter(), ZoneOffset.UTC));
+        
+		// <Conditions> are optional elements in SAML2 assertions, so if NotBefore or
+		// NotOnOrAfter are not included, they are null here and using them in
+		// ZonedDateTime.ofInstant() causes an NPE.
+		if (conditions != null) {
+			this.conditions = new SAMLConditions();
+			
+			if (conditions.getNotBefore() != null) {
+				this.conditions.setNotBefore(ZonedDateTime.ofInstant(conditions.getNotBefore(), ZoneOffset.UTC));
+			}
+
+			if (conditions.getNotOnOrAfter() != null) {
+				this.conditions.setNotOnOrAfter(ZonedDateTime.ofInstant(conditions.getNotOnOrAfter(), ZoneOffset.UTC));
+			}
+		}
+
         this.authnContexts = authnContexts;
 
         logger.info("Constructed SAML2 credentials: {}", this);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -121,10 +121,14 @@ public class SAML2Authenticator extends ProfileDefinitionAware implements Authen
         // Adding them to both the "regular" and authentication attributes so we don't break anyone currently using it.
         final var conditions = credentials.getConditions();
         if (conditions != null) {
-            profile.addAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, conditions.getNotBefore());
-            profile.addAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, conditions.getNotBefore());
-            profile.addAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, conditions.getNotOnOrAfter());
-            profile.addAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, conditions.getNotOnOrAfter());
+        	if (conditions.getNotBefore() != null) {
+                profile.addAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, conditions.getNotBefore());
+                profile.addAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, conditions.getNotBefore());
+        	}
+        	if (conditions.getNotOnOrAfter() != null) {
+                profile.addAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, conditions.getNotOnOrAfter());
+                profile.addAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, conditions.getNotOnOrAfter());
+        	}
         }
 
         credentials.setUserProfile(profile);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/authenticator/SAML2Authenticator.java
@@ -121,14 +121,14 @@ public class SAML2Authenticator extends ProfileDefinitionAware implements Authen
         // Adding them to both the "regular" and authentication attributes so we don't break anyone currently using it.
         final var conditions = credentials.getConditions();
         if (conditions != null) {
-        	if (conditions.getNotBefore() != null) {
+            if (conditions.getNotBefore() != null) {
                 profile.addAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, conditions.getNotBefore());
                 profile.addAuthenticationAttribute(SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, conditions.getNotBefore());
-        	}
-        	if (conditions.getNotOnOrAfter() != null) {
+            }
+            if (conditions.getNotOnOrAfter() != null) {
                 profile.addAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, conditions.getNotOnOrAfter());
                 profile.addAuthenticationAttribute(SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, conditions.getNotOnOrAfter());
-        	}
+            }
         }
 
         credentials.setUserProfile(profile);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
@@ -39,15 +39,84 @@ public class SAML2AuthenticatorTests {
 
     @Test
     public void verifyAttributeMapping() {
-        final var nameid = nameIdBuilder.buildObject();
+        final var credentials = createCredentialsForTest(true, true);
+        final Map<String, String> mappedAttributes = createMappedAttributesForTest();
+
+        final var authenticator = new SAML2Authenticator("username", mappedAttributes);
+        authenticator.validate(credentials, MockWebContext.create(), new MockSessionStore());
+
+        final var finalProfile = credentials.getUserProfile();
+        assertTrue(finalProfile.containsAttribute("mapped-display-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-given-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-surname"));
+    }
+
+    @Test
+    public void validateWithMissingNotBeforeCondition() {
+        final var credentials = createCredentialsForTest(false, true);
+        final Map<String, String> mappedAttributes = createMappedAttributesForTest();
+
+        final var authenticator = new SAML2Authenticator("username", mappedAttributes);
+        authenticator.validate(credentials, MockWebContext.create(), new MockSessionStore());
+
+        final var finalProfile = credentials.getUserProfile();
+        assertTrue(finalProfile.containsAttribute("mapped-display-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-given-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-surname"));
+    }
+    
+    @Test
+    public void validateWithMissingNotOnOrAfterCondition() {
+        final var credentials = createCredentialsForTest(true, false);
+        final Map<String, String> mappedAttributes = createMappedAttributesForTest();
+
+        final var authenticator = new SAML2Authenticator("username", mappedAttributes);
+        authenticator.validate(credentials, MockWebContext.create(), new MockSessionStore());
+
+        final var finalProfile = credentials.getUserProfile();
+        assertTrue(finalProfile.containsAttribute("mapped-display-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-given-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-surname"));
+    }
+    
+    @Test
+    public void validateWithEmptyConditions() {
+        final var credentials = createCredentialsForTest(false, false);
+        final Map<String, String> mappedAttributes = createMappedAttributesForTest();
+
+        final var authenticator = new SAML2Authenticator("username", mappedAttributes);
+        authenticator.validate(credentials, MockWebContext.create(), new MockSessionStore());
+
+        final var finalProfile = credentials.getUserProfile();
+        assertTrue(finalProfile.containsAttribute("mapped-display-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-given-name"));
+        assertTrue(finalProfile.containsAttribute("mapped-surname"));
+    }
+    
+	private Map<String, String> createMappedAttributesForTest() {
+		final Map<String, String> mappedAttributes = new LinkedHashMap<>();
+        mappedAttributes.put("urn:oid:2.16.840.1.113730.3.1.241", "mapped-display-name");
+        mappedAttributes.put("urn:oid:2.5.4.42", "mapped-given-name");
+        mappedAttributes.put("urn:oid:2.5.4.4", "mapped-surname");
+		return mappedAttributes;
+	}
+    
+	private SAML2Credentials createCredentialsForTest(boolean includeNotBefore, boolean includeNotOnOrAfter) {
+		final var nameid = nameIdBuilder.buildObject();
         nameid.setValue("pac4j");
         nameid.setSPNameQualifier("pac4j");
         nameid.setNameQualifier("pac4j");
         nameid.setSPProvidedID("pac4j");
 
         final var conditions = conditionsBuilder.buildObject();
-        conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
-        conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+        
+        if (includeNotBefore) {
+        	conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+        }
+        
+        if (includeNotOnOrAfter) {
+        	conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+        }
 
         final List<String> contexts = new ArrayList<>();
         contexts.add("cas-context");
@@ -62,20 +131,8 @@ public class SAML2AuthenticatorTests {
         final var credentials = new SAML2Credentials(SAML2Credentials.SAMLNameID.from(nameid),
             "example.issuer.com",
             SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts);
-
-        final Map<String, String> mappedAttributes = new LinkedHashMap<>();
-        mappedAttributes.put("urn:oid:2.16.840.1.113730.3.1.241", "mapped-display-name");
-        mappedAttributes.put("urn:oid:2.5.4.42", "mapped-given-name");
-        mappedAttributes.put("urn:oid:2.5.4.4", "mapped-surname");
-
-        final var authenticator = new SAML2Authenticator("username", mappedAttributes);
-        authenticator.validate(credentials, MockWebContext.create(), new MockSessionStore());
-
-        final var finalProfile = credentials.getUserProfile();
-        assertTrue(finalProfile.containsAttribute("mapped-display-name"));
-        assertTrue(finalProfile.containsAttribute("mapped-given-name"));
-        assertTrue(finalProfile.containsAttribute("mapped-surname"));
-    }
+		return credentials;
+	}
 
     private Attribute createAttribute(final String friendlyName, final String name, final String value) {
         final var attributeBuilder = (SAMLObjectBuilder<Attribute>)

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
@@ -93,16 +93,16 @@ public class SAML2AuthenticatorTests {
         assertTrue(finalProfile.containsAttribute("mapped-surname"));
     }
     
-	private Map<String, String> createMappedAttributesForTest() {
-		final Map<String, String> mappedAttributes = new LinkedHashMap<>();
+    private Map<String, String> createMappedAttributesForTest() {
+        final Map<String, String> mappedAttributes = new LinkedHashMap<>();
         mappedAttributes.put("urn:oid:2.16.840.1.113730.3.1.241", "mapped-display-name");
         mappedAttributes.put("urn:oid:2.5.4.42", "mapped-given-name");
         mappedAttributes.put("urn:oid:2.5.4.4", "mapped-surname");
-		return mappedAttributes;
-	}
+        return mappedAttributes;
+    }
     
-	private SAML2Credentials createCredentialsForTest(boolean includeNotBefore, boolean includeNotOnOrAfter) {
-		final var nameid = nameIdBuilder.buildObject();
+    private SAML2Credentials createCredentialsForTest(boolean includeNotBefore, boolean includeNotOnOrAfter) {
+        final var nameid = nameIdBuilder.buildObject();
         nameid.setValue("pac4j");
         nameid.setSPNameQualifier("pac4j");
         nameid.setNameQualifier("pac4j");
@@ -111,11 +111,11 @@ public class SAML2AuthenticatorTests {
         final var conditions = conditionsBuilder.buildObject();
         
         if (includeNotBefore) {
-        	conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+            conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
         }
         
         if (includeNotOnOrAfter) {
-        	conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+            conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
         }
 
         final List<String> contexts = new ArrayList<>();
@@ -131,8 +131,8 @@ public class SAML2AuthenticatorTests {
         final var credentials = new SAML2Credentials(SAML2Credentials.SAMLNameID.from(nameid),
             "example.issuer.com",
             SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts);
-		return credentials;
-	}
+        return credentials;
+    }
 
     private Attribute createAttribute(final String friendlyName, final String name, final String value) {
         final var attributeBuilder = (SAMLObjectBuilder<Attribute>)


### PR DESCRIPTION
According to the SAML2 specifications at https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf, the Conditions element is optional and so are the attributes NotBefore and NotOnOrAfter.

Currently if Conditions is included in an assertion, but only NotBefore or (xor!) NotOnOrAfter are provided,  the ZonedDateTime.ofInstant() call causes a NullPointerException.