### PR TITLE
Extraction of attributevalues with complex types

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -1,5 +1,11 @@
 package org.pac4j.saml.credentials;
 
+import java.io.Serializable;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Conditions;
@@ -7,13 +13,8 @@ import org.opensaml.saml.saml2.core.NameID;
 import org.pac4j.core.credentials.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 
 /**
  * Credentials containing the nameId of the SAML subject and all of its attributes.
@@ -218,20 +219,63 @@ public class SAML2Credentials extends Credentials {
         private String nameFormat;
         private List<String> attributeValues = new ArrayList<>();
 
+		public static SAMLAttribute from(Attribute attribute) {
+			final var samlAttribute = new SAMLAttribute();
+			samlAttribute.setFriendlyName(attribute.getFriendlyName());
+			samlAttribute.setName(attribute.getName());
+			samlAttribute.setNameFormat(attribute.getNameFormat());
+			attribute.getAttributeValues()
+			    .stream()
+			    .map(XMLObject::getDOM)
+			    .filter(dom -> dom != null && dom.getTextContent() != null)
+			    .forEach(dom -> samlAttribute.getAttributeValues().add(dom.getTextContent()));
+			return samlAttribute;
+		}
+        
         public static List<SAMLAttribute> from(final List<Attribute> samlAttributes) {
-            return samlAttributes.stream().map(attribute -> {
-                final var samlAttribute = new SAMLAttribute();
-                samlAttribute.setFriendlyName(attribute.getFriendlyName());
-                samlAttribute.setName(attribute.getName());
-                samlAttribute.setNameFormat(attribute.getNameFormat());
-                attribute.getAttributeValues()
-                    .stream()
-                    .map(XMLObject::getDOM)
-                    .filter(dom -> dom != null && dom.getTextContent() != null)
-                    .forEach(dom -> samlAttribute.getAttributeValues().add(dom.getTextContent()));
-                return samlAttribute;
-            }).collect(Collectors.toList());
+        	
+    		List<SAMLAttribute> extractedAttributes = new ArrayList<>();
+    		
+    		samlAttributes.forEach(openSamlAttribute -> {
+    			openSamlAttribute.getAttributeValues().forEach(attributeValue -> {
+    				boolean isKnownType = attributeValue.getSchemaType() != null;
+    				
+    				if (isKnownType) {
+    					extractedAttributes.add(SAMLAttribute.from(openSamlAttribute));
+    				}
+    				else {
+    					List<SAMLAttribute> attrs = collectAttributesFromNodeList(attributeValue.getDOM().getChildNodes());
+    					extractedAttributes.addAll(attrs);
+    				}
+    			});
+    		});
+        	
+        	return extractedAttributes;
         }
+        
+    	private static List<SAMLAttribute> collectAttributesFromNodeList(NodeList nodeList)  {
+
+    		var results = new ArrayList<SAMLAttribute>();
+
+    		if (nodeList == null) {
+    			return results;
+    		}
+    		
+			for (int i = 0; i < nodeList.getLength(); i++) {
+				Node node = nodeList.item(i);
+
+				if (node.hasChildNodes()) {
+					results.addAll(collectAttributesFromNodeList(node.getChildNodes()));
+				} else if (!node.getTextContent().isBlank()) {
+					SAMLAttribute samlAttribute = new SAMLAttribute();
+					samlAttribute.setName(node.getParentNode().getLocalName());
+					samlAttribute.getAttributeValues().add(node.getTextContent());
+					results.add(samlAttribute);
+				}
+			}
+
+    		return results;
+    	}
 
         public String getFriendlyName() {
             return friendlyName;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -46,10 +46,10 @@ public class SAML2Credentials extends Credentials {
         this.issuerId = issuerId;
         this.sessionIndex = sessionIndex;
         this.attributes = samlAttributes;
-        
+
         if (conditions != null) {
             this.conditions = new SAMLConditions();
-            
+
             if (conditions.getNotBefore() != null) {
                 this.conditions.setNotBefore(ZonedDateTime.ofInstant(conditions.getNotBefore(), ZoneOffset.UTC));
             }
@@ -219,63 +219,63 @@ public class SAML2Credentials extends Credentials {
         private String nameFormat;
         private List<String> attributeValues = new ArrayList<>();
 
-		public static SAMLAttribute from(Attribute attribute) {
-			final var samlAttribute = new SAMLAttribute();
-			samlAttribute.setFriendlyName(attribute.getFriendlyName());
-			samlAttribute.setName(attribute.getName());
-			samlAttribute.setNameFormat(attribute.getNameFormat());
-			attribute.getAttributeValues()
-			    .stream()
-			    .map(XMLObject::getDOM)
-			    .filter(dom -> dom != null && dom.getTextContent() != null)
-			    .forEach(dom -> samlAttribute.getAttributeValues().add(dom.getTextContent()));
-			return samlAttribute;
-		}
-        
-        public static List<SAMLAttribute> from(final List<Attribute> samlAttributes) {
-        	
-    		List<SAMLAttribute> extractedAttributes = new ArrayList<>();
-    		
-    		samlAttributes.forEach(openSamlAttribute -> {
-    			openSamlAttribute.getAttributeValues().forEach(attributeValue -> {
-    				boolean isKnownType = attributeValue.getSchemaType() != null;
-    				
-    				if (isKnownType) {
-    					extractedAttributes.add(SAMLAttribute.from(openSamlAttribute));
-    				}
-    				else {
-    					List<SAMLAttribute> attrs = collectAttributesFromNodeList(attributeValue.getDOM().getChildNodes());
-    					extractedAttributes.addAll(attrs);
-    				}
-    			});
-    		});
-        	
-        	return extractedAttributes;
+        public static SAMLAttribute from(Attribute attribute) {
+            final var samlAttribute = new SAMLAttribute();
+            samlAttribute.setFriendlyName(attribute.getFriendlyName());
+            samlAttribute.setName(attribute.getName());
+            samlAttribute.setNameFormat(attribute.getNameFormat());
+            attribute.getAttributeValues()
+                .stream()
+                .map(XMLObject::getDOM)
+                .filter(dom -> dom != null && dom.getTextContent() != null)
+                .forEach(dom -> samlAttribute.getAttributeValues().add(dom.getTextContent()));
+            return samlAttribute;
         }
-        
-    	private static List<SAMLAttribute> collectAttributesFromNodeList(NodeList nodeList)  {
 
-    		var results = new ArrayList<SAMLAttribute>();
+        public static List<SAMLAttribute> from(final List<Attribute> samlAttributes) {
 
-    		if (nodeList == null) {
-    			return results;
-    		}
-    		
-			for (int i = 0; i < nodeList.getLength(); i++) {
-				Node node = nodeList.item(i);
+            List<SAMLAttribute> extractedAttributes = new ArrayList<>();
 
-				if (node.hasChildNodes()) {
-					results.addAll(collectAttributesFromNodeList(node.getChildNodes()));
-				} else if (!node.getTextContent().isBlank()) {
-					SAMLAttribute samlAttribute = new SAMLAttribute();
-					samlAttribute.setName(node.getParentNode().getLocalName());
-					samlAttribute.getAttributeValues().add(node.getTextContent());
-					results.add(samlAttribute);
-				}
-			}
+            samlAttributes.forEach(openSamlAttribute -> {
+                openSamlAttribute.getAttributeValues().forEach(attributeValue -> {
+                    boolean isKnownType = attributeValue.getSchemaType() != null;
 
-    		return results;
-    	}
+                    if (isKnownType) {
+                        extractedAttributes.add(SAMLAttribute.from(openSamlAttribute));
+                    }
+                    else {
+                        List<SAMLAttribute> attrs = collectAttributesFromNodeList(attributeValue.getDOM().getChildNodes());
+                        extractedAttributes.addAll(attrs);
+                    }
+                });
+            });
+
+            return extractedAttributes;
+        }
+
+        private static List<SAMLAttribute> collectAttributesFromNodeList(NodeList nodeList)  {
+
+            var results = new ArrayList<SAMLAttribute>();
+
+            if (nodeList == null) {
+                return results;
+            }
+
+            for (int i = 0; i < nodeList.getLength(); i++) {
+                Node node = nodeList.item(i);
+
+                if (node.hasChildNodes()) {
+                    results.addAll(collectAttributesFromNodeList(node.getChildNodes()));
+                } else if (!node.getTextContent().isBlank()) {
+                    SAMLAttribute samlAttribute = new SAMLAttribute();
+                    samlAttribute.setName(node.getParentNode().getLocalName());
+                    samlAttribute.getAttributeValues().add(node.getTextContent());
+                    results.add(samlAttribute);
+                }
+            }
+
+            return results;
+        }
 
         public String getFriendlyName() {
             return friendlyName;

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -1,10 +1,23 @@
 package org.pac4j.saml.credentials;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.common.messaging.context.SAMLEndpointContext;
+import org.opensaml.saml.common.messaging.context.SAMLSubjectNameIdentifierContext;
+import org.opensaml.saml.saml2.core.*;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.Endpoint;
+import org.pac4j.core.logout.handler.LogoutHandler;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.context.SAML2ConfigurationContext;
+import org.pac4j.saml.context.SAML2MessageContext;
+import org.pac4j.saml.credentials.SAML2Credentials.SAMLAttribute;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.sso.impl.SAML2AuthnResponseValidator;
+import org.pac4j.saml.util.Configuration;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -15,30 +28,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import junit.framework.AssertionFailedError;
-import org.hibernate.criterion.Example;
-import org.junit.Before;
-import org.junit.Test;
-import org.opensaml.core.xml.util.XMLObjectSupport;
-import org.opensaml.messaging.context.MessageContext;
-import org.opensaml.saml.common.SAMLVersion;
-import org.opensaml.saml.common.messaging.context.SAMLEndpointContext;
-import org.opensaml.saml.common.messaging.context.SAMLSubjectNameIdentifierContext;
-import org.opensaml.saml.saml2.core.*;
-import org.opensaml.saml.saml2.core.impl.StatusImpl;
-import org.opensaml.saml.saml2.encryption.Decrypter;
-import org.opensaml.saml.saml2.metadata.Endpoint;
-import org.opensaml.storage.ReplayCache;
-import org.pac4j.core.credentials.Credentials;
-import org.pac4j.core.logout.handler.LogoutHandler;
-import org.pac4j.saml.config.SAML2Configuration;
-import org.pac4j.saml.context.SAML2ConfigurationContext;
-import org.pac4j.saml.context.SAML2MessageContext;
-import org.pac4j.saml.credentials.SAML2Credentials.SAMLAttribute;
-import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
-import org.pac4j.saml.replay.ReplayCacheProvider;
-import org.pac4j.saml.sso.impl.SAML2AuthnResponseValidator;
-import org.pac4j.saml.util.Configuration;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SAML2CredentialsTest {
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -1,22 +1,39 @@
 package org.pac4j.saml.credentials;
 
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import junit.framework.AssertionFailedError;
+import org.hibernate.criterion.Example;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensaml.core.xml.util.XMLObjectSupport;
-import org.opensaml.saml.saml2.core.Assertion;
-import org.opensaml.saml.saml2.core.Attribute;
-import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.messaging.context.MessageContext;
+import org.opensaml.saml.common.SAMLVersion;
+import org.opensaml.saml.common.messaging.context.SAMLEndpointContext;
+import org.opensaml.saml.common.messaging.context.SAMLSubjectNameIdentifierContext;
+import org.opensaml.saml.saml2.core.*;
+import org.opensaml.saml.saml2.core.impl.StatusImpl;
 import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.metadata.Endpoint;
+import org.opensaml.storage.ReplayCache;
+import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.context.SAML2ConfigurationContext;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.credentials.SAML2Credentials.SAMLAttribute;
 import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
 import org.pac4j.saml.replay.ReplayCacheProvider;
@@ -27,12 +44,46 @@ public class SAML2CredentialsTest {
 
     public static final String RESPONSE_FILE_NAME = "sample_authn_response_with_complextype.xml";
 
-    private SAML2AuthnResponseValidatorForTest validator;
+    private SAML2AuthnResponseValidator validator;
+
+    private SAML2MessageContext mockSaml2MessageContext;
 
     @Before
     public void setUp() {
-        validator = new SAML2AuthnResponseValidatorForTest(mock(SAML2SignatureTrustEngineProvider.class),
-            mock(Decrypter.class), mock(ReplayCacheProvider.class), mock(SAML2Configuration.class));
+
+        final var mockStatus = mock(Status.class);
+        final var mockStatusCode = mock (StatusCode.class);
+        when(mockStatus.getStatusCode()).thenReturn(mockStatusCode);
+        when(mockStatusCode.getValue()).thenReturn(StatusCode.SUCCESS);
+
+        final var mockResponse = mock(Response.class);
+        when(mockResponse.getStatus()).thenReturn(mockStatus);
+        when(mockResponse.getVersion()).thenReturn(SAMLVersion.VERSION_20);
+        when(mockResponse.getIssueInstant()).thenReturn(Instant.now());
+
+        final var mockEndpoint = mock(Endpoint.class);
+        final var mockSamlEndpointContext = mock(SAMLEndpointContext.class);
+        when (mockSamlEndpointContext.getEndpoint()).thenReturn(mockEndpoint);
+
+        final var mockMessageContext = mock(MessageContext.class);
+        when(mockMessageContext.getMessage()).thenReturn(mockResponse);
+
+        final var mockSAMLSubjectNameIdentifierContext = mock(SAMLSubjectNameIdentifierContext.class);
+        when(mockSAMLSubjectNameIdentifierContext.getSAML2SubjectNameID()).thenReturn(mock(NameID.class));
+
+        final var mockSaml2Configuration = mock(SAML2Configuration.class);
+        when(mockSaml2Configuration.getLogoutHandler()).thenReturn(mock(LogoutHandler.class));
+
+        mockSaml2MessageContext = mock(SAML2MessageContext.class);
+        when(mockSaml2MessageContext.getMessageContext()).thenReturn(mockMessageContext);
+        when(mockSaml2MessageContext.getConfigurationContext()).thenReturn(mock(SAML2ConfigurationContext.class));
+        when(mockSaml2MessageContext.getSAMLEndpointContext()).thenReturn(mockSamlEndpointContext);
+        when(mockSaml2MessageContext.getSAML2Configuration()).thenReturn(mock(SAML2Configuration.class));
+        when(mockSaml2MessageContext.getSAMLSubjectNameIdentifierContext()).thenReturn(mockSAMLSubjectNameIdentifierContext);
+        when(mockSaml2MessageContext.getBaseID()).thenReturn(mock(BaseID.class));
+
+        validator = new SAML2AuthnResponseValidator(mock(SAML2SignatureTrustEngineProvider.class),
+            mock(Decrypter.class), null, mockSaml2Configuration);
     }
 
     @Test
@@ -44,33 +95,22 @@ public class SAML2CredentialsTest {
             new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
 
         final var response = (Response) xmlObject;
-        Assertion assertion = response.getAssertions().get(0);
+        final Assertion assertion = response.getAssertions().get(0);
+        when(mockSaml2MessageContext.getSubjectAssertion()).thenReturn(assertion);
 
-        var openSamlAttributes = validator.collectAssertionAttributes(assertion);
-        List<SAMLAttribute> extractedPac4jAttributes = SAML2Credentials.SAMLAttribute.from(openSamlAttributes);
-        assertTrue(extractedPac4jAttributes.size() > 0);
+        final var credentials = (SAML2Credentials)validator.validate(mockSaml2MessageContext);
+        assertNotNull(credentials);
+        final List<SAMLAttribute> attributes = credentials.getAttributes();
+        assertNotNull(attributes);
 
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Foo")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("OrganizationName")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("EmailAddress")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Street")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("StreetNumber")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("City")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("ZipCode")).findAny().orElseThrow(AssertionError::new);
-        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Country")).findAny().orElseThrow(AssertionError::new);
-    }
-
-    public static class SAML2AuthnResponseValidatorForTest extends SAML2AuthnResponseValidator {
-
-        public SAML2AuthnResponseValidatorForTest(SAML2SignatureTrustEngineProvider engine, Decrypter decrypter,
-                                                  ReplayCacheProvider replayCache, SAML2Configuration saml2Configuration) {
-            super(engine, decrypter, replayCache, saml2Configuration);
-        }
-
-        // Changed visibility to public.
-        @Override
-        public List<Attribute> collectAssertionAttributes(final Assertion subjectAssertion) {
-            return super.collectAssertionAttributes(subjectAssertion);
-        }
+        final Map<String, List<String>> resultAttributes = attributes.stream().collect(Collectors.toMap(SAMLAttribute::getName, SAMLAttribute::getAttributeValues));
+        assertEquals("Bar", resultAttributes.get("Foo").get(0));
+        assertEquals("Example Corp", resultAttributes.get("OrganizationName").get(0));
+        assertEquals("employee@example.com", resultAttributes.get("EmailAddress").get(0));
+        assertEquals("Example St", resultAttributes.get("Street").get(0));
+        assertEquals("123", resultAttributes.get("StreetNumber").get(0));
+        assertEquals("ExampleCity", resultAttributes.get("City").get(0));
+        assertEquals("123456", resultAttributes.get("ZipCode").get(0));
+        assertEquals("ExampleCountry", resultAttributes.get("Country").get(0));
     }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -1,0 +1,76 @@
+package org.pac4j.saml.credentials;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.core.xml.util.XMLObjectSupport;
+import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.Attribute;
+import org.opensaml.saml.saml2.core.Response;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.credentials.SAML2Credentials.SAMLAttribute;
+import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
+import org.pac4j.saml.replay.ReplayCacheProvider;
+import org.pac4j.saml.sso.impl.SAML2AuthnResponseValidator;
+import org.pac4j.saml.util.Configuration;
+
+public class SAML2CredentialsTest {
+
+	public static final String RESPONSE_FILE_NAME = "sample_authn_response_with_complextype.xml";
+
+	private SAML2AuthnResponseValidatorForTest validator;
+
+	@Before
+	public void setUp() {
+		validator = new SAML2AuthnResponseValidatorForTest(mock(SAML2SignatureTrustEngineProvider.class),
+				mock(Decrypter.class), mock(ReplayCacheProvider.class), mock(SAML2Configuration.class));
+	}
+
+	@Test
+	public void verifyComplexTypeExtractionWorks() throws Exception {
+		final var file = new File(
+				SAML2CredentialsTest.class.getClassLoader().getResource(RESPONSE_FILE_NAME).getFile());
+
+		final var xmlObject = XMLObjectSupport.unmarshallFromReader(Configuration.getParserPool(),
+				new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
+
+		final var response = (Response) xmlObject;
+		Assertion assertion = response.getAssertions().get(0);
+
+		var openSamlAttributes = validator.collectAssertionAttributes(assertion);
+		List<SAMLAttribute> extractedPac4jAttributes = SAML2Credentials.SAMLAttribute.from(openSamlAttributes);
+		assertTrue(extractedPac4jAttributes.size() > 0);
+		
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Foo")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("OrganizationName")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("EmailAddress")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Street")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("StreetNumber")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("City")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("ZipCode")).findAny().orElseThrow(AssertionError::new);
+		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Country")).findAny().orElseThrow(AssertionError::new);
+	}
+
+	public static class SAML2AuthnResponseValidatorForTest extends SAML2AuthnResponseValidator {
+
+		public SAML2AuthnResponseValidatorForTest(SAML2SignatureTrustEngineProvider engine, Decrypter decrypter,
+				ReplayCacheProvider replayCache, SAML2Configuration saml2Configuration) {
+			super(engine, decrypter, replayCache, saml2Configuration);
+		}
+
+		// Changed visibility to public.
+		@Override
+		public List<Attribute> collectAssertionAttributes(final Assertion subjectAssertion) {
+			return super.collectAssertionAttributes(subjectAssertion);
+		}
+	}
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -25,52 +25,52 @@ import org.pac4j.saml.util.Configuration;
 
 public class SAML2CredentialsTest {
 
-	public static final String RESPONSE_FILE_NAME = "sample_authn_response_with_complextype.xml";
+    public static final String RESPONSE_FILE_NAME = "sample_authn_response_with_complextype.xml";
 
-	private SAML2AuthnResponseValidatorForTest validator;
+    private SAML2AuthnResponseValidatorForTest validator;
 
-	@Before
-	public void setUp() {
-		validator = new SAML2AuthnResponseValidatorForTest(mock(SAML2SignatureTrustEngineProvider.class),
-				mock(Decrypter.class), mock(ReplayCacheProvider.class), mock(SAML2Configuration.class));
-	}
+    @Before
+    public void setUp() {
+        validator = new SAML2AuthnResponseValidatorForTest(mock(SAML2SignatureTrustEngineProvider.class),
+            mock(Decrypter.class), mock(ReplayCacheProvider.class), mock(SAML2Configuration.class));
+    }
 
-	@Test
-	public void verifyComplexTypeExtractionWorks() throws Exception {
-		final var file = new File(
-				SAML2CredentialsTest.class.getClassLoader().getResource(RESPONSE_FILE_NAME).getFile());
+    @Test
+    public void verifyComplexTypeExtractionWorks() throws Exception {
+        final var file = new File(
+            SAML2CredentialsTest.class.getClassLoader().getResource(RESPONSE_FILE_NAME).getFile());
 
-		final var xmlObject = XMLObjectSupport.unmarshallFromReader(Configuration.getParserPool(),
-				new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
+        final var xmlObject = XMLObjectSupport.unmarshallFromReader(Configuration.getParserPool(),
+            new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
 
-		final var response = (Response) xmlObject;
-		Assertion assertion = response.getAssertions().get(0);
+        final var response = (Response) xmlObject;
+        Assertion assertion = response.getAssertions().get(0);
 
-		var openSamlAttributes = validator.collectAssertionAttributes(assertion);
-		List<SAMLAttribute> extractedPac4jAttributes = SAML2Credentials.SAMLAttribute.from(openSamlAttributes);
-		assertTrue(extractedPac4jAttributes.size() > 0);
-		
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Foo")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("OrganizationName")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("EmailAddress")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Street")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("StreetNumber")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("City")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("ZipCode")).findAny().orElseThrow(AssertionError::new);
-		extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Country")).findAny().orElseThrow(AssertionError::new);
-	}
+        var openSamlAttributes = validator.collectAssertionAttributes(assertion);
+        List<SAMLAttribute> extractedPac4jAttributes = SAML2Credentials.SAMLAttribute.from(openSamlAttributes);
+        assertTrue(extractedPac4jAttributes.size() > 0);
 
-	public static class SAML2AuthnResponseValidatorForTest extends SAML2AuthnResponseValidator {
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Foo")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("OrganizationName")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("EmailAddress")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Street")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("StreetNumber")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("City")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("ZipCode")).findAny().orElseThrow(AssertionError::new);
+        extractedPac4jAttributes.stream().filter(x -> x.getName().equals("Country")).findAny().orElseThrow(AssertionError::new);
+    }
 
-		public SAML2AuthnResponseValidatorForTest(SAML2SignatureTrustEngineProvider engine, Decrypter decrypter,
-				ReplayCacheProvider replayCache, SAML2Configuration saml2Configuration) {
-			super(engine, decrypter, replayCache, saml2Configuration);
-		}
+    public static class SAML2AuthnResponseValidatorForTest extends SAML2AuthnResponseValidator {
 
-		// Changed visibility to public.
-		@Override
-		public List<Attribute> collectAssertionAttributes(final Assertion subjectAssertion) {
-			return super.collectAssertionAttributes(subjectAssertion);
-		}
-	}
+        public SAML2AuthnResponseValidatorForTest(SAML2SignatureTrustEngineProvider engine, Decrypter decrypter,
+                                                  ReplayCacheProvider replayCache, SAML2Configuration saml2Configuration) {
+            super(engine, decrypter, replayCache, saml2Configuration);
+        }
+
+        // Changed visibility to public.
+        @Override
+        public List<Attribute> collectAssertionAttributes(final Assertion subjectAssertion) {
+            return super.collectAssertionAttributes(subjectAssertion);
+        }
+    }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -103,7 +103,8 @@ public class SAML2CredentialsTest {
         final List<SAMLAttribute> attributes = credentials.getAttributes();
         assertNotNull(attributes);
 
-        final Map<String, List<String>> resultAttributes = attributes.stream().collect(Collectors.toMap(SAMLAttribute::getName, SAMLAttribute::getAttributeValues));
+        final Map<String, List<String>> resultAttributes = attributes.stream()
+            .collect(Collectors.toMap(SAMLAttribute::getName, SAMLAttribute::getAttributeValues));
         assertEquals("Bar", resultAttributes.get("Foo").get(0));
         assertEquals("Example Corp", resultAttributes.get("OrganizationName").get(0));
         assertEquals("employee@example.com", resultAttributes.get("EmailAddress").get(0));

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
@@ -13,6 +13,7 @@ import org.pac4j.saml.credentials.SAML2Credentials;
 import org.pac4j.saml.util.Configuration;
 import org.w3c.dom.Element;
 
+import javax.xml.namespace.QName;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -64,7 +65,7 @@ public class SAML2AuthenticatorTests {
         assertTrue(finalProfile.containsAttribute("mapped-given-name"));
         assertTrue(finalProfile.containsAttribute("mapped-surname"));
     }
-    
+
     @Test
     public void validateWithMissingNotOnOrAfterCondition() {
         final var credentials = createCredentialsForTest(true, false);
@@ -78,7 +79,7 @@ public class SAML2AuthenticatorTests {
         assertTrue(finalProfile.containsAttribute("mapped-given-name"));
         assertTrue(finalProfile.containsAttribute("mapped-surname"));
     }
-    
+
     @Test
     public void validateWithEmptyConditions() {
         final var credentials = createCredentialsForTest(false, false);
@@ -92,7 +93,7 @@ public class SAML2AuthenticatorTests {
         assertTrue(finalProfile.containsAttribute("mapped-given-name"));
         assertTrue(finalProfile.containsAttribute("mapped-surname"));
     }
-    
+
     private Map<String, String> createMappedAttributesForTest() {
         final Map<String, String> mappedAttributes = new LinkedHashMap<>();
         mappedAttributes.put("urn:oid:2.16.840.1.113730.3.1.241", "mapped-display-name");
@@ -100,7 +101,7 @@ public class SAML2AuthenticatorTests {
         mappedAttributes.put("urn:oid:2.5.4.4", "mapped-surname");
         return mappedAttributes;
     }
-    
+
     private SAML2Credentials createCredentialsForTest(boolean includeNotBefore, boolean includeNotOnOrAfter) {
         final var nameid = nameIdBuilder.buildObject();
         nameid.setValue("pac4j");
@@ -109,11 +110,11 @@ public class SAML2AuthenticatorTests {
         nameid.setSPProvidedID("pac4j");
 
         final var conditions = conditionsBuilder.buildObject();
-        
+
         if (includeNotBefore) {
             conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
         }
-        
+
         if (includeNotOnOrAfter) {
             conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
         }
@@ -146,6 +147,7 @@ public class SAML2AuthenticatorTests {
         final var dom = mock(Element.class);
         when(dom.getTextContent()).thenReturn(value);
         when(attrValue.getDOM()).thenReturn(dom);
+        when(attrValue.getSchemaType()).thenReturn(new QName(" http://www.w3.org/2001/XMLSchema", "string", "xs"));
 
         attr.getAttributeValues().add(attrValue);
         return attr;

--- a/pac4j-saml/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/pac4j-saml/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/pac4j-saml/src/test/resources/sample_authn_response_with_complextype.xml
+++ b/pac4j-saml/src/test/resources/sample_authn_response_with_complextype.xml
@@ -1,0 +1,164 @@
+<samlp:Response
+  xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Version="2.0"
+  IssueInstant="2020-01-31T15:55:38Z"
+  InResponseTo="_5815d22eaf804954b84ce1418f16edad3018926"
+  Destination="https://auth.izslt.it/cas/login?client_name=idptest"
+  ID="id_c082f790d3a0eb69cff209a0a1de34d3bf428b71">
+  <saml:Issuer
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+    NameQualifier="http://localhost:8088">http://localhost:8088</saml:Issuer>
+  <ds:Signature
+    xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod
+        Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+      <ds:SignatureMethod
+        Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+      <ds:Reference
+        URI="#id_c082f790d3a0eb69cff209a0a1de34d3bf428b71">
+        <ds:Transforms>
+          <ds:Transform
+            Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+          <ds:Transform
+            Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+        </ds:Transforms>
+        <ds:DigestMethod
+          Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+        <ds:DigestValue>Jvq7KJnbhqQx5EI8pbkPa4Isk4gKorVugi9qaN0PgzA=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>XboEc8nGkORSkRWtu11O/hZv8XUq9CfMagBTrHtsq8UGVUAAiHBYKRQlLDtEsLUzWU9GENbg6IO3NA9hfiFJoWprj5cXiqUTgmZ7IGSjQab7cV3Ta7d/g4Uux15LzFH7QKET8Tbtsln5p++BkUxmuqG5qFU6bIMRKRlpbV5HsiRRXARFbUS5OL1SxSdz60W3sEdrlYeox8q7DxIfiJaTLS1GxTqtjlxXCe9C2ZuT5nmVS0/YQIzJPODZPYDukICbOcXSqxjoInaCPRRcxbuVRF0CM+DGXc8H+l6JTDysfN15AQp9XIBmJPR3fElTIJnhAOqkK9BqUg8xaKT/kjnqCQ==</ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509Certificate>MIIC7TCCAdWgAwIBAgIJAPilQcSjwd+pMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNV
+          BAYTAklUMB4XDTE5MDYxMTEyMzkwN1oXDTE5MDcxMTEyMzkwN1owDTELMAkGA1UE
+          BhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCcBsGU+Je53Xw2
+          kgjRY/25Bi93eNO96CfYu3ZYCj/VOV1DytAWpCXtLQXAG1SVaeP3Ak8tkNi+RbCW
+          w0/WRTrUBEujLXjyHJHD80Dc6vuPuqJbZ1AClhIZyDIfwiMxmDRsYwf9QbEUoeX+
+          jqLK1i5+DGJBlAhWxn6cWfcXYRyGYihVh87B7wAqS0d2P5E3tvMx669IL3cuV2qn
+          y74l0OhK6xkYVwheb5b1XtmekBGVbiBVtz6CjTAh1d89lSOp0LVo19rCzDwI+4cO
+          jEmtDL0Fw6knzm29fUI8c5PLwAHfu+OjsHUONJj/YEjeqQqpQiFUHg3CkX18hPxs
+          WAZqjB7fAgMBAAGjUDBOMB0GA1UdDgQWBBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAf
+          BgNVHSMEGDAWgBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAMBgNVHRMEBTADAQH/MA0G
+          CSqGSIb3DQEBCwUAA4IBAQCBjICQbLfbKlDUfcm2AqsPD7crvq+jEH54Plnsj2WI
+          1iTnK0WWXs0OE4RymAqsP/4mvq95e0MxPy7n+L05EOp8+VFG47XzuQtjcqRzmg/4
+          sDojz6ToUl3dYKCcJYyklHIiFOA8vHJ5w4LKKfVMbHjnv7FT7lTAOiAtvH2/IpYT
+          y2EtLa7pdM3EuGxAKvH9UOli8NcFurZVA+gCS7Gp9tZkLHsa2anKbgxHdz0mH+vA
+          Aqton5KdRuilrZuyJTemkGOgqMHOTm7CMuWMe28dM1/hEMgK0QQgAKN9LgG3aB1V
+          5HjwjCGCyISmUXY7qXcYjrdlOHRaIsVG8ZLp1oPNwKus</ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+  <samlp:Status>
+    <samlp:StatusCode
+      Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+  </samlp:Status>
+  <saml:Assertion
+    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" Version="2.0"
+    IssueInstant="2020-01-31T15:55:38Z"
+    ID="id_2de40e36bd922a18c4ba96af7c5e6d4dc90750c6">
+    <saml:Issuer
+      Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"
+      NameQualifier="http://localhost:8088">http://localhost:8088</saml:Issuer>
+    <ds:Signature
+      xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+      <ds:SignedInfo>
+        <ds:CanonicalizationMethod
+          Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+        <ds:SignatureMethod
+          Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" />
+        <ds:Reference
+          URI="#id_2de40e36bd922a18c4ba96af7c5e6d4dc90750c6">
+          <ds:Transforms>
+            <ds:Transform
+              Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature" />
+            <ds:Transform
+              Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#" />
+          </ds:Transforms>
+          <ds:DigestMethod
+            Algorithm="http://www.w3.org/2001/04/xmlenc#sha256" />
+          <ds:DigestValue>z14LzufA65YR59jdYjHBigAB+sQNWTTaGWbsXe3hsrI=</ds:DigestValue>
+        </ds:Reference>
+      </ds:SignedInfo>
+      <ds:SignatureValue>VoiuWCujz2jrjgufC5mwiyfKUEdIOyti9ybndJX2CuFTfjq2ONfbOuZxSChPhw8hPmZ+LIuCN/Tpdrn5Pr5fPx4Mob0LcAly7FByFvlIZXwutCx9eKQmqhxo9umDD7Kjg+x9bvHzDKwGk8wg+KeG4fOU+hvewb9M6Fu1QyDSpyCNojj91VDDsXFpA523tq25S6v0mJBISAOGrrqUXSIPdsN/7zZxERvS/uW07dZN2JJL9stOoZ2JYHICJ5iQwj0u0y0REJZgTcLJ2HGgAp8ZUXsN6tUk0Aw5hE69gvYxm4gbRVC7/SCLQ2vJm14dXndBkKOzjmRc/Z9eejjm04Iw8w==</ds:SignatureValue>
+      <ds:KeyInfo>
+        <ds:X509Data>
+          <ds:X509Certificate>MIIC7TCCAdWgAwIBAgIJAPilQcSjwd+pMA0GCSqGSIb3DQEBCwUAMA0xCzAJBgNV
+            BAYTAklUMB4XDTE5MDYxMTEyMzkwN1oXDTE5MDcxMTEyMzkwN1owDTELMAkGA1UE
+            BhMCSVQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCcBsGU+Je53Xw2
+            kgjRY/25Bi93eNO96CfYu3ZYCj/VOV1DytAWpCXtLQXAG1SVaeP3Ak8tkNi+RbCW
+            w0/WRTrUBEujLXjyHJHD80Dc6vuPuqJbZ1AClhIZyDIfwiMxmDRsYwf9QbEUoeX+
+            jqLK1i5+DGJBlAhWxn6cWfcXYRyGYihVh87B7wAqS0d2P5E3tvMx669IL3cuV2qn
+            y74l0OhK6xkYVwheb5b1XtmekBGVbiBVtz6CjTAh1d89lSOp0LVo19rCzDwI+4cO
+            jEmtDL0Fw6knzm29fUI8c5PLwAHfu+OjsHUONJj/YEjeqQqpQiFUHg3CkX18hPxs
+            WAZqjB7fAgMBAAGjUDBOMB0GA1UdDgQWBBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAf
+            BgNVHSMEGDAWgBQtv0XwVMEh7eCaeH/B/2pVy9kjvjAMBgNVHRMEBTADAQH/MA0G
+            CSqGSIb3DQEBCwUAA4IBAQCBjICQbLfbKlDUfcm2AqsPD7crvq+jEH54Plnsj2WI
+            1iTnK0WWXs0OE4RymAqsP/4mvq95e0MxPy7n+L05EOp8+VFG47XzuQtjcqRzmg/4
+            sDojz6ToUl3dYKCcJYyklHIiFOA8vHJ5w4LKKfVMbHjnv7FT7lTAOiAtvH2/IpYT
+            y2EtLa7pdM3EuGxAKvH9UOli8NcFurZVA+gCS7Gp9tZkLHsa2anKbgxHdz0mH+vA
+            Aqton5KdRuilrZuyJTemkGOgqMHOTm7CMuWMe28dM1/hEMgK0QQgAKN9LgG3aB1V
+            5HjwjCGCyISmUXY7qXcYjrdlOHRaIsVG8ZLp1oPNwKus</ds:X509Certificate>
+        </ds:X509Data>
+      </ds:KeyInfo>
+    </ds:Signature>
+    <saml:Subject>
+      <saml:NameID
+        Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+        NameQualifier="http://localhost:8088">id_ca96571f3e66c15359d4f59c0bdf5ed0dd025cfd
+      </saml:NameID>
+      <saml:SubjectConfirmation
+        Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml:SubjectConfirmationData
+          Recipient="https://auth.izslt.it/cas/login?client_name=idptest"
+          InResponseTo="_5815d22eaf804954b84ce1418f16edad3018926"
+          NotOnOrAfter="2020-01-31T15:57:38Z" />
+      </saml:SubjectConfirmation>
+    </saml:Subject>
+    <saml:Conditions NotBefore="2020-01-31T15:53:38Z"
+      NotOnOrAfter="2020-01-31T15:57:38Z">
+      <saml:AudienceRestriction>
+        <saml:Audience>https://auth.izslt.it</saml:Audience>
+      </saml:AudienceRestriction>
+    </saml:Conditions>
+    <saml:AuthnStatement
+      AuthnInstant="2020-01-31T15:55:38Z"
+      SessionIndex="id_7a3b76060b41652676680b8311e083219c91d165">
+      <saml:AuthnContext>
+        <saml:AuthnContextClassRef>https://www.spid.gov.it/SpidL1
+        </saml:AuthnContextClassRef>
+      </saml:AuthnContext>
+    </saml:AuthnStatement>
+    <saml:AttributeStatement>
+      <saml:Attribute Name="Foo">
+        <saml:AttributeValue xsi:type="xs:string">Bar</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="Organization"
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml:AttributeValue>
+          <OrganizationType
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:q1="urn:osp:foo:schemas:identity"
+            xsi:type="q1:OrganizationType"
+            id="ab417e71-3fe8-4981-d629-08d90ef68525">
+            <q1:OrganizationName q1:attributeId="urn:osp:foo:attribute:organizationName">Example Corp</q1:OrganizationName>
+            <q1:EmailAddress q1:attributeId="urn:osp:foo:attribute:emailAddress">employee@example.com</q1:EmailAddress>
+            <q1:Address q1:attributeId="urn:osp:foo:attribute:address">
+              <q1:Street q1:attributeId="urn:osp:foo:attribute:street">Example St</q1:Street>
+              <q1:StreetNumber q1:attributeId="urn:osp:foo:attribute:streetNumber">123</q1:StreetNumber>
+              <q1:City q1:attributeId="urn:osp:foo:attribute:city">ExampleCity</q1:City>
+              <q1:ZipCode q1:attributeId="urn:osp:foo:attribute:zipCode">123456</q1:ZipCode>
+              <q1:Country q1:attributeId="urn:osp:foo:attribute:country">ExampleCountry</q1:Country>
+            </q1:Address>
+          </OrganizationType>
+        </saml:AttributeValue>
+      </saml:Attribute>
+    </saml:AttributeStatement>
+  </saml:Assertion>
+</samlp:Response>


### PR DESCRIPTION
Hello everyone,

while using Pac4j for SAML Delegate Authentication in CAS, I have encountered a problem when extracting complex type attributes from SAML2 assertions. After checking with the Pac4j codebase, I have noticed that there is no differentiation at all and the value is just being extracted by calling dom.getTextContent(), which stuffs all attribute values from complex types into one long string.

Example:

```
    <saml:AttributeStatement>
      <saml:Attribute Name="Foo">
        <saml:AttributeValue xsi:type="xs:string">Bar</saml:AttributeValue>
      </saml:Attribute>
      <saml:Attribute Name="Organization"
        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
        <saml:AttributeValue>
          <OrganizationType
            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:q1="urn:osp:foo:schemas:identity"
            xsi:type="q1:OrganizationType"
            id="ab417e71-3fe8-4981-d629-08d90ef68525">
            <q1:OrganizationName q1:attributeId="urn:osp:foo:attribute:organizationName">Example Corp</q1:OrganizationName>
            <q1:EmailAddress q1:attributeId="urn:osp:foo:attribute:emailAddress">employee@example.com</q1:EmailAddress>
            <q1:Address q1:attributeId="urn:osp:foo:attribute:address">
              <q1:Street q1:attributeId="urn:osp:foo:attribute:street">Example St</q1:Street>
              <q1:StreetNumber q1:attributeId="urn:osp:foo:attribute:streetNumber">123</q1:StreetNumber>
              <q1:City q1:attributeId="urn:osp:foo:attribute:city">ExampleCity</q1:City>
              <q1:ZipCode q1:attributeId="urn:osp:foo:attribute:zipCode">123456</q1:ZipCode>
              <q1:Country q1:attributeId="urn:osp:foo:attribute:country">ExampleCountry</q1:Country>
            </q1:Address>
          </OrganizationType>
        </saml:AttributeValue>
      </saml:Attribute>
    </saml:AttributeStatement>
```

While the attribute Foo is extracted without a problem, the attribute Organization with it's complex value type is extracted as one large text with line delimiters. After extraction with the current code base, printing the results looks like this:

```
Foo=Bar
Organization=
          
            Example Corp
            employee@example.com
            
              Example St
              123
              ExampleCity
              123456
              ExampleCountry
```

I have implemented a more forgiving extractor. With it the output looks a little better:

```
Foo=Bar
OrganizationName=Example Corp
EmailAddress=employee@example.com
Street=Example St
StreetNumber=123
City=ExampleCity
ZipCode=123456
Country=ExampleCountry
```

What do you think?

Cheers

