### PR TITLE
Expose HttpServletRequest's request url for web context

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -6,6 +6,7 @@ title: Release notes&#58;
 **v5.1.2**:
 
 - Support SAML2 `Scoping` in authentication requests.
+- `WebContext` is now able to provide the request url directly.
 
 **v5.1.1**:
 

--- a/pac4j-core/src/main/java/org/pac4j/core/context/JEEContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/JEEContext.java
@@ -133,6 +133,16 @@ public class JEEContext implements WebContext {
     }
 
     @Override
+    public String getRequestURL() {
+        final var url = request.getRequestURL().toString();
+        var idx = url.indexOf('?');
+        if (idx != -1) {
+            return url.substring(0, idx);
+        }
+        return url;
+    }
+
+    @Override
     public String getFullRequestURL() {
         final var requestURL = request.getRequestURL();
         final var queryString = request.getQueryString();

--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
@@ -127,6 +127,14 @@ public interface WebContext {
     String getFullRequestURL();
 
     /**
+     * Return the full URL (without the query string) the client used to request the server.
+     *
+     * @return the URL
+     * @since 5.1.2
+     */
+    String getRequestURL();
+
+    /**
      * Retrieves request cookies.
      *
      * @return the request cookies

--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
@@ -132,7 +132,13 @@ public interface WebContext {
      * @return the URL
      * @since 5.1.2
      */
-    String getRequestURL();
+    default String getRequestURL() {
+        var idx = getFullRequestURL().indexOf('?');
+        if (idx != -1) {
+            return getFullRequestURL().substring(0, idx);
+        }
+        return getFullRequestURL();
+    }
 
     /**
      * Retrieves request cookies.

--- a/pac4j-core/src/test/java/org/pac4j/core/context/JEEContextTest.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/JEEContextTest.java
@@ -70,6 +70,13 @@ public final class JEEContextTest implements TestsConstants {
     }
 
     @Test
+    public void testGetRequestUrl() throws Exception {
+        when(request.getRequestURL()).thenReturn(new StringBuffer("https://pac4j.org?name=value&name2=value2"));
+        final var context = new JEEContext(request, response);
+        assertEquals("https://pac4j.org", context.getRequestURL());
+    }
+
+    @Test
     public void testGetPathFullpathContext() {
         when(request.getRequestURI()).thenReturn(CTX_PATH);
         when(request.getContextPath()).thenReturn(CTX);

--- a/pac4j-core/src/test/java/org/pac4j/core/context/MockWebContext.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/MockWebContext.java
@@ -183,15 +183,6 @@ public final class MockWebContext implements WebContext {
     }
 
     @Override
-    public String getRequestURL() {
-        var idx = getFullRequestURL().indexOf('?');
-        if (idx != -1) {
-            return getFullRequestURL().substring(0, idx);
-        }
-        return getFullRequestURL();
-    }
-
-    @Override
     public String getFullRequestURL() {
         if (fullRequestURL != null) {
             return fullRequestURL;

--- a/pac4j-core/src/test/java/org/pac4j/core/context/MockWebContext.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/MockWebContext.java
@@ -183,6 +183,15 @@ public final class MockWebContext implements WebContext {
     }
 
     @Override
+    public String getRequestURL() {
+        var idx = getFullRequestURL().indexOf('?');
+        if (idx != -1) {
+            return getFullRequestURL().substring(0, idx);
+        }
+        return getFullRequestURL();
+    }
+
+    @Override
     public String getFullRequestURL() {
         if (fullRequestURL != null) {
             return fullRequestURL;


### PR DESCRIPTION
Avoids casting down to JEEContext.