### PR TITLE
Allow claims mapping for OIDC user profile

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -120,6 +121,8 @@ public class OidcConfiguration extends BaseClientConfiguration {
     private int readTimeout = HttpConstants.DEFAULT_READ_TIMEOUT;
 
     private boolean withState = true;
+
+    private Map<String, String> mappedClaims = new LinkedHashMap<>();
 
     private ValueGenerator stateGenerator = new RandomValueGenerator();
 
@@ -475,6 +478,14 @@ public class OidcConfiguration extends BaseClientConfiguration {
         return tokenValidator;
     }
 
+    public Map<String, String> getMappedClaims() {
+        return mappedClaims;
+    }
+
+    public void setMappedClaims(Map<String, String> mappedClaims) {
+        this.mappedClaims = mappedClaims;
+    }
+
     @Override
     public String toString() {
         return toNiceString(this.getClass(), "clientId", clientId, "secret", "[protected]",
@@ -484,6 +495,6 @@ public class OidcConfiguration extends BaseClientConfiguration {
             "connectTimeout", connectTimeout, "readTimeout", readTimeout, "resourceRetriever", resourceRetriever,
             "responseType", responseType, "responseMode", responseMode, "logoutUrl", logoutUrl,
             "withState", withState, "stateGenerator", stateGenerator, "logoutHandler", logoutHandler,
-            "tokenValidator", tokenValidator);
+            "tokenValidator", tokenValidator, "mappedClaims", mappedClaims);
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/OidcProfile.java
@@ -107,11 +107,14 @@ public class OidcProfile extends AbstractJwtProfile {
                 addAttribute(OidcProfileDefinition.EXPIRATION,
                     Date.from(Instant.now().plusSeconds(accessToken.getLifetime())));
             } else {
-                Date exp;
+                Date exp = null;
                 try {
-                    exp = JWTParser.parse(accessToken.getValue()).getJWTClaimsSet().getExpirationTime();
+                    final var jwtClaimsSet = JWTParser.parse(accessToken.getValue()).getJWTClaimsSet();
+                    if (jwtClaimsSet != null) {
+                        exp = jwtClaimsSet.getExpirationTime();
+                    }
                 } catch (ParseException e) {
-                    exp = null;
+                    logger.trace(e.getMessage(), e);
                 }
                 if (exp != null) {
                     addAttribute(OidcProfileDefinition.EXPIRATION,


### PR DESCRIPTION
When fetching the OIDC user profile, allow the OIDC configuration to specify arbitrary claim mapping rules.

PS This is similar to how SAML2 allows mapping of attributes.