### PR TITLE
Access should be denied when zero roles/permissions are in profile

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/AbstractRequireAnyAuthorizer.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/AbstractRequireAnyAuthorizer.java
@@ -16,7 +16,7 @@ public abstract class AbstractRequireAnyAuthorizer<E extends Object> extends Abs
     @Override
     protected boolean isProfileAuthorized(final WebContext context, final SessionStore sessionStore, final UserProfile profile) {
         if (elements == null || elements.isEmpty()) {
-            return true;
+            return check(context, sessionStore, profile, null);
         }
         for (final var element : elements) {
             if (check(context, sessionStore, profile, element)) {

--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/RequireAnyPermissionAuthorizer.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/RequireAnyPermissionAuthorizer.java
@@ -32,6 +32,12 @@ public class RequireAnyPermissionAuthorizer extends AbstractRequireAnyAuthorizer
     @Override
     protected boolean check(final WebContext context, final SessionStore sessionStore, final UserProfile profile, final String element) {
         final var profilePermissions = profile.getPermissions();
+        if( profilePermissions.isEmpty() ) {
+            return false;
+        }
+        if( element == null ) {
+            return true;
+        }
         return profilePermissions.contains(element);
     }
 

--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/RequireAnyRoleAuthorizer.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/RequireAnyRoleAuthorizer.java
@@ -30,6 +30,12 @@ public class RequireAnyRoleAuthorizer extends AbstractRequireAnyAuthorizer<Strin
     @Override
     protected boolean check(final WebContext context, final SessionStore sessionStore, final UserProfile profile, final String element) {
         final var profileRoles = profile.getRoles();
+        if( profileRoles.isEmpty() ) {
+            return false;
+        }
+        if( element == null ) {
+            return true;
+        }
         return profileRoles.contains(element);
     }
 

--- a/pac4j-core/src/test/java/org/pac4j/core/authorization/authorizer/RequireAnyPermissionAuthorizerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/authorization/authorizer/RequireAnyPermissionAuthorizerTests.java
@@ -115,4 +115,10 @@ public final class RequireAnyPermissionAuthorizerTests {
         profile.addPermission(PERMISSION3);
         assertFalse(authorizer.isAuthorized(context, new MockSessionStore(), profiles));
     }
+
+    @Test
+    public void testHasAnyPermissionAtLeastOne() {
+        final var authorizer = new RequireAnyPermissionAuthorizer();
+        assertFalse(authorizer.isAuthorized(context, new MockSessionStore(), profiles));
+    }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/authorization/authorizer/RequireAnyRoleAuthorizerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/authorization/authorizer/RequireAnyRoleAuthorizerTests.java
@@ -114,4 +114,10 @@ public final class RequireAnyRoleAuthorizerTests {
         profile.addRole(ROLE3);
         assertFalse(authorizer.isAuthorized(context, new MockSessionStore(), profiles));
     }
+
+    @Test
+    public void testHasAnyRoleAtLeastOne() {
+        final var authorizer = new RequireAnyRoleAuthorizer();
+        assertFalse(authorizer.isAuthorized(context, new MockSessionStore(), profiles));
+    }
 }


### PR DESCRIPTION
Documentation states: 
[RequireAnyRoleAuthorizer](https://github.com/pac4j/pac4j/blob/master/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/RequireAnyRoleAuthorizer.java) checks that a user profile has at least one
[RequireAnyPermissionAuthorizer](https://github.com/pac4j/pac4j/blob/master/pac4j-core/src/main/java/org/pac4j/core/authorization/authorizer/RequireAnyPermissionAuthorizer.java) checks that a user profile has at least one

If profile has 0 - then access must be denied.

Before submitting any pull request, please read the contribution guide: https://www.pac4j.org/docs/contribute.html