### PR TITLE
Do not collect multi valued attributes multiple times

### DIFF
--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsTest.java
@@ -28,6 +28,7 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.time.Instant;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertEquals;
@@ -40,6 +41,7 @@ public class SAML2CredentialsTest {
     private static final String RESPONSE_FILE_NAME = "sample_authn_response.xml";
     private static final String RESPONSE_FILE_NAME_FROM_ADFS = "sample_authn_response_from_adfs.xml";
     private static final String RESPONSE_FILE_NAME_WITH_COMPLEXTYPE = "sample_authn_response_with_complextype.xml";
+    private static final String RESPONSE_FILE_NAME_WITH_MULTIVALUEDATTR = "sample_authn_response_with_multivaluedattr.xml";
 
     private SAML2AuthnResponseValidator validator;
     private SAML2MessageContext mockSaml2MessageContext;
@@ -141,6 +143,20 @@ public class SAML2CredentialsTest {
         assertEquals("ExampleCity", resultAttributes.get("City").get(0));
         assertEquals("123456", resultAttributes.get("ZipCode").get(0));
         assertEquals("ExampleCountry", resultAttributes.get("Country").get(0));
+    }
+
+    @Test
+    public void verifyMultiValuedAttributeExtraction() throws Exception {
+        var credentials = extractCredentials(RESPONSE_FILE_NAME_WITH_MULTIVALUEDATTR);
+        assertNotNull(credentials);
+        var attributes = credentials.getAttributes();
+        assertNotNull(attributes);
+
+        assertEquals(1, attributes.size());
+        var resultAttributes = attributes.stream()
+            .collect(Collectors.toMap(SAMLAttribute::getName, SAMLAttribute::getAttributeValues));
+        assertEquals(1, resultAttributes.size());
+        assertEquals(List.of("Product-X Dev", "Product-X Test"), resultAttributes.get("groups"));
     }
 
     private SAML2Credentials extractCredentials(String filename) throws Exception {

--- a/pac4j-saml/src/test/resources/sample_authn_response_with_multivaluedattr.xml
+++ b/pac4j-saml/src/test/resources/sample_authn_response_with_multivaluedattr.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<saml2p:Response xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Destination="https://keyhub-test-app:8443/keyhub-sso/saml2client/callback" ID="_14d4ad6cae022d3c3805e5e6a85ea7ecbaf729468e3ad879c5dbfa31d700018b63dc5b138ca053f0023751099e2eb933a83d199c65ac22f687d4b6177e4109fa" InResponseTo="_0a879c76b4f2447c9a2e14095d6b6064d29bda4" IssueInstant="2021-11-05T19:18:14.023Z" Version="2.0">
+  <saml2:Issuer xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">https://keyhub-test-app:8443</saml2:Issuer>
+  <ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+    <ds:SignedInfo>
+      <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+      <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+      <ds:Reference URI="#_14d4ad6cae022d3c3805e5e6a85ea7ecbaf729468e3ad879c5dbfa31d700018b63dc5b138ca053f0023751099e2eb933a83d199c65ac22f687d4b6177e4109fa">
+        <ds:Transforms>
+          <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+          <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+            <ec:InclusiveNamespaces xmlns:ec="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="xsd"/>
+          </ds:Transform>
+        </ds:Transforms>
+        <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+        <ds:DigestValue>LhdbivmK7mm/CoS5Gu1NzbgukARTNhTEkUcRmVLHpLo=</ds:DigestValue>
+      </ds:Reference>
+    </ds:SignedInfo>
+    <ds:SignatureValue>k/MbcsHTHO2PISqIq3Idl23T+bMVHfC4wn9lm0E6xqRemDUkTREH2gIX+ecWN0t/LObZSnbnapdan5gWnBfvwP3136Ti97opi3fmE5IYt4wAvKsYIAomR8Xoy9dk38B8btUMcGfd1WZwYdN1VuVwh63VquvdwZO7w1VqCNrwYORDwiNMwJsuS6mMqzg89lc8R/5s3qNK/Zp6zO1iCPuAmoEKACVCFIP8LDpkZ/d3uKbinhYBb7sGwu/4VApIY29ieyfN0eyaRiBv1U8yad/ytSwxxPmLJwLi1BgRPG/UlMHeS+gmP0WThYw38TjT2ZT57ilRPagfQBVYRHBBkIwvjXbvrnBFnc9fWkuoUCeLG48SMzSTIOzqZWBdvmHRy8281lvriO5Ai0eFDAvVvjtklWtgEtIXNEm0FalFW/E6j8O+QTWiYYc8p4JiyRxJjWtH6PUS8lvMwvmwJwjwAtJR4opLByAC8UTTTaT5Z3VjRL85bpLYiS7a/oJ5Ic2Q1ipgDOKFlIOE1ZGbZfWgW85xIjGVwgceqZMzXE4cIXS4BeRmOwVqR/JHKjKayUTKNDFVOAl7mD3hlpobrCz0aBISUzceDtqKmzvdU7p1zK+Uos13cwU6BSrxzDgWAQ4hxb2IUUGlD7MrqbqE5PCohIocuacRBRbkPmStjX+8k+cbtys=</ds:SignatureValue>
+    <ds:KeyInfo>
+      <ds:X509Data>
+        <ds:X509Certificate>MIIE7zCCAtcCCCupw+JuDwmqMA0GCSqGSIb3DQEBCwUAMDoxCzAJBgNVBAYTAk5MMRowGAYDVQQK
+DBFUb3BpY3VzIE9uZGVyd2lqczEPMA0GA1UECwwGS2V5SHViMB4XDTIxMTEwNTE5MTYwMVoXDTI2
+MTEwOTAwMDAwMFowOjELMAkGA1UEBhMCTkwxGjAYBgNVBAoMEVRvcGljdXMgT25kZXJ3aWpzMQ8w
+DQYDVQQLDAZLZXlIdWIwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCtLQozYvZaT8O2
+4eqVzymXgXfQZmOMSmq4YHczCe7SCP2Tq7GztoS5UE/qpRSvqiCx1hvOriavpdeUXIzVYXti1mbi
+dLqffaBTSBwxgZCGvkjPEzD3dHJiaS2ISA5iwBAtAIsA9JXkCmqIV5ppsm5Z3u4Jm2u0PlJgtf20
+mOVUIPlY0A41y+LEzDg/MIKLrgwmFp6fR6uJImkANiRGBKXV2HPVQYutau3NsXycmwN/G9bvnbdi
+aqTeuT0xaa4enD1qAaEfbyf1XgkYUJ2GEZxl4PWgCvdnwXI/dx4f9zk4OObfIaPrxo1FLPT1c7Py
+ZMhEaLIArjDoqjHDbCbhumj5sO+U9uE/PDoutVnSDYPhg4gAOIB6s/fC5Oli4Zx7X5c4tnPTZpw9
+JLniJXS192JEs5T89SaYj34wFlxI34LFXR2OzDWVRFDa8yIM5XmHoJ+5NdLb+NhCeKH13Xr64CmD
+IoFTu0kqNKrw0wXhsXSZHB2LndIMXdUK93c2anwNi3i+7ZFYEG9IWAupH3fHg6F4ZZcF/82CCLa+
+JSQ4IhthzKSV8uIJaG27ZyCRNaAZUmft7AB1RCACaT0iQzKY+fkH2nfO7O/7WZtK9xZfB1ZQHCKx
+8y/oiiNIJa6fULnDQphWe5dSPKCQakiu2LJXE+Dq1p35iPWEfzF/vuVxyTiAEQIDAQABMA0GCSqG
+SIb3DQEBCwUAA4ICAQBib45bBRb0yiaNTicEoTG6UKEcnoTUBBIAQ0r5s9DsuN22x+YLsVCw5bhH
+2dNmSAWf2XWez3hlnzO86ctGh2bvsr5VW+iSR0esyJjQe1zMZO2sYB3KNbcj/dXHrevmDEJLNjM8
+E1XIF4pMJeodgTqkRyDfRI4ivYoN95tDls0VP5fLXjQ6qP65xtcD8pczqtipfdk7TcE6TVus+8YR
+3G7eLsSEax1mFI3MmWxOfOz4o84dj22TD+c70qTu3uQLFCyVjOY5YOfUyo8yAgvGkYGi4cZ7/Kf+
+uvJIdJEZF7HZri2VsVCLrb2W4YeqMpbnMACveEaStVuHOkHzM8ZCE2lVHYDb3csJ+T6x+hwdFVdq
+p60szC/KE5p47BdhRROrpq5qZK8ij/JGloqo1Kc5XHYsAC5txOAHbmjoyMIjrMVE1c+FcHbSynxn
+hYhwdHp8fTKKoD0vsA24zkkkLP5v1kZoNUv/sRtl0tEct/Y/fhU8TgnMQ/dDMBmmMxcnAUrVxOHo
+SM7ji0L5omAVhH+ZlGeq8QZkU7pgRj+suuEJ8x3RICspRErGA94WTpliLK83teF+1vH7EDieFbV/
+1menTZaN6IuMCWm2FgvzRhFxbREZ2pT3siKgBgxDYlRtXZcZQKMYbnC/yyxDxXCsdQ8oMSqHQSnF
+sMQZgkC6KRNf+6sCgQ==</ds:X509Certificate>
+      </ds:X509Data>
+    </ds:KeyInfo>
+  </ds:Signature>
+  <saml2p:Status>
+    <saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </saml2p:Status>
+  <saml2:Assertion xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="_ed726b9eee5030d336b4366da3fc6ab300d550b81ecf0c9abac7efc2b8623f86b9681e27b967173a0cdde224e0100d9c6dbc27845d8bd1075ad473ea4e04b8a2" IssueInstant="2021-11-05T19:18:14.021Z" Version="2.0">
+    <saml2:Issuer>https://keyhub-test-app:8443</saml2:Issuer>
+    <saml2:Subject>
+      <saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">keyhubuser@keyhub.example.com</saml2:NameID>
+      <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+        <saml2:SubjectConfirmationData InResponseTo="_0a879c76b4f2447c9a2e14095d6b6064d29bda4" NotOnOrAfter="2021-11-05T20:18:14.021Z" Recipient="https://keyhub-test-app:8443/keyhub-sso/saml2client/callback"/>
+      </saml2:SubjectConfirmation>
+    </saml2:Subject>
+    <saml2:Conditions NotBefore="2021-11-05T19:18:14.021Z" NotOnOrAfter="2021-11-05T20:18:14.021Z">
+      <saml2:AudienceRestriction>
+        <saml2:Audience>https://keyhub.localhost/keyhub-sso/saml2client</saml2:Audience>
+      </saml2:AudienceRestriction>
+    </saml2:Conditions>
+    <saml2:AuthnStatement AuthnInstant="2021-11-05T19:18:14.021Z" SessionIndex="22f5d558-8719-486e-a1dd-19533b2c27c3">
+      <saml2:AuthnContext>
+        <saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
+      </saml2:AuthnContext>
+    </saml2:AuthnStatement>
+    <saml2:AttributeStatement>
+      <saml2:Attribute Name="groups">
+        <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Product-X Dev</saml2:AttributeValue>
+        <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Product-X Test</saml2:AttributeValue>
+      </saml2:Attribute>
+    </saml2:AttributeStatement>
+  </saml2:Assertion>
+</saml2p:Response>


### PR DESCRIPTION
Multi valued attributes are collected multiple times. For each value, the entire attribute is processed. This results in the same attribute being added with all values for every value. For example:
```      <saml2:Attribute Name="groups">
        <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Product-X Dev</saml2:AttributeValue>
        <saml2:AttributeValue xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xsd:string">Product-X Test</saml2:AttributeValue>
      </saml2:Attribute>
```
Gives:
```
groups -> [Product-X Dev, Product-X Test]
groups -> [Product-X Dev, Product-X Test]
```

The PR first collects all values for complex attributes and then adds a single attribute for all simple values (if any).