### PR TITLE
Check if the PartialLogout response code is part of the response instead of checking for String equality

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -197,7 +197,9 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     @Override
     protected void validateSuccess(Status status) {
 
-        if (StatusCode.PARTIAL_LOGOUT.equals(status.getStatusCode().getValue()) && isPartialLogoutTreatedAsSuccess) {
+        if (isPartialLogoutTreatedAsSuccess
+            && status != null && status.getStatusCode() != null && status.getStatusCode().getValue() != null
+            && status.getStatusCode().getValue().contains(StatusCode.PARTIAL_LOGOUT)) {
             logger.debug(
                 "Response status code is {} and partial logouts are configured to be treated as success => validation successful!",
                 StatusCode.PARTIAL_LOGOUT);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -128,7 +128,7 @@ public class SAML2LogoutValidatorTests {
             "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
             "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
             "  <samlp:Status>%n" +
-            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>%n" +
+            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Responder / urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>%n" +
             "  </samlp:Status>%n" +
             "</samlp:LogoutResponse>";
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -128,7 +128,8 @@ public class SAML2LogoutValidatorTests {
             "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
             "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
             "  <samlp:Status>%n" +
-            "    <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Responder / urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>%n" +
+            "    <samlp:StatusCode Value="+
+            "\"urn:oasis:names:tc:SAML:2.0:status:Responder / urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>%n" +
             "  </samlp:Status>%n" +
             "</samlp:LogoutResponse>";
 


### PR DESCRIPTION
(Followup of https://github.com/pac4j/pac4j/pull/1941 )

Partial Logouts are accepted by the `SAML2LogoutValidator` since 5.1.3, however the actual validation currently relies on string equality between the constant `"urn:oasis:names:tc:SAML:2.0:status:PartialLogout"` and the response string. Some identity providers return more than the partial logout status, i.e. when an internal error occured. Example response: `urn:oasis:names:tc:SAML:2.0:status:Responder / urn:oasis:names:tc:SAML:2.0:status:PartialLogout`

This behaviour currently leads to an exception in the Pac4j flow. This PR introduces a solution.