### PR TITLE
Remove cast to BearerAccessToken when requesting OIDC user info

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -4,7 +4,6 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.proc.BadJOSEException;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.*;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
@@ -92,8 +91,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
 
             // User Info request
             if (configuration.findProviderMetadata().getUserInfoEndpointURI() != null && accessToken != null) {
-                final var userInfoRequest = new UserInfoRequest(configuration.findProviderMetadata().getUserInfoEndpointURI(),
-                    (BearerAccessToken) accessToken);
+                final var userInfoRequest = new UserInfoRequest(configuration.findProviderMetadata().getUserInfoEndpointURI(), accessToken);
                 final var userInfoHttpRequest = userInfoRequest.toHTTPRequest();
                 configuration.configureHttpRequest(userInfoHttpRequest);
                 final var httpResponse = userInfoHttpRequest.send();


### PR DESCRIPTION
Avoids the following stacktrace:

```
ERROR [org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/cas].[dispatcherServlet]] - <Servlet.service() for servlet [dispatcherServlet] in context wit
 java.lang.NoSuchMethodError: com.nimbusds.openid.connect.sdk.UserInfoRequest.<init>(Ljava/net/URI;Lcom/nimbusds/oauth2/sdk/token/BearerAccessToken;)V
    at org.pac4j.oidc.profile.creator.OidcProfileCreator.create(OidcProfileCreator.java:95) ~[pac4j-oidc-5.1.3.jar!/:?]
    at org.pac4j.core.client.BaseClient.retrieveUserProfile(BaseClient.java:126) ~[pac4j-core-5.1.3.jar!/:?]
    at org.pac4j.core.client.BaseClient.getUserProfile(BaseClient.java:105) ~[pac4j-core-5.1.3.jar!/:?]
```

This is due to an API change in the nimbus-oidc library, starting with version 9.14 and above.
