### PR TITLE
Update dependency com.nimbusds:nimbus-jose-jwt to v8.22.1 [4.4.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<commons-codec.version>1.15</commons-codec.version>
 		<commons-io.version>2.8.0</commons-io.version>
 		<guava.version>29.0-jre</guava.version>
-		<nimbus-jose-jwt.version>8.20.1</nimbus-jose-jwt.version>
+		<nimbus-jose-jwt.version>8.22.1</nimbus-jose-jwt.version>
 		<spring.version>5.2.9.RELEASE</spring.version>
 		<spring.security.version>5.4.0</spring.security.version>
 		<shiro.version>1.6.0</shiro.version>


### PR DESCRIPTION
This is addressing a critical vulnerability in `net.minidev:json-smart:2.3.x` which is used in `com.nimbusds:nimbus-jose-jwt:8.20.1`.

https://nvd.nist.gov/vuln/detail/CVE-2021-27568
https://github.com/advisories/GHSA-v528-7hrm-frqp
https://bitbucket.org/connect2id/nimbus-jose-jwt/commits/7b68f934e5b450666473e27592fb64694486fcde

Before submitting any pull request, please read the contribution guide: http://www.pac4j.org/docs/contribute.html