### PR TITLE
Handle malformed auth creds in BasicAuthExtractor

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
@@ -36,7 +36,12 @@ public class BasicAuthExtractor implements CredentialsExtractor {
         return optCredentials.map(cred -> {
 
             final var credentials = (TokenCredentials) cred;
-            final var decoded = Base64.getDecoder().decode(credentials.getToken());
+            final byte[] decoded;
+            try {
+                decoded = Base64.getDecoder().decode(credentials.getToken());
+            } catch (IllegalArgumentException e) {
+                throw new CredentialsException("Bad format of the basic auth header");
+            }
             final var token = new String(decoded, StandardCharsets.UTF_8);
 
             final var delim = token.indexOf(":");


### PR DESCRIPTION
Base64.Decoder can throw an IllegalArgumentException if string
it is attempting to decode does not contain enough bits. In the
BasicAuthExtractor this could only be the result of a request
with incorrect credentials, so this should result in a client
error rather than a RuntimeException and likely 500 status code.

Before submitting any pull request, please read the contribution guide: https://www.pac4j.org/docs/contribute.html