### PR TITLE
add support for Windows ADFS Openid Connect using self-signed cert

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -166,8 +166,12 @@ public class OidcConfiguration extends BaseClientConfiguration {
         // default value
         if (getResourceRetriever() == null) {
             try {
-                setResourceRetriever(SSLFactory == null ? new DefaultResourceRetriever(getConnectTimeout(),getReadTimeout()) : new DefaultResourceRetriever(getConnectTimeout(),getReadTimeout(),0,false, (SSLSocketFactory) Class.forName(SSLFactory).getDeclaredConstructor().newInstance()));
-            } catch (ClassNotFoundException | InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+                setResourceRetriever(SSLFactory == null ?
+                    new DefaultResourceRetriever(getConnectTimeout(),getReadTimeout()) :
+                    new DefaultResourceRetriever(getConnectTimeout(),getReadTimeout(), 0, false,
+                        (SSLSocketFactory) Class.forName(SSLFactory).getDeclaredConstructor().newInstance()));
+            } catch (ClassNotFoundException | InvocationTargetException | InstantiationException
+                | IllegalAccessException | NoSuchMethodException e) {
                 throw new TechnicalException("SSLFactory loaded fail, please check your configuration");
             }
         }
@@ -522,6 +526,7 @@ public class OidcConfiguration extends BaseClientConfiguration {
             "connectTimeout", connectTimeout, "readTimeout", readTimeout, "resourceRetriever", resourceRetriever,
             "responseType", responseType, "responseMode", responseMode, "logoutUrl", logoutUrl,
             "withState", withState, "stateGenerator", stateGenerator, "logoutHandler", logoutHandler,
-            "tokenValidator", tokenValidator, "mappedClaims", mappedClaims, "allowUnsignedIdTokens", allowUnsignedIdTokens, "SSLFactory", SSLFactory);
+            "tokenValidator", tokenValidator, "mappedClaims", mappedClaims, "allowUnsignedIdTokens", allowUnsignedIdTokens,
+            "SSLFactory", SSLFactory);
     }
 }


### PR DESCRIPTION
add support for Windows ADFS Openid Connect using self-signed certificate in development or testing environment by using custom SSLFactory.
use it like:
config.setSSLFactory("org.pac4j.oidc.test.XXXSSLSupportFactory");
it's working fine and passed the test.