### PR TITLE
Implement RFC 9207 OAuth 2.0 Authorization Server Issuer Identification

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -9,6 +9,7 @@ title: Release notes&#58;
   - the `pac4j-javaee` dependency (JEE components in the `org.pac4j.jee` package, based on the `javax.servlet-api` library v4) or
   - the `pac4j-jakartaee` dependency (JEE components in the `org.pac4j.jee` package, based on the `jakarta.servlet-api` library v5)
 - Refactored the SAML2 attributes conversion (from the SAML2 authn response) to rely on a defined `AttributeConverter` at the `SAML2Configuration` level
+- Implemented RFC 9207 OAuth 2.0 Authorization Server Issuer Identification in `pac4j-oidc`
 
 **v5.3.1**:
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcExtractor.java
@@ -99,6 +99,12 @@ public class OidcExtractor implements CredentialsExtractor {
             logger.debug("Authentication response successful");
             var successResponse = (AuthenticationSuccessResponse) response;
 
+            var metadata = configuration.getProviderMetadata();
+            if (metadata.supportsAuthorizationResponseIssuerParam() &&
+                !metadata.getIssuer().equals(successResponse.getIssuer())) {
+                throw new TechnicalException("Issuer mismatch, possible mix-up attack.");
+            }
+
             if (configuration.isWithState()) {
                 // Validate state for CSRF mitigation
                 final var requestState = (State) configuration.getValueRetriever()


### PR DESCRIPTION
IdPs supporting this specification, will advertise this via the metadata. If the IdP indicates it supports RFC 9207, the RP must check the issuer parameter in authorization responses. Its value must match the issuer in the IdP metadata.

See https://www.rfc-editor.org/rfc/rfc9207.html for more information. It is a simple spec that protects RPs from mix-up attacks: a form of attack were a client is tricked into sending an authorization code for one IdP to another, compromised IdP.