### PR TITLE
Generic OAuth20 Client: discovery of attribute converters

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/converter/DateConverter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/converter/DateConverter.java
@@ -2,6 +2,7 @@ package org.pac4j.core.profile.converter;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.Locale;
 
@@ -21,6 +22,10 @@ public class DateConverter extends AbstractAttributeConverter {
     protected String format;
 
     protected Locale locale;
+
+    public DateConverter() {
+        this(DateTimeFormatter.ISO_LOCAL_DATE_TIME.toString());
+    }
 
     public DateConverter(final String format) {
         super(Date.class);

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/definition/ProfileDefinition.java
@@ -168,7 +168,7 @@ public abstract class ProfileDefinition {
         return this.secondaries;
     }
 
-    protected Map<String, AttributeConverter> getConverters() {
+    public Map<String, AttributeConverter> getConverters() {
         return converters;
     }
 

--- a/pac4j-oauth/pom.xml
+++ b/pac4j-oauth/pom.xml
@@ -35,6 +35,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.reflections</groupId>
+            <artifactId>reflections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/client/GenericOAuth20ClientTest.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/client/GenericOAuth20ClientTest.java
@@ -1,9 +1,13 @@
 package org.pac4j.oauth.client;
 
 import org.junit.Test;
-import org.pac4j.core.profile.converter.*;
-import org.pac4j.core.profile.definition.ProfileDefinition;
-import org.pac4j.oauth.config.OAuth20Configuration;
+import org.pac4j.core.profile.converter.BooleanConverter;
+import org.pac4j.core.profile.converter.ColorConverter;
+import org.pac4j.core.profile.converter.GenderConverter;
+import org.pac4j.core.profile.converter.IntegerConverter;
+import org.pac4j.core.profile.converter.LocaleConverter;
+import org.pac4j.core.profile.converter.LongConverter;
+import org.pac4j.core.profile.converter.UrlConverter;
 import org.pac4j.oauth.profile.generic.GenericOAuth20ProfileDefinition;
 
 import java.util.HashMap;
@@ -36,20 +40,15 @@ public class GenericOAuth20ClientTest {
         client.setProfileAttrs(map);
         client.setCallbackUrl(CALLBACK_URL);
         client.init();
-        var configurationField = OAuth20Client.class.getDeclaredField("configuration");
-        configurationField.setAccessible(true);
-        var configuration = (OAuth20Configuration) configurationField.get(client);
-        var profileDefinition = (GenericOAuth20ProfileDefinition) configuration.getProfileDefinition();
-        var getConverters = ProfileDefinition.class.getDeclaredMethod("getConverters");
-        getConverters.setAccessible(true);
-        var converters = (Map<String, AttributeConverter>) getConverters.invoke(profileDefinition);
-        assertTrue(converters.get(AGE) instanceof IntegerConverter);
-        assertTrue(converters.get(IS_ADMIN) instanceof BooleanConverter);
-        assertTrue(converters.get(BG_COLOR) instanceof ColorConverter);
-        assertTrue(converters.get(GENDER) instanceof GenderConverter);
-        assertTrue(converters.get(BIRTHDAY) instanceof LocaleConverter);
-        assertTrue(converters.get(ID) instanceof LongConverter);
-        assertTrue(converters.get(BLOG) instanceof UrlConverter);
+
+        var profileDefinition = (GenericOAuth20ProfileDefinition) client.getConfiguration().getProfileDefinition();
+        assertTrue(profileDefinition.getConverters().get(AGE) instanceof IntegerConverter);
+        assertTrue(profileDefinition.getConverters().get(IS_ADMIN) instanceof BooleanConverter);
+        assertTrue(profileDefinition.getConverters().get(BG_COLOR) instanceof ColorConverter);
+        assertTrue(profileDefinition.getConverters().get(GENDER) instanceof GenderConverter);
+        assertTrue(profileDefinition.getConverters().get(BIRTHDAY) instanceof LocaleConverter);
+        assertTrue(profileDefinition.getConverters().get(ID) instanceof LongConverter);
+        assertTrue(profileDefinition.getConverters().get(BLOG) instanceof UrlConverter);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <h2.version>1.4.200</h2.version>
 		<java.version>11</java.version>
         <jackson.version>2.13.0</jackson.version>
+        <reflections.version>0.10.2</reflections.version>
         <nanohttpd.version>2.3.1</nanohttpd.version>
         <mockserver.version>5.10</mockserver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -181,6 +182,11 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.reflections</groupId>
+                <artifactId>reflections</artifactId>
+                <version>${reflections.version}</version>
             </dependency>
             <!-- for testing -->
 			<dependency>


### PR DESCRIPTION
The current strategy used by `GenericOAuth20Client` appears broken; it can never find appropriate subclasses correctly, likely due to recent changes in the JDK and what application code is allowed to do with ClassLoader components. 

This PR provides an alternative approach:

1. Allow callers to register their own converter freely, so discovery is not strictly required
2. Uses the reflections library to locate subclasses safely and correctly starting from the top package name.
