### PR TITLE
[pac4j-saml:4.5.x] Upgrade to velocity-core-engine 2.3

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -15,12 +15,9 @@
     <properties>
         <opensaml.version>4.0.1</opensaml.version>
         <joda-time.version>2.10.6</joda-time.version>
-        <velocity.version>2.2</velocity.version>
+        <velocity.version>2.3</velocity.version>
         <xmlsectool.version>2.0.0</xmlsectool.version>
         <xmlsec.version>2.2.0</xmlsec.version>
-        <!-- The dependency to commons-collections 3.2.2 is explicitly made to replace 3.2.1 (vulnerable) used by
-        velocity 1.7. It can be removed as soon as velocity 1.7 is not used anymore-->
-        <commons-collections.version>3.2.2</commons-collections.version>
         <cryptacular.version>1.2.4</cryptacular.version>
         <!-- This version is used to override the version xmlsectool depends on. it should be compatible -->
         <httpcore.version>4.4.13</httpcore.version>
@@ -146,11 +143,6 @@
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <version>${velocity.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>${commons-collections.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
While updating the Velocity version in `pac4j-saml-opensamlv3` in #1970, it was forgotten to update the dependency in `pac4j-saml` as well.

Change in dependency tree of `pac4j-saml`:
```diff
diff pac4j-saml/deps-{old,new}.txt
66,68c66,67
< +- org.apache.velocity:velocity-engine-core:jar:2.2:compile
< |  \- org.apache.commons:commons-lang3:jar:3.9:compile
< +- commons-collections:commons-collections:jar:3.2.2:compile
---
> +- org.apache.velocity:velocity-engine-core:jar:2.3:compile
> |  \- org.apache.commons:commons-lang3:jar:3.11:compile
```