### PR TITLE
Bump spring.version to 5.2.20.RELEASE (CVE-2022-22965)

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -3,6 +3,10 @@ layout: doc
 title: Release notes&#58;
 ---
 
+**v4.5.6**:
+
+- Fix [CVE-2022-22965](https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement)
+
 **v4.5.5**:
 
 - Fix CVE-2021-44878

--- a/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/client/SAML2ClientTests.java
+++ b/pac4j-saml-opensamlv3/src/test/java/org/pac4j/saml/client/SAML2ClientTests.java
@@ -35,7 +35,7 @@ public final class SAML2ClientTests {
 
     @Test
     public void testIdpMetadataParsing_fromUrl() throws MalformedURLException {
-        internalTestIdpMetadataParsing(new UrlResource("http://www.pac4j.org/testshib-providers.xml"));
+        internalTestIdpMetadataParsing(new UrlResource("https://www.pac4j.org/testshib-providers.xml"));
     }
 
     @Test

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -100,6 +100,16 @@
             <version>${opensaml.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-beans</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.opensaml</groupId>
             <artifactId>opensaml-xmlsec-impl</artifactId>
             <version>${opensaml.version}</version>

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/SAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/SAML2ClientTests.java
@@ -35,7 +35,7 @@ public final class SAML2ClientTests {
 
     @Test
     public void testIdpMetadataParsing_fromUrl() throws MalformedURLException {
-        internalTestIdpMetadataParsing(new UrlResource("http://www.pac4j.org/testshib-providers.xml"));
+        internalTestIdpMetadataParsing(new UrlResource("https://www.pac4j.org/testshib-providers.xml"));
     }
 
     @Test

--- a/pac4j-springboot/pom.xml
+++ b/pac4j-springboot/pom.xml
@@ -13,12 +13,19 @@
     <name>pac4j for Spring Boot</name>
 
     <properties>
-        <springboot.version>2.3.4.RELEASE</springboot.version>
+        <springboot.version>2.3.12.RELEASE</springboot.version>
         <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-framework-bom</artifactId>
+                <version>${spring.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<commons-io.version>2.8.0</commons-io.version>
 		<guava.version>29.0-jre</guava.version>
 		<nimbus-jose-jwt.version>8.22.1</nimbus-jose-jwt.version>
-		<spring.version>5.2.9.RELEASE</spring.version>
+		<spring.version>5.2.20.RELEASE</spring.version>
 		<spring.security.version>5.4.0</spring.security.version>
 		<shiro.version>1.6.0</shiro.version>
         <jbcrypt.version>0.4.1</jbcrypt.version>


### PR DESCRIPTION
Bump the Spring Framework version to 5.2.20.RELEASE to address CVE-2022-22965.

https://tanzu.vmware.com/security/cve-2022-22965
https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement