### PR TITLE
Allow the default SAML metadata signer to accept SAML2Configuration

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSigner.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSigner.java
@@ -1,14 +1,15 @@
 package org.pac4j.saml.metadata;
 
-import org.opensaml.core.xml.io.MarshallingException;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.opensaml.security.SecurityException;
 import org.opensaml.xmlsec.SignatureSigningParameters;
 import org.opensaml.xmlsec.signature.support.SignatureConstants;
-import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
+import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.crypto.CredentialProvider;
 import org.pac4j.saml.exceptions.SAMLException;
+
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * This is {@link DefaultSAML2MetadataSigner}.
@@ -16,15 +17,26 @@ import org.pac4j.saml.exceptions.SAMLException;
  * @author Misagh Moayyed
  * @since 5.0.0
  */
-public class DefaultSAML2MetadataSigner implements SAML2MetadataSigner{
+public class DefaultSAML2MetadataSigner implements SAML2MetadataSigner {
     protected final CredentialProvider credentialProvider;
 
     protected final String signatureAlgorithm;
 
     protected final String signatureReferenceDigestMethod;
 
+    protected final SAML2Configuration configuration;
+
+    public DefaultSAML2MetadataSigner(final SAML2Configuration configuration) {
+        this.configuration = configuration;
+        this.credentialProvider = null;
+        this.signatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        this.signatureReferenceDigestMethod = "http://www.w3.org/2001/04/xmlenc#sha256";
+    }
+
     public DefaultSAML2MetadataSigner(final CredentialProvider credentialProvider,
-                                      final String signatureAlgorithm, final String signatureReferenceDigestMethod) {
+                                      final String signatureAlgorithm,
+                                      final String signatureReferenceDigestMethod) {
+        this.configuration = null;
         this.credentialProvider = credentialProvider;
         this.signatureAlgorithm = signatureAlgorithm;
         this.signatureReferenceDigestMethod = signatureReferenceDigestMethod;
@@ -32,17 +44,34 @@ public class DefaultSAML2MetadataSigner implements SAML2MetadataSigner{
 
     @Override
     public void sign(final EntityDescriptor descriptor) {
-        final var signingParameters = new SignatureSigningParameters();
-        signingParameters.setKeyInfoGenerator(credentialProvider.getKeyInfoGenerator());
-        signingParameters.setSigningCredential(credentialProvider.getCredential());
-        signingParameters.setSignatureAlgorithm(signatureAlgorithm);
-        signingParameters.setSignatureReferenceDigestMethod(signatureReferenceDigestMethod);
-        signingParameters.setSignatureCanonicalizationAlgorithm(
-            SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
-
         try {
+            final var signingParameters = new SignatureSigningParameters();
+
+            final var activeProvider = Objects.requireNonNull(Optional.ofNullable(configuration)
+                .map(SAML2Configuration::getCredentialProvider)
+                .orElseGet(() -> this.credentialProvider));
+            signingParameters.setKeyInfoGenerator(activeProvider.getKeyInfoGenerator());
+            signingParameters.setSigningCredential(activeProvider.getCredential());
+
+            final var signingAlgorithm = Optional.ofNullable(configuration)
+                .map(SAML2Configuration::getSignatureAlgorithms)
+                .filter(algorithms -> !algorithms.isEmpty())
+                .map(algorithms -> algorithms.get(0))
+                .orElse(this.signatureAlgorithm);
+            signingParameters.setSignatureAlgorithm(signingAlgorithm);
+
+            final var signingReference = Optional.ofNullable(configuration)
+                .map(SAML2Configuration::getSignatureReferenceDigestMethods)
+                .filter(algorithms -> !algorithms.isEmpty())
+                .map(algorithms -> algorithms.get(0))
+                .orElse(this.signatureReferenceDigestMethod);
+            signingParameters.setSignatureReferenceDigestMethod(signingReference);
+
+            signingParameters.setSignatureCanonicalizationAlgorithm(
+                SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+
             SignatureSupport.signObject(descriptor, signingParameters);
-        } catch (final SecurityException | MarshallingException | SignatureException e) {
+        } catch (final Exception e) {
             throw new SAMLException(e.getMessage(), e);
         }
     }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSignerTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSignerTests.java
@@ -1,0 +1,56 @@
+package org.pac4j.saml.metadata;
+
+import org.junit.Test;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.util.DefaultConfigurationManager;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This is {@link DefaultSAML2MetadataSignerTests}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.4.4
+ */
+public class DefaultSAML2MetadataSignerTests {
+    @Test
+    public void verifySigningWithConfigurationDefaults() throws Exception {
+        final var configuration = new SAML2Configuration();
+        verifyMetadataSigning(configuration);
+    }
+
+    @Test
+    public void verifySigningWithConfigurationOverride() throws Exception {
+        final var configuration = new SAML2Configuration();
+        configuration.setSignatureAlgorithms(List.of("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"));
+        configuration.setSignatureReferenceDigestMethods(List.of("http://www.w3.org/2001/04/xmlenc#sha256"));
+        verifyMetadataSigning(configuration);
+    }
+
+    private static void verifyMetadataSigning(SAML2Configuration configuration) throws Exception {
+        configuration.setForceKeystoreGeneration(true);
+        configuration.setKeystorePath("target/keystore.jks");
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+        configuration.setSignMetadata(true);
+        configuration.setServiceProviderMetadataResource(new FileSystemResource("target/out.xml"));
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.setMetadataSigner(new DefaultSAML2MetadataSigner(configuration));
+        configuration.init();
+
+        final var mgr = new DefaultConfigurationManager();
+        mgr.configure();
+        final var metadataGenerator = configuration.toMetadataGenerator();
+        final var entity = metadataGenerator.buildEntityDescriptor();
+        assertNotNull(entity);
+        final var metadata = metadataGenerator.getMetadata(entity);
+        assertNotNull(metadata);
+
+        metadataGenerator.storeMetadata(metadata, configuration.getServiceProviderMetadataResource(), true);
+        assertNotNull(metadataGenerator.buildMetadataResolver(configuration.getServiceProviderMetadataResource()));
+    }
+}


### PR DESCRIPTION
This pull request allows the `DefaultSAML2MetadataSigner` to accept a `SAML2Configuration` to use for locating signing credentials and signature settings. For compatibility reasons, the existing approach using a direct credential provider is kept. Clients when using `SAML2Configuration`, are able to override the signing algorithms separately.

Added tests to confirm behavior.