### PR TITLE
Restoring lost methods.

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -29,8 +29,12 @@ public interface UserProfile extends Serializable {
     boolean containsAttribute(String name);
 
     void addAttribute(String key, Object value);
-
+    
+    void removeAttribute(String key);
+    
     void addAuthenticationAttribute(String key, Object value);
+    
+    void removeAuthenticationAttribute(String key);
 
     void addRole(String role);
 


### PR DESCRIPTION
During our migration to 5.3.2 we noticed that the remove*Attribute methods have been dropped from the UserProfile interface as it seems. They still exist on BasicUserProfile and there are no signs of deprecation, so it might be good to add them again.

Sorry, I couldn't follow the instructions in the contribution guide, because I don't and will not own a google-group-account.