### PR TITLE
PartialLogout handling / SAML2 spec compliance

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -197,13 +197,19 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     @Override
     protected void validateSuccess(Status status) {
 
-        if (isPartialLogoutTreatedAsSuccess
-            && status != null && status.getStatusCode() != null && status.getStatusCode().getValue() != null
-            && status.getStatusCode().getValue().contains(StatusCode.PARTIAL_LOGOUT)) {
-            logger.debug(
-                "Response status code is {} and partial logouts are configured to be treated as success => validation successful!",
-                StatusCode.PARTIAL_LOGOUT);
-            return;
+        if (isPartialLogoutTreatedAsSuccess && status != null && status.getStatusCode() != null
+            && StatusCode.RESPONDER.equals(status.getStatusCode().getValue())) {
+
+            logger.debug("Response status code: {}", status.getStatusCode().getValue());
+
+            if (status.getStatusCode().getOrderedChildren().stream()
+                .filter(StatusCode.class::isInstance).map(StatusCode.class::cast)
+                .anyMatch(code -> StatusCode.PARTIAL_LOGOUT.equals(code.getValue()))) {
+                logger.debug(
+                    "Response sub-status code is {} and partial logouts are configured to be treated as success => validation successful!",
+                    StatusCode.PARTIAL_LOGOUT);
+                return;
+            }
         }
 
         super.validateSuccess(status);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -197,13 +197,19 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     @Override
     protected void validateSuccess(Status status) {
 
-        if (isPartialLogoutTreatedAsSuccess && status != null && status.getStatusCode() != null
-            && StatusCode.RESPONDER.equals(status.getStatusCode().getValue())) {
+        if (isPartialLogoutTreatedAsSuccess && status != null && status.getStatusCode() != null) {
+
+            if (StatusCode.PARTIAL_LOGOUT.equals(status.getStatusCode().getValue())) {
+                logger.debug(
+                    "Response status code is {} and partial logouts are configured to be treated as success => validation successful!",
+                    StatusCode.PARTIAL_LOGOUT);
+                return;
+            }
 
             logger.debug("Response status code: {}", status.getStatusCode().getValue());
 
-            if (status.getStatusCode().getOrderedChildren().stream()
-                .filter(StatusCode.class::isInstance).map(StatusCode.class::cast)
+            if (StatusCode.RESPONDER.equals(status.getStatusCode().getValue())
+                && status.getStatusCode().getOrderedChildren().stream().filter(StatusCode.class::isInstance).map(StatusCode.class::cast)
                 .anyMatch(code -> StatusCode.PARTIAL_LOGOUT.equals(code.getValue()))) {
                 logger.debug(
                     "Response sub-status code is {} and partial logouts are configured to be treated as success => validation successful!",

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -120,17 +120,17 @@ public class SAML2LogoutValidatorTests {
     @Test
     public void verifyThatPartialLogoutIsAcceptedAsSuccess() throws Exception {
 
-        final var xml = "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" " +
-            "xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" " +
-            "ID=\"_6c3737282f007720e736f0f4028feed8cb9b40291c\" Version=\"2.0\" " +
-            "IssueInstant=\"" + ZonedDateTime.now(ZoneOffset.UTC)
-            + "\" Destination=\"http://sp.example.com/demo1/logout?x=1000%26y=1234\" " +
-            "InResponseTo=\"ONELOGIN_21df91a89767879fc0f7df6a1490c6000c81644d\">%n" +
-            "  <saml:Issuer>http://idp.example.com/metadata.php</saml:Issuer>%n" +
-            "  <samlp:Status>%n" +
-            "    <samlp:StatusCode Value="+
-            "\"urn:oasis:names:tc:SAML:2.0:status:Responder / urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>%n" +
-            "  </samlp:Status>%n" +
+        final var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Destination=\"http://sp.example.com/demo1/logout\" " +
+            "ID=\"_0a59a9e8-1885-4127-84c8-515354c7e29d\" InResponseTo=\"_1981f72063034b65b659cf5dc484e2f01698e96\" " +
+            "IssueInstant=\""+ZonedDateTime.now(ZoneOffset.UTC)+"\" Version=\"2.0\">\n" +
+            "    <saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:some:redacted:issuer</saml:Issuer>\n" +
+            "    <samlp:Status>\n" +
+            "        <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Responder\">\n" +
+            "            <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>\n" +
+            "        </samlp:StatusCode>\n" +
+            "        <samlp:StatusMessage>urn:oasis:names:tc:SAML:2.0:status:PartialLogout</samlp:StatusMessage>\n" +
+            "    </samlp:Status>\n" +
             "</samlp:LogoutResponse>";
 
         final var webContext = getMockWebContext();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -118,7 +118,7 @@ public class SAML2LogoutValidatorTests {
     }
 
     @Test
-    public void verifyThatPartialLogoutIsAcceptedAsSuccess() throws Exception {
+    public void verifyThatPartialLogoutAsSecondLevelStatusCodeIsAcceptedAsSuccess() throws Exception {
 
         final var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Destination=\"http://sp.example.com/demo1/logout\" " +
@@ -129,10 +129,29 @@ public class SAML2LogoutValidatorTests {
             "        <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:Responder\">\n" +
             "            <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>\n" +
             "        </samlp:StatusCode>\n" +
-            "        <samlp:StatusMessage>urn:oasis:names:tc:SAML:2.0:status:PartialLogout</samlp:StatusMessage>\n" +
             "    </samlp:Status>\n" +
             "</samlp:LogoutResponse>";
 
+        validateResponse(xml);
+    }
+
+    @Test
+    public void verifyThatPartialLogoutAsTopLevelStatusCodeIsAcceptedAsSuccess() throws Exception {
+
+        final var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Destination=\"http://sp.example.com/demo1/logout\" " +
+            "ID=\"_0a59a9e8-1885-4127-84c8-515354c7e29d\" InResponseTo=\"_1981f72063034b65b659cf5dc484e2f01698e96\" " +
+            "IssueInstant=\""+ZonedDateTime.now(ZoneOffset.UTC)+"\" Version=\"2.0\">\n" +
+            "    <saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:some:redacted:issuer</saml:Issuer>\n" +
+            "    <samlp:Status>\n" +
+            "        <samlp:StatusCode Value=\"urn:oasis:names:tc:SAML:2.0:status:PartialLogout\"/>\n" +
+            "    </samlp:Status>\n" +
+            "</samlp:LogoutResponse>";
+
+        validateResponse(xml);
+    }
+
+    private void validateResponse(String xml) {
         final var webContext = getMockWebContext();
         final var context = getSaml2MessageContext(webContext, xml);
         final var validator = new SAML2LogoutValidator(

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -121,7 +121,8 @@ public class SAML2LogoutValidatorTests {
     public void verifyThatPartialLogoutAsSecondLevelStatusCodeIsAcceptedAsSuccess() throws Exception {
 
         final var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Destination=\"http://sp.example.com/demo1/logout\" " +
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" "+
+            "Destination=\"http://sp.example.com/demo1/logout\" " +
             "ID=\"_0a59a9e8-1885-4127-84c8-515354c7e29d\" InResponseTo=\"_1981f72063034b65b659cf5dc484e2f01698e96\" " +
             "IssueInstant=\""+ZonedDateTime.now(ZoneOffset.UTC)+"\" Version=\"2.0\">\n" +
             "    <saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:some:redacted:issuer</saml:Issuer>\n" +
@@ -139,7 +140,8 @@ public class SAML2LogoutValidatorTests {
     public void verifyThatPartialLogoutAsTopLevelStatusCodeIsAcceptedAsSuccess() throws Exception {
 
         final var xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Destination=\"http://sp.example.com/demo1/logout\" " +
+            "<samlp:LogoutResponse xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" "+
+            "Destination=\"http://sp.example.com/demo1/logout\" " +
             "ID=\"_0a59a9e8-1885-4127-84c8-515354c7e29d\" InResponseTo=\"_1981f72063034b65b659cf5dc484e2f01698e96\" " +
             "IssueInstant=\""+ZonedDateTime.now(ZoneOffset.UTC)+"\" Version=\"2.0\">\n" +
             "    <saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:some:redacted:issuer</saml:Issuer>\n" +


### PR DESCRIPTION
Hello everyone,

a while ago I submitted a pull request to support the handling of PartialLogout status codes in SAML2 Responses as successful logouts. However I made a mistake in the implementation, which doesn't comply with the SAML2 spec. Apologies for that. Our SAML2 IdP had that part incorrectly in their implementation too and only fixed it a while after we had been discussing the issue. Now their fix is live and I stumbled upon this topic again.

**Actual behaviour**: The current implementation searches for the PartialLogout code only on the top level.

**Expected behaviour**: The PartialLogout code is allowed as a sub-code of the Responder status-code. 

**Proof**: From the SAML 2.0 core spec ([link](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)) lines 2641-2645:
> In the event that not all session participants successfully respond to these <LogoutRequest> messages
> (or if not all participants can be contacted), then the session authority MUST include in its
> <LogoutResponse> message a second-level status code of
> urn:oasis:names:tc:SAML:2.0:status:PartialLogout to indicate that not all other session
> participants successfully responded with confirmation of the logout.

Schema definition (same document, line 1700):
```
<element name="StatusCode" type="samlp:StatusCodeType"/>
<complexType name="StatusCodeType">
  <sequence>
    <element ref="samlp:StatusCode" minOccurs="0"/>
  </sequence>
  <attribute name="Value" type="anyURI" use="required"/>
</complexType>
```

However according to lines 1634 and following, PartialLogout is also allowed on top level. If it occurs on second level, then only the Responder status code seems to be eligible to carry the PartialLogout status as second level code.

**Impact of this pull request**: Now both top level and second level status codes of type PartialLogout are supported, as described by the OASIS spec.