### PR TITLE
Support SAML2 scoping in authn requests

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -3,6 +3,10 @@ layout: doc
 title: Release notes&#58;
 ---
 
+**v5.1.2**:
+
+- Support SAML2 `Scoping` in authentication requests.
+
 **v5.1.1**:
 
 - Removed the ORCID OAuth client which no longer works. Use the `OidcClient` instead

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -32,6 +32,7 @@ import org.pac4j.saml.metadata.SAML2ServiceProviderRequestedAttribute;
 import org.pac4j.saml.metadata.keystore.SAML2FileSystemKeystoreGenerator;
 import org.pac4j.saml.metadata.keystore.SAML2HttpUrlKeystoreGenerator;
 import org.pac4j.saml.metadata.keystore.SAML2KeystoreGenerator;
+import org.pac4j.saml.sso.impl.SAML2ScopingIdentityProvider;
 import org.pac4j.saml.store.EmptyStoreFactory;
 import org.pac4j.saml.store.SAMLMessageStoreFactory;
 import org.pac4j.saml.util.SAML2HttpClientBuilder;
@@ -71,6 +72,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
     protected static final String DEFAULT_PROVIDER_NAME = "pac4j-saml";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SAML2Configuration.class);
+
+    private final List<SAML2ScopingIdentityProvider> scopingIdentityProviders = new ArrayList<>();
 
     private final List<SAML2ServiceProviderRequestedAttribute> requestedServiceProviderAttributes = new ArrayList<>();
 
@@ -375,6 +378,11 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     public void setPrivateKeySize(final int privateKeySize) {
         this.privateKeySize = privateKeySize;
+    }
+
+
+    public List<SAML2ScopingIdentityProvider> getScopingIdentityProviders() {
+        return scopingIdentityProviders;
     }
 
     public List<SAML2ServiceProviderRequestedAttribute> getRequestedServiceProviderAttributes() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2ScopingIdentityProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2ScopingIdentityProvider.java
@@ -1,0 +1,37 @@
+package org.pac4j.saml.sso.impl;
+
+import org.pac4j.core.util.CommonHelper;
+
+import java.io.Serializable;
+
+/**
+ * This is {@link SAML2ScopingIdentityProvider}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.1.2
+ */
+public class SAML2ScopingIdentityProvider implements Serializable {
+    private final String providerId;
+
+    private final String name;
+
+    public SAML2ScopingIdentityProvider(final String providerId, final String name) {
+        this.providerId = providerId;
+        this.name = name;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return CommonHelper.toNiceString(this.getClass(),
+            "providerId", this.providerId,
+            "name", this.name);
+    }
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
@@ -36,6 +36,9 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
     public void setup() {
         configuration = getSaml2Configuration();
         configuration.setAssertionConsumerServiceIndex(1);
+
+        var scopedIdP = new SAML2ScopingIdentityProvider("idp-entity-id", "My Identity Provider");
+        configuration.getScopingIdentityProviders().add(scopedIdP);
     }
 
     @Test
@@ -105,6 +108,15 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         final var context = buildContext();
         context.getWebContext().setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE, true);
         assertNotNull(builder.build(context));
+    }
+
+    @Test
+    public void testScopingIdentityProviders() {
+        final var builder = new SAML2AuthnRequestBuilder();
+        final var context = buildContext();
+        var authnRequest = builder.build(context);
+        assertNotNull(authnRequest);
+        assertNotNull(authnRequest.getScoping());
     }
 
     @Override


### PR DESCRIPTION
Scoping allows a pac4j SAML2 service provider to specify a list of identity providers in an authnRequest to an identity provider. This is an indication to the identity provider that the service will only deal with the identity providers specified.

Authn requests may look like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<saml2p:AuthnRequest xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" 
  AssertionConsumerServiceIndex="1" ForceAuthn="false" 
  ID="_ebf5682cbf7c48cf908c4d9127057b09920a3b2" IsPassive="false" IssueInstant="2021-07-01T11:31:27.426Z" 
   ProviderName="pac4j-saml" Version="2.0">
<saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" 
   Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">entity-id</saml2:Issuer>
<saml2p:Scoping>
<saml2p:IDPList>
   <saml2p:IDPEntry Name="My Identity Provider" ProviderID="idp-entity-id"/></saml2p:IDPList>
</saml2p:Scoping>
</saml2p:AuthnRequest>
```


PS Support for this change will be added to CAS once pac4j is released.