### PR TITLE
allow to remove or replace a specific default matcher or autorizer by name

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/util/Pac4jConstants.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/Pac4jConstants.java
@@ -50,6 +50,8 @@ public interface Pac4jConstants {
 
     String ADD_ELEMENT = "+";
 
+	String REMOVE_ELEMENT = "-";
+
     String TYPED_ID_SEPARATOR = "#";
 
     /* The logout pattern for url */

--- a/pac4j-core/src/test/java/org/pac4j/core/authorization/checker/DefaultAuthorizationCheckerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/authorization/checker/DefaultAuthorizationCheckerTests.java
@@ -1,5 +1,16 @@
 package org.pac4j.core.authorization.checker;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.pac4j.core.authorization.authorizer.Authorizer;
@@ -9,7 +20,9 @@ import org.pac4j.core.client.Client;
 import org.pac4j.core.client.MockDirectClient;
 import org.pac4j.core.client.MockIndirectClient;
 import org.pac4j.core.client.direct.AnonymousClient;
-import org.pac4j.core.context.*;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.TechnicalException;
@@ -20,10 +33,6 @@ import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
-
-import java.util.*;
-
-import static org.junit.Assert.*;
 
 /**
  * Tests the {@link DefaultAuthorizationChecker}.
@@ -308,6 +317,20 @@ public final class DefaultAuthorizationCheckerTests implements TestsConstants {
             DefaultAuthorizationChecker.IS_FULLY_AUTHENTICATED_AUTHORIZER),
             checker.computeAuthorizers(MockWebContext.create(), new ArrayList<>(),
                 "+" + DefaultAuthorizers.IS_FULLY_AUTHENTICATED, new HashMap<>(), new ArrayList<>()));
+    }
+    
+    @Test
+    public void testComputeAuthorizerNoClientMinusIsAuthenticated() {
+		assertEquals(0, checker.computeAuthorizers(MockWebContext.create(), new ArrayList<>(),
+                "-" + DefaultAuthorizers.IS_FULLY_AUTHENTICATED, new HashMap<>(), new ArrayList<>()).size());
+    }
+    
+    @Test
+    public void testComputeAuthorizerNoClientPlusIsFullyAuthenticatedMinusIsAuthenticated() {
+        assertEquals(Arrays.asList(
+            DefaultAuthorizationChecker.IS_FULLY_AUTHENTICATED_AUTHORIZER),
+            checker.computeAuthorizers(MockWebContext.create(), new ArrayList<>(),
+                "+" + DefaultAuthorizers.IS_FULLY_AUTHENTICATED + "-" + DefaultAuthorizationChecker.IS_AUTHENTICATED_AUTHORIZER, new HashMap<>(), new ArrayList<>()));
     }
 
     @Test

--- a/pac4j-core/src/test/java/org/pac4j/core/matching/checker/DefaultMatchingCheckerTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/matching/checker/DefaultMatchingCheckerTests.java
@@ -1,9 +1,30 @@
 package org.pac4j.core.matching.checker;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.pac4j.core.context.HttpConstants.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER;
+import static org.pac4j.core.context.HttpConstants.ACCESS_CONTROL_ALLOW_METHODS_HEADER;
+import static org.pac4j.core.context.HttpConstants.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER;
+import static org.pac4j.core.context.HttpConstants.SCHEME_HTTPS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.junit.Test;
 import org.pac4j.core.client.Client;
 import org.pac4j.core.client.MockIndirectClient;
-import org.pac4j.core.context.*;
+import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.context.HttpConstants.HTTP_METHOD;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.WebContextHelper;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.TechnicalException;
@@ -13,12 +34,6 @@ import org.pac4j.core.matching.matcher.Matcher;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
-
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
-import static org.pac4j.core.context.HttpConstants.*;
 
 /**
  * Tests {@link DefaultMatchingChecker}.
@@ -283,6 +298,26 @@ public final class DefaultMatchingCheckerTests implements TestsConstants {
         matchers.addAll(DefaultMatchingChecker.SECURITY_HEADERS_MATCHERS);
         matchers.add(DefaultMatchingChecker.POST_MATCHER);
         assertEquals(matchers, checker.computeMatchers(MockWebContext.create(), new MockSessionStore(), "   +   post",
+            new HashMap<>(), new ArrayList<>()));
+    }
+    
+    @Test
+	public void testComputeMatchersMinusCacheControl() {
+		final List<Matcher> matchers = new ArrayList<>();
+		matchers.addAll(DefaultMatchingChecker.SECURITY_HEADERS_MATCHERS);
+		matchers.remove(DefaultMatchingChecker.CACHE_CONTROL_MATCHER);
+		assertEquals(matchers, checker.computeMatchers(MockWebContext.create(), new MockSessionStore(),
+				"   -   " + DefaultMatchers.NOCACHE, new HashMap<>(), new ArrayList<>()));
+	}
+
+	@Test
+	public void testComputeMatchersPlusPostMinusCacheControl() {
+        final List<Matcher> matchers = new ArrayList<>();
+        matchers.addAll(DefaultMatchingChecker.SECURITY_HEADERS_MATCHERS);
+		matchers.add(DefaultMatchingChecker.POST_MATCHER);
+        matchers.remove(DefaultMatchingChecker.CACHE_CONTROL_MATCHER);
+		assertEquals(matchers, checker.computeMatchers(MockWebContext.create(), new MockSessionStore(),
+				"   +   post" + "   -   " + DefaultMatchers.NOCACHE,
             new HashMap<>(), new ArrayList<>()));
     }
 


### PR DESCRIPTION
My problem: I had a angular app authenticating through saml session. pac4j were sending csrftoken httpONly, so i had to  use withCredentials when making http request with angular httpClientModule. The problems began when a request comes after two subsequent requests. 

in that case the token sent by the browser is too old even if it's in the same second and then it is not seen by the crsfAutorizer as a current nor a previousToken. Moreoever before that i had to create an autorizer that would read into the cookies as the browser sent them because the default one looks only into header and request param.

Now this solve my issue but still i have to put my new autorizer into the config and now i see that i can only had new autorizers by beginning the matcher string with a "+" or i can replace them all. because the default one prevented my angular app to authentcate I had to replace it a thus I had to copy all the other default matchers so they're still existing in my new config.

This pull request tries to answer this problem by allow users to put at the end of the matcher (or autorizer) string a "-" specifying which of the default he wants to be removed from his config, the others would stay.

As an addendum I would think interesting to completely remove the new for this string for matcher or authorizer one could just give a map of the added matchers or a map of mathers that ovverides the defaults. For the case of removal the user would give a list of names in an enumeration that describe the default matchers