### PR TITLE
Track SAML2 inResponseTo field in the SAML2Credential 

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -27,25 +27,29 @@ public class SAML2Credentials extends Credentials {
 
     private static final long serialVersionUID = 5040516205957826527L;
 
-    private SAMLNameID nameId;
+    private final SAMLNameID nameId;
 
-    private String sessionIndex;
+    private final String sessionIndex;
 
-    private List<SAMLAttribute> attributes;
+    private final List<SAMLAttribute> attributes;
 
-    private SAMLConditions conditions;
+    private final SAMLConditions conditions;
 
-    private String issuerId;
+    private final String issuerId;
 
-    private List<String> authnContexts;
+    private final List<String> authnContexts;
+
+    private final String inResponseTo;
 
     public SAML2Credentials(final SAMLNameID nameId, final String issuerId,
                             final List<SAMLAttribute> samlAttributes, final Conditions conditions,
-                            final String sessionIndex, final List<String> authnContexts) {
+                            final String sessionIndex, final List<String> authnContexts,
+                            final String inResponseTo) {
         this.nameId = nameId;
         this.issuerId = issuerId;
         this.sessionIndex = sessionIndex;
         this.attributes = samlAttributes;
+        this.inResponseTo = inResponseTo;
 
         if (conditions != null) {
             this.conditions = new SAMLConditions();
@@ -57,8 +61,9 @@ public class SAML2Credentials extends Credentials {
             if (conditions.getNotOnOrAfter() != null) {
                 this.conditions.setNotOnOrAfter(ZonedDateTime.ofInstant(conditions.getNotOnOrAfter(), ZoneOffset.UTC));
             }
+        } else {
+            this.conditions = null;
         }
-
         this.authnContexts = authnContexts;
 
         logger.info("Constructed SAML2 credentials: {}", this);
@@ -131,6 +136,10 @@ public class SAML2Credentials extends Credentials {
 
     public List<String> getAuthnContexts() {
         return authnContexts;
+    }
+
+    public String getInResponseTo() {
+        return inResponseTo;
     }
 
     public static class SAMLNameID implements Serializable {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -92,10 +92,11 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
         }
 
         validateSamlSSOResponse(response, context, engine, decrypter);
-        return buildSAML2Credentials(context);
+        return buildSAML2Credentials(context, response);
     }
 
-    protected SAML2Credentials buildSAML2Credentials(final SAML2MessageContext context) {
+    protected SAML2Credentials buildSAML2Credentials(final SAML2MessageContext context,
+                                                     final Response response) {
         final var subjectAssertion = context.getSubjectAssertion();
 
         final var attributes = collectAssertionAttributes(subjectAssertion);
@@ -115,7 +116,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
             }
         }
         return new SAML2Credentials(samlNameId, issuerEntityId, SAML2Credentials.SAMLAttribute.from(attributes),
-            subjectAssertion.getConditions(), sessionIndex, authnContexts);
+            subjectAssertion.getConditions(), sessionIndex, authnContexts, response.getInResponseTo());
     }
 
     protected List<Attribute> collectAssertionAttributes(final Assertion subjectAssertion) {

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
@@ -13,6 +13,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.Assert.*;
 
@@ -58,9 +59,11 @@ public class SAML2CredentialsSerializationTests {
         attr.setNameFormat("pac4j");
         attributes.add(attr);
         final var credentials = new SAML2Credentials(SAML2Credentials.SAMLNameID.from(nameid), "example.issuer.com",
-            SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts);
+            SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts,
+            UUID.randomUUID().toString());
         final var data = SerializationUtils.serialize(credentials);
         final var result = (SAML2Credentials) SerializationUtils.deserialize(data);
         assertNotNull(result);
+        assertNotNull(result.getInResponseTo());
     }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -131,7 +132,8 @@ public class SAML2AuthenticatorTests {
 
         final var credentials = new SAML2Credentials(SAML2Credentials.SAMLNameID.from(nameid),
             "example.issuer.com",
-            SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts);
+            SAML2Credentials.SAMLAttribute.from(attributes), conditions, "session-index", contexts,
+            UUID.randomUUID().toString());
         return credentials;
     }
 


### PR DESCRIPTION
This pull request stores and tracks the `inResponseTo` field of the SAML2 `Response` in `SAML2Credential`. This would become useful in scenarios where one would need to locate the original SAML2 authn request from the SAML2 message store using this id.