### PR TITLE
Allow PartialLogout to be a successful as SAML2 logout response, if configured explicitly. 

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -170,6 +170,7 @@ public class SAML2Client extends IndirectClient {
             this.configuration.getPostLogoutURL(), this.replayCache,
             this.configuration.getUriComparator());
         this.logoutValidator.setAcceptedSkew(this.configuration.getAcceptedSkew());
+        this.logoutValidator.setIsPartialLogoutTreatedAsSuccess(this.configuration.isPartialLogoutTreatedAsSuccess());
     }
 
     protected void initSAMLResponseValidator() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -109,6 +109,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private String comparisonType = null;
 
+    private boolean isPartialLogoutTreatedAsSuccess = false;
+
     private String authnRequestBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
 
     private String responseBindingType = SAMLConstants.SAML2_POST_BINDING_URI;
@@ -946,5 +948,13 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     public void setIdentityProviderMetadataResolver(final SAML2MetadataResolver identityProviderMetadataResolver) {
         this.identityProviderMetadataResolver = identityProviderMetadataResolver;
+    }
+
+    public boolean isPartialLogoutTreatedAsSuccess() {
+        return isPartialLogoutTreatedAsSuccess;
+    }
+
+    public void setPartialLogoutTreatedAsSuccess(boolean partialLogoutTreatedAsSuccess) {
+        isPartialLogoutTreatedAsSuccess = partialLogoutTreatedAsSuccess;
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -6,6 +6,8 @@ import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.LogoutResponse;
+import org.opensaml.saml.saml2.core.Status;
+import org.opensaml.saml.saml2.core.StatusCode;
 import org.opensaml.saml.saml2.encryption.Decrypter;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.opensaml.xmlsec.signature.support.SignatureTrustEngine;
@@ -44,6 +46,12 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
      * move on without throwing {@link OkAction}.
      */
     private boolean actionOnSuccess = true;
+
+    /**
+     * Logouts are only successful if the IdP was able to inform all services, otherwise it will
+     * respond with PartialLogout. This setting allows clients to ignore such server-side problems.
+     */
+    private boolean isPartialLogoutTreatedAsSuccess = false;
 
     /**
      * Expected destination endpoint when validating saml2 logout responses.
@@ -186,6 +194,17 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
         verifyEndpoint(expected, logoutResponse.getDestination(), isDestinationMandatory);
     }
 
+    @Override
+    protected void validateSuccess(Status status) {
+
+        if (StatusCode.PARTIAL_LOGOUT.equals(status.getStatusCode().getValue()) && isPartialLogoutTreatedAsSuccess) {
+            logger.debug("Response status code is {} and partial logouts are configured to be treated as success => validation successful!", StatusCode.PARTIAL_LOGOUT);
+            return;
+        }
+
+        super.validateSuccess(status);
+    }
+
     public void setActionOnSuccess(final boolean actionOnSuccess) {
         this.actionOnSuccess = actionOnSuccess;
     }
@@ -196,6 +215,10 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
 
     public void setExpectedDestination(final String expectedDestination) {
         this.expectedDestination = expectedDestination;
+    }
+
+    public void setIsPartialLogoutTreatedAsSuccess(final boolean isPartialLogoutTreatedAsSuccess) {
+        this.isPartialLogoutTreatedAsSuccess = isPartialLogoutTreatedAsSuccess;
     }
 
     public String getPostLogoutURL() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -198,7 +198,9 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     protected void validateSuccess(Status status) {
 
         if (StatusCode.PARTIAL_LOGOUT.equals(status.getStatusCode().getValue()) && isPartialLogoutTreatedAsSuccess) {
-            logger.debug("Response status code is {} and partial logouts are configured to be treated as success => validation successful!", StatusCode.PARTIAL_LOGOUT);
+            logger.debug(
+                "Response status code is {} and partial logouts are configured to be treated as success => validation successful!",
+                StatusCode.PARTIAL_LOGOUT);
             return;
         }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -1,6 +1,5 @@
 package org.pac4j.saml.logout.impl;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.saml2.core.LogoutResponse;

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -26,6 +26,7 @@ import org.springframework.core.io.FileSystemResource;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -146,10 +147,10 @@ public class SAML2LogoutValidatorTests {
 
         try {
             validator.validate(context);
-            Assert.fail("Validation should have failed, because response status PartialLogout is not accepted as success by default.");
+            fail("Validation should have failed, because response status PartialLogout is not accepted as success by default.");
         }
-        catch(SAMLException e) {
-            // expected
+        catch(SAMLException expectedException) {
+            assertNotNull(expectedException);
         }
 
         validator.setIsPartialLogoutTreatedAsSuccess(true);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.logout.impl;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.saml2.core.LogoutResponse;
@@ -13,6 +14,7 @@ import org.pac4j.core.logout.handler.LogoutHandler;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.crypto.ExplicitSignatureTrustEngineProvider;
+import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
 import org.pac4j.saml.metadata.SAML2ServiceProviderMetadataResolver;
 import org.pac4j.saml.replay.ReplayCacheProvider;
@@ -60,22 +62,11 @@ public class SAML2LogoutValidatorTests {
         return MockWebContext.create();
     }
 
-    private static SAML2MessageContext getSaml2MessageContext(final MockWebContext webContext) {
+    private static SAML2MessageContext getSaml2MessageContext(final MockWebContext webContext, final String xml) {
         final var context = new SAML2MessageContext();
         context.setSaml2Configuration(getSaml2Configuration());
 
         final var samlMessage = new MessageContext();
-        final var xml = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
-            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
-            "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
-            "IssueInstant=\"" + ZonedDateTime.now(ZoneOffset.UTC)
-            + "\" Destination=\"http://sp.example.com/demo1/logout?x=1000%26y=1234\" " +
-            "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
-            "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
-            "  <samlp:Status>%n" +
-            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>%n" +
-            "  </samlp:Status>%n" +
-            "</samlp:LogoutResponse>";
         final var samlResponse = (LogoutResponse) Configuration.deserializeSamlObject(xml).get();
 
         samlMessage.setMessage(samlResponse);
@@ -95,9 +86,22 @@ public class SAML2LogoutValidatorTests {
 
     @Test
     public void verifyHostComparison() {
+
+        final var xml = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+            "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+            "IssueInstant=\"" + ZonedDateTime.now(ZoneOffset.UTC)
+            + "\" Destination=\"http://sp.example.com/demo1/logout?x=1000%26y=1234\" " +
+            "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
+            "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
+            "  <samlp:Status>%n" +
+            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Success\"/>%n" +
+            "  </samlp:Status>%n" +
+            "</samlp:LogoutResponse>";
+
         try {
             final var webContext = getMockWebContext();
-            final var context = getSaml2MessageContext(webContext);
+            final var context = getSaml2MessageContext(webContext, xml);
             final var validator = new SAML2LogoutValidator(
                 getTrustEngine(),
                 mock(Decrypter.class),
@@ -111,5 +115,44 @@ public class SAML2LogoutValidatorTests {
         } catch (final Exception e) {
             fail(e.getMessage());
         }
+    }
+
+    @Test
+    public void verifyThatPartialLogoutIsAcceptedAsSuccess() throws Exception {
+
+        final var xml = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
+            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
+            "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
+            "IssueInstant=\"" + ZonedDateTime.now(ZoneOffset.UTC)
+            + "\" Destination=\"http://sp.example.com/demo1/logout?x=1000%26y=1234\" " +
+            "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
+            "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
+            "  <samlp:Status>%n" +
+            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>%n" +
+            "  </samlp:Status>%n" +
+            "</samlp:LogoutResponse>";
+
+        final var webContext = getMockWebContext();
+        final var context = getSaml2MessageContext(webContext, xml);
+        final var validator = new SAML2LogoutValidator(
+            getTrustEngine(),
+            mock(Decrypter.class),
+            mock(LogoutHandler.class),
+            null,
+            mock(ReplayCacheProvider.class),
+            new ExcludingParametersURIComparator()
+        );
+        validator.setActionOnSuccess(false);
+
+        try {
+            validator.validate(context);
+            Assert.fail("Validation should have failed, because response status PartialLogout is not accepted as success by default.");
+        }
+        catch(SAMLException e) {
+            // expected
+        }
+
+        validator.setIsPartialLogoutTreatedAsSuccess(true);
+        validator.validate(context);
     }
 }


### PR DESCRIPTION
When sending a SAML2 logout response to a service, the IdP can respond with urn:oasis:names:tc:SAML:2.0:status:PartialLogout because it was unable to contact all participating services (SLO). The session has been terminated on the IdP however and since the logout request was initiated by the service, it may be ok to continue the flow even when SLO is not configured properly somewhere else.

This changeset introduces a new SAML2 client property, allowing to treat PartialLogout responses like a Success, if configured explicitly. The default behaviour is not changed for now, although it would probably make sense, because the logout process between Pac4j-Service and IdP is still successful in the described case.