### PR TITLE
Include more SAML2 settings in `PropertiesFactory`

### DIFF
--- a/pac4j-config/src/main/java/org/pac4j/config/builder/AbstractBuilder.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/builder/AbstractBuilder.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 public abstract class AbstractBuilder implements PropertiesConstants {
 
-    protected static final int MAX_NUM_CLIENTS = 10;
+    protected static final int MAX_NUM_CLIENTS = 100;
     protected static final int MAX_NUM_AUTHENTICATORS = 10;
     protected static final int MAX_NUM_CUSTOM_PROPERTIES = 5;
     protected static final int MAX_NUM_ENCODERS = 10;

--- a/pac4j-config/src/main/java/org/pac4j/config/builder/Saml2ClientBuilder.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/builder/Saml2ClientBuilder.java
@@ -1,11 +1,14 @@
 package org.pac4j.config.builder;
 
+import org.apache.commons.lang3.StringUtils;
 import org.pac4j.core.client.Client;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.config.SAML2Configuration;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.pac4j.core.util.CommonHelper.isNotBlank;
 
@@ -27,6 +30,7 @@ public class Saml2ClientBuilder extends AbstractBuilder {
             final var privateKeyPassword = getProperty(SAML_PRIVATE_KEY_PASSWORD, i);
             final var keystorePath = getProperty(SAML_KEYSTORE_PATH, i);
             final var identityProviderMetadataPath = getProperty(SAML_IDENTITY_PROVIDER_METADATA_PATH, i);
+
 
             if (isNotBlank(keystorePassword) && isNotBlank(privateKeyPassword)
                     && isNotBlank(keystorePath) && isNotBlank(identityProviderMetadataPath)) {
@@ -54,8 +58,84 @@ public class Saml2ClientBuilder extends AbstractBuilder {
                 if (isNotBlank(keystoreAlias)) {
                     cfg.setKeystoreAlias(keystoreAlias);
                 }
+
+                final var acceptedSkew = getProperty(SAML_ACCEPTED_SKEW, i);
+                if (isNotBlank(acceptedSkew)) {
+                    cfg.setAcceptedSkew(Long.parseLong(acceptedSkew));
+                }
+
+                final var assertionConsumerServiceIndex = getProperty(SAML_ASSERTION_CONSUMER_SERVICE_INDEX, i);
+                if (isNotBlank(assertionConsumerServiceIndex)) {
+                    cfg.setAssertionConsumerServiceIndex(Integer.parseInt(assertionConsumerServiceIndex));
+                }
+
+                final var forceAuth = getProperty(SAML_FORCE_AUTH, i);
+                if (isNotBlank(forceAuth)) {
+                    cfg.setForceAuth(Boolean.parseBoolean(forceAuth));
+                }
+
+                final var attributeAsId = getProperty(SAML_ATTRIBUTE_AS_ID, i);
+                if (isNotBlank(attributeAsId)) {
+                    cfg.setAttributeAsId(attributeAsId);
+                }
+
+                final var authnContextClassRefs = getProperty(SAML_AUTHN_CONTEXT_CLASS_REFS, i);
+                if (isNotBlank(authnContextClassRefs)) {
+                    cfg.setAuthnContextClassRefs(Arrays.stream(authnContextClassRefs.split(",")).collect(Collectors.toList()));
+                }
+
+                final var comparisonType = getProperty(SAML_COMPARISON_TYPE, i);
+                if (isNotBlank(comparisonType)) {
+                    cfg.setComparisonType(comparisonType);
+                }
+
+                final var issuerFormat = getProperty(SAML_ISSUER_FORMAT, i);
+                if (isNotBlank(issuerFormat)) {
+                    cfg.setIssuerFormat(issuerFormat);
+                }
+
+                final var authnRequestSigned = getProperty(SAML_AUTHN_REQUEST_SIGNED, i);
+                if (isNotBlank(authnRequestSigned)) {
+                    cfg.setAuthnRequestSigned(Boolean.parseBoolean(authnRequestSigned));
+                }
+
+                final var mappedAttributes = getProperty(SAML_MAPPED_ATTRIBUTES, i);
+                if (isNotBlank(mappedAttributes)) {
+                    var mapped = Arrays.stream(mappedAttributes.split(","))
+                        .collect(Collectors.toMap(key -> key.split(":")[0],
+                            value -> value.split(":")[1]));
+                    cfg.setMappedAttributes(mapped);
+                }
+
+                final var nameIdAttribute = getProperty(SAML_NAMEID_ATTRIBUTE, i);
+                if (isNotBlank(nameIdAttribute)) {
+                    cfg.setNameIdAttribute(nameIdAttribute);
+                }
+
+                final var passive = getProperty(SAML_PASSIVE, i);
+                if (isNotBlank(passive)) {
+                    cfg.setPassive(Boolean.parseBoolean(passive));
+                }
+
+                final var responseBindingType = getProperty(SAML_RESPONSE_BINDING_TYPE, i);
+                if (isNotBlank(responseBindingType)) {
+                    cfg.setResponseBindingType(responseBindingType);
+                }
+
+                final var wantsAssertionsSigned = getProperty(SAML_WANTS_ASSERTIONS_SIGNED, i);
+                if (isNotBlank(wantsAssertionsSigned)) {
+                    cfg.setWantsAssertionsSigned(Boolean.parseBoolean(wantsAssertionsSigned));
+                }
+
+                final var wantsResponsesSigned = getProperty(SAML_WANTS_RESPONSES_SIGNED, i);
+                if (isNotBlank(wantsResponsesSigned)) {
+                    cfg.setWantsResponsesSigned(Boolean.parseBoolean(wantsResponsesSigned));
+                }
+
                 final var saml2Client = new SAML2Client(cfg);
-                saml2Client.setName(concat(saml2Client.getName(), i));
+                final var clientName = StringUtils.defaultString(getProperty(CLIENT_NAME, i),
+                    concat(saml2Client.getName(), i));
+                saml2Client.setName(clientName);
 
                 clients.add(saml2Client);
             }

--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
@@ -7,6 +7,7 @@ package org.pac4j.config.client;
  * @since 2.0.0
  */
 public interface PropertiesConstants {
+    String CLIENT_NAME = "client.name";
 
     String FACEBOOK_ID = "facebook.id";
     String FACEBOOK_SECRET = "facebook.secret";
@@ -63,6 +64,20 @@ public interface PropertiesConstants {
     String SAML_SERVICE_PROVIDER_METADATA_PATH = "saml.serviceProviderMetadataPath";
     String SAML_AUTHN_REQUEST_BINDING_TYPE = "saml.authnRequestBindingType";
     String SAML_KEYSTORE_ALIAS = "saml.keystoreAlias";
+    String SAML_ACCEPTED_SKEW = "saml.acceptedSkew";
+    String SAML_ASSERTION_CONSUMER_SERVICE_INDEX = "saml.assertionConsumerServiceIndex";
+    String SAML_FORCE_AUTH = "saml.forceAuth";
+    String SAML_ATTRIBUTE_AS_ID = "saml.attributeAsId";
+    String SAML_AUTHN_CONTEXT_CLASS_REFS = "saml.authnContextClassRefs";
+    String SAML_COMPARISON_TYPE = "saml.comparisonType";
+    String SAML_ISSUER_FORMAT = "saml.issuerFormat";
+    String SAML_AUTHN_REQUEST_SIGNED = "saml.authnRequestSigned";
+    String SAML_MAPPED_ATTRIBUTES = "saml.mappedAttributes";
+    String SAML_NAMEID_ATTRIBUTE = "saml.nameIdAttribute";
+    String SAML_PASSIVE = "saml.passive";
+    String SAML_RESPONSE_BINDING_TYPE = "saml.responseBindingType";
+    String SAML_WANTS_ASSERTIONS_SIGNED = "saml.wantsAssertionsSigned";
+    String SAML_WANTS_RESPONSES_SIGNED = "saml.wantsResponsesSigned";
 
     String CAS_LOGIN_URL = "cas.loginUrl";
     String CAS_PROTOCOL = "cas.protocol";

--- a/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
+++ b/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
@@ -62,6 +62,19 @@ public final class PropertiesConfigFactoryTests implements TestsConstants {
             properties.put(SAML_IDENTITY_PROVIDER_METADATA_PATH, PATH);
             properties.put(SAML_AUTHN_REQUEST_BINDING_TYPE, SAMLConstants.SAML2_REDIRECT_BINDING_URI);
             properties.put(SAML_KEYSTORE_ALIAS, VALUE);
+            properties.put(SAML_ACCEPTED_SKEW, "100");
+            properties.put(SAML_ASSERTION_CONSUMER_SERVICE_INDEX, "1");
+            properties.put(SAML_FORCE_AUTH, "true");
+            properties.put(SAML_ATTRIBUTE_AS_ID, "attribute");
+            properties.put(SAML_COMPARISON_TYPE, "exact");
+            properties.put(SAML_AUTHN_CONTEXT_CLASS_REFS, "test1,test2");
+            properties.put(SAML_AUTHN_REQUEST_SIGNED, "true");
+            properties.put(SAML_WANTS_RESPONSES_SIGNED, "true");
+            properties.put(SAML_WANTS_ASSERTIONS_SIGNED, "true");
+            properties.put(SAML_PASSIVE, "false");
+            properties.put(SAML_RESPONSE_BINDING_TYPE, "post");
+            properties.put(SAML_MAPPED_ATTRIBUTES, "attr1:new1,attr2:new2");
+
             properties.put(OIDC_ID, ID);
             properties.put(OIDC_SECRET, SECRET);
             properties.put(OIDC_DISCOVERY_URI, CALLBACK_URL);


### PR DESCRIPTION
- Include additional settings for SAML2, when building clients using PropertiesFactory
- Increase number of known clients to 100.