### PR TITLE
Enable mergify for bots

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,22 +1,3 @@
-#
-# Licensed to Apereo under one or more contributor license
-# agreements. See the NOTICE file distributed with this work
-# for additional information regarding copyright ownership.
-# Apereo licenses this file to you under the Apache License,
-# Version 2.0 (the "License"); you may not use this file
-# except in compliance with the License.  You may obtain a
-# copy of the License at the following location:
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-#
-
 pull_request_rules:
 - name: automatic merge
   conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,31 @@
+#
+# Licensed to Apereo under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Apereo licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pull_request_rules:
+- name: automatic merge
+  conditions:
+    - status-success=build
+    - "#changes-requested-reviews-by=0"
+    - base=master
+    - label=dependencies
+  actions:
+    merge:
+      method: merge
+      strict: false
+    delete_head_branch:

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": [
         "config:base"
-    ]
+    ],
+    "labels": ["dependencies", "bot"]
 }


### PR DESCRIPTION
This mergify configuration enables automatic merging of PRs, if:

- Build passes
- Target branch is master
- The PR is tagged with "dependencies"

I modified the renovate configuration to assign the correct labels to PRs. This should help reduce your workload, and we let the bots do the job, until they all rise up and claim humanity :) 
