### PR TITLE
Avoid NullPointer exception validating authn statements

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -623,7 +623,9 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
                     throw new SAMLAuthnSessionCriteriaException("Authentication session between IDP and subject has ended");
                 }
             }
-            authnClassRefs.add(statement.getAuthnContext().getAuthnContextClassRef().getURI());
+            if (statement.getAuthnContext().getAuthnContextClassRef() != null) {
+                authnClassRefs.add(statement.getAuthnContext().getAuthnContextClassRef().getURI());
+            }
         }
 
         validateAuthnContextClassRefs(context, authnClassRefs);


### PR DESCRIPTION
Avoid NullPointer exception when statement.getAuthnContext().getAuthnContextClassRef() is null (https://groups.google.com/g/pac4j-users/c/16CUNSy0TME)