### PR TITLE
Fix SAML2 response attributes resolution when using ADFS as IdP

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -7,6 +7,7 @@ title: Release notes&#58;
 
 - Support SAML2 `Scoping` in authentication requests.
 - `WebContext` is now able to provide the request url directly.
+- Fix SAML2 response attributes resolution when using ADFS as IdP.
 
 **v5.1.1**:
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -238,14 +238,13 @@ public class SAML2Credentials extends Credentials {
 
             samlAttributes.forEach(openSamlAttribute -> {
                 openSamlAttribute.getAttributeValues().forEach(attributeValue -> {
-                    boolean isKnownType = attributeValue.getSchemaType() != null;
+                    boolean isComplexType = attributeValue.hasChildren();
 
-                    if (isKnownType) {
-                        extractedAttributes.add(SAMLAttribute.from(openSamlAttribute));
-                    }
-                    else {
+                    if (isComplexType) {
                         List<SAMLAttribute> attrs = collectAttributesFromNodeList(attributeValue.getDOM().getChildNodes());
                         extractedAttributes.addAll(attrs);
+                    } else {
+                        extractedAttributes.add(SAMLAttribute.from(openSamlAttribute));
                     }
                 });
             });

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 public class SAML2CredentialsTest {
 
     private static final String RESPONSE_FILE_NAME = "sample_authn_response.xml";
+    private static final String RESPONSE_FILE_NAME_FROM_ADFS = "sample_authn_response_from_adfs.xml";
     private static final String RESPONSE_FILE_NAME_WITH_COMPLEXTYPE = "sample_authn_response_with_complextype.xml";
 
     private SAML2AuthnResponseValidator validator;
@@ -104,6 +105,22 @@ public class SAML2CredentialsTest {
         assertEquals("", resultAttributes.get("digitalAddress").get(0));
         assertEquals("42", resultAttributes.get("anInteger").get(0));
         assertEquals("true", resultAttributes.get("aBoolean").get(0));
+    }
+
+    @Test
+    public void verifyStandardExtractionWorksForAdfs() throws Exception {
+        var credentials = extractCredentials(RESPONSE_FILE_NAME_FROM_ADFS);
+        assertNotNull(credentials);
+        var attributes = credentials.getAttributes();
+        assertNotNull(attributes);
+
+        var resultAttributes = attributes.stream()
+            .collect(Collectors.toMap(SAMLAttribute::getName, SAMLAttribute::getAttributeValues));
+        assertEquals(4, resultAttributes.size());
+        assertEquals("John", resultAttributes.get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname").get(0));
+        assertEquals("DOE", resultAttributes.get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname").get(0));
+        assertEquals("jdoe@company", resultAttributes.get("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress").get(0));
+        assertEquals("...", resultAttributes.get("http://schemas.microsoft.com/ws/2008/06/identity/claims/role").get(0));
     }
 
     @Test

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 
 public class SAML2CredentialsTest {
 
+    private static final String RESPONSE_FILE_NAME = "sample_authn_response.xml";
     private static final String RESPONSE_FILE_NAME_WITH_COMPLEXTYPE = "sample_authn_response_with_complextype.xml";
 
     private SAML2AuthnResponseValidator validator;
@@ -77,6 +78,32 @@ public class SAML2CredentialsTest {
 
         validator = new SAML2AuthnResponseValidator(mock(SAML2SignatureTrustEngineProvider.class),
             mock(Decrypter.class), null, mockSaml2Configuration);
+    }
+
+    @Test
+    public void verifyStandardExtractionWorks() throws Exception {
+        var credentials = extractCredentials(RESPONSE_FILE_NAME);
+        assertNotNull(credentials);
+        var attributes = credentials.getAttributes();
+        assertNotNull(attributes);
+
+        var resultAttributes = attributes.stream()
+            .collect(Collectors.toMap(SAMLAttribute::getName, SAMLAttribute::getAttributeValues));
+        assertEquals(14, resultAttributes.size());
+        assertEquals("F", resultAttributes.get("gender").get(0));
+        assertEquals("Ricci", resultAttributes.get("familyName").get(0));
+        assertEquals("Eustachio", resultAttributes.get("name").get(0));
+        assertEquals("", resultAttributes.get("mobilePhone").get(0));
+        assertEquals("TINIT-NNJEMM98O38H730Z", resultAttributes.get("fiscalNumber").get(0));
+        assertEquals("", resultAttributes.get("placeOfBirth").get(0));
+        assertEquals("longosibilla@libero.it", resultAttributes.get("email").get(0));
+        assertEquals("", resultAttributes.get("countyOfBirth").get(0));
+        assertEquals("", resultAttributes.get("address").get(0));
+        assertEquals("1990-01-31", resultAttributes.get("dateOfBirth").get(0));
+        assertEquals("779ec30a-36de-de1a-b783-0032689e74ba", resultAttributes.get("spidCode").get(0));
+        assertEquals("", resultAttributes.get("digitalAddress").get(0));
+        assertEquals("42", resultAttributes.get("anInteger").get(0));
+        assertEquals("true", resultAttributes.get("aBoolean").get(0));
     }
 
     @Test

--- a/pac4j-saml/src/test/resources/sample_authn_response.xml
+++ b/pac4j-saml/src/test/resources/sample_authn_response.xml
@@ -90,6 +90,12 @@ Aqton5KdRuilrZuyJTemkGOgqMHOTm7CMuWMe28dM1/hEMgK0QQgAKN9LgG3aB1V
       <saml:Attribute Name="digitalAddress">
         <saml:AttributeValue xsi:type="xs:string"/>
       </saml:Attribute>
+      <saml:Attribute Name="anInteger">
+        <saml:AttributeValue xsi:type="xs:integer">42</saml:AttributeValue>
+      </saml:Attribute>
+      <saml:Attribute Name="aBoolean">
+        <saml:AttributeValue xsi:type="xs:boolean">true</saml:AttributeValue>
+      </saml:Attribute>
     </saml:AttributeStatement>
   </saml:Assertion>
 </samlp:Response>

--- a/pac4j-saml/src/test/resources/sample_authn_response_from_adfs.xml
+++ b/pac4j-saml/src/test/resources/sample_authn_response_from_adfs.xml
@@ -1,0 +1,59 @@
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" Consent="urn:oasis:names:tc:SAML:2.0:consent:unspecified" Destination="https://..." ID="_53b2582b-7ae7-44a5-991f-48d8870eaf83" InResponseTo="_a50703b5d17b4f9b9e2e46bb259130e507e3bb9" IssueInstant="2021-07-02T08:08:12.098Z" Version="2.0">
+    <Issuer xmlns="urn:oasis:names:tc:SAML:2.0:assertion">http://.../adfs/services/trust</Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <Assertion xmlns="urn:oasis:names:tc:SAML:2.0:assertion" ID="_b2e4c68c-f38a-4b36-9bf1-fdb74931f542" IssueInstant="2021-07-02T08:08:12.082Z" Version="2.0">
+        <Issuer>http://.../adfs/services/trust</Issuer>
+        <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+            <ds:SignedInfo>
+                <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+                <ds:Reference URI="#_b2e4c68c-f38a-4b36-9bf1-fdb74931f542">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+                    </ds:Transforms>
+                    <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                    <ds:DigestValue>...</ds:DigestValue>
+                </ds:Reference>
+            </ds:SignedInfo>
+            <ds:SignatureValue>...</ds:SignatureValue>
+            <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+                <ds:X509Data>
+                    <ds:X509Certificate>...</ds:X509Certificate>
+                </ds:X509Data>
+            </KeyInfo>
+        </ds:Signature>
+        <Subject>
+            <NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">jdoe@company</NameID>
+            <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <SubjectConfirmationData InResponseTo="_a50703b5d17b4f9b9e2e46bb259130e507e3bb9" NotOnOrAfter="2021-07-02T08:13:12.098Z" Recipient="https://..."/>
+            </SubjectConfirmation>
+        </Subject>
+        <Conditions NotBefore="2021-07-02T08:08:12.082Z" NotOnOrAfter="2021-07-02T09:08:12.082Z">
+            <AudienceRestriction>
+                <Audience>https://...</Audience>
+            </AudienceRestriction>
+        </Conditions>
+        <AttributeStatement>
+            <Attribute xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname" a:OriginalIssuer="https://...">
+                <AttributeValue>John</AttributeValue>
+            </Attribute>
+            <Attribute xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname" a:OriginalIssuer="https://...">
+                <AttributeValue>DOE</AttributeValue>
+            </Attribute>
+            <Attribute xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims" Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress" a:OriginalIssuer="https://...">
+                <AttributeValue>jdoe@company</AttributeValue>
+            </Attribute>
+            <Attribute Name="http://schemas.microsoft.com/ws/2008/06/identity/claims/role">
+                <AttributeValue>...</AttributeValue>
+            </Attribute>
+        </AttributeStatement>
+        <AuthnStatement AuthnInstant="2021-07-02T08:08:12.025Z" SessionIndex="_b2e4c68c-f38a-4b36-9bf1-fdb74931f542">
+            <AuthnContext>
+                <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</AuthnContextClassRef>
+            </AuthnContext>
+        </AuthnStatement>
+    </Assertion>
+</samlp:Response>


### PR DESCRIPTION
Pac4j 5.1.1 (PR #1926) introduced a change on how attributes are extracted from SAML responses.
This causes a regression when dealing with ADFS IdPs that omit the `xsi:type` attribute on the `AttributeValue` elements.
The SAML specification indicates this attribute is optional ([2.7.3.1.1, line 1239](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)), so Pac4j can't rely on it to resolve response attributes.