### PR TITLE
Bump OpenSAMLv3 to version 3.4.6

### DIFF
--- a/pac4j-saml-opensamlv3/pom.xml
+++ b/pac4j-saml-opensamlv3/pom.xml
@@ -13,7 +13,7 @@
     <name>pac4j: Java web security via SAML protocol (JDK 8, OpenSAML v3)</name>
 
     <properties>
-        <opensaml.version>3.4.5</opensaml.version>
+        <opensaml.version>3.4.6</opensaml.version>
         <joda-time.version>2.10.6</joda-time.version>
         <velocity.version>2.3</velocity.version>
         <xmlsectool.version>2.0.0</xmlsectool.version>


### PR DESCRIPTION
This will fix the build due Maven 3.8.1 blocking non-HTTPS repositories:
https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked

`opensaml-core:3.4.5` uses `opensaml-parent:3.4.5` as parent which in turn is using `net.shibboleth:parent:7.11.0` as parent which is referencing Maven Central with an HTTP URL (instead of using HTTPS).

Old dependencies:

- https://mvnrepository.com/artifact/org.opensaml/opensaml-core/3.4.5
- https://mvnrepository.com/artifact/org.opensaml/opensaml-parent/3.4.5
- https://mvnrepository.com/artifact/net.shibboleth/parent/7.11.0

New dependencies:

- https://mvnrepository.com/artifact/org.opensaml/opensaml-core/3.4.6
- https://mvnrepository.com/artifact/org.opensaml/opensaml-parent/3.4.6
- https://mvnrepository.com/artifact/net.shibboleth/parent/7.11.2