### PR TITLE
Disable JWT access token parsing by default

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -3,6 +3,9 @@ layout: doc
 title: Release notes&#58;
 ---
 
+**v5.4.6**:
+- Disable JWT access token parsing by default, use `OidcConfiguration.setIncludeAccessTokenClaimsInProfile` to re-enable.
+
 **v5.4.5**:
 
 - Deprecated the `new PathMatcher(regex)` constructor

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -144,6 +144,15 @@ public class OidcConfiguration extends BaseClientConfiguration {
     private TokenValidator tokenValidator;
 
     private boolean allowUnsignedIdTokens;
+    
+    /** If enabled, try to process the access token as a JWT and include its claims in the profile.
+     * Only enable this if there is an agreement between the IdP and the client about the format of
+     * the access token. If not, the authorization server and the resource server might decide to 
+     * change the token format at any time (for example, by switching from this profile to opaque 
+     * tokens); hence, any logic in the client relying on the ability to read the access token 
+     * content would break without recourse.
+     */
+    private boolean includeAccessTokenClaimsInProfile = false;
 
     private String SSLFactory;
 
@@ -507,6 +516,14 @@ public class OidcConfiguration extends BaseClientConfiguration {
 
     public void setAllowUnsignedIdTokens(final boolean allowUnsignedIdTokens) {
         this.allowUnsignedIdTokens = allowUnsignedIdTokens;
+    }
+    
+    public boolean isIncludeAccessTokenClaimsInProfile() {
+        return includeAccessTokenClaimsInProfile;
+    }
+    
+    public void setIncludeAccessTokenClaimsInProfile(boolean includeAccessTokenClaimsInProfile) {
+        this.includeAccessTokenClaimsInProfile = includeAccessTokenClaimsInProfile;
     }
 
     public String getSSLFactory() {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -134,7 +134,9 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
                 }
             }
 
-            collectClaimsFromAccessTokenIfAny(credentials, nonce, profile);
+            if (configuration.isIncludeAccessTokenClaimsInProfile()) {
+                collectClaimsFromAccessTokenIfAny(credentials, nonce, profile);
+            }
 
             // session expiration with token behavior
             profile.setTokenExpirationAdvance(configuration.getTokenExpirationAdvance());

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
@@ -1,31 +1,35 @@
 package org.pac4j.oidc.profile.creator;
 
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.credentials.OidcCredentials;
+
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.PlainJWT;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
-import org.junit.Before;
-import org.junit.Test;
-import org.pac4j.core.context.MockWebContext;
-import org.pac4j.core.context.session.MockSessionStore;
-import org.pac4j.core.util.TestsConstants;
-import org.pac4j.oidc.client.OidcClient;
-import org.pac4j.oidc.config.OidcConfiguration;
-import org.pac4j.oidc.credentials.OidcCredentials;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests {@link OidcProfileCreatorTests}.
@@ -57,7 +61,8 @@ public class OidcProfileCreatorTests implements TestsConstants {
         when(configuration.findProviderMetadata()).thenReturn(metadata);
 
         var tokenValidator = mock(TokenValidator.class);
-        when(tokenValidator.validate(any(), any())).thenReturn(idTokenClaims);
+        when(tokenValidator.validate(any(), any())).thenAnswer(
+                a -> IDTokenClaimsSet.parse(((JWT) a.getArgument(0)).getJWTClaimsSet().toString()));
 
         when(configuration.findTokenValidator()).thenReturn(tokenValidator);
         when(configuration.getClientId()).thenReturn(ID);
@@ -68,17 +73,31 @@ public class OidcProfileCreatorTests implements TestsConstants {
 
     @Test
     public void testCreateOidcProfile() throws Exception {
+        when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(true);
         var creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
         credentials.setAccessToken(new BearerAccessToken(UUID.randomUUID().toString()));
         var idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
         credentials.setIdToken(idToken);
-        assertNotNull(creator.create(credentials, webContext, new MockSessionStore()));
+        assertTrue(creator.create(credentials, webContext, new MockSessionStore()).isPresent());
+    }
+
+    @Test
+    public void testCreateOidcProfileWithoutAccessToken() throws Exception {
+        when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(true);
+        var creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
+        var webContext = MockWebContext.create();
+        var credentials = new OidcCredentials();
+        credentials.setAccessToken(null);
+        var idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
+        credentials.setIdToken(idToken);
+        assertTrue(creator.create(credentials, webContext, new MockSessionStore()).isPresent());
     }
 
     @Test
     public void testCreateOidcProfileJwtAccessToken() throws Exception {
+        when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(false);
         var creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
@@ -89,6 +108,13 @@ public class OidcProfileCreatorTests implements TestsConstants {
 
         var idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
         credentials.setIdToken(idToken);
-        assertNotNull(creator.create(credentials, webContext, new MockSessionStore()));
+        Optional<UserProfile> profile = creator.create(credentials, webContext, new MockSessionStore());
+        assertTrue(profile.isPresent());
+        assertNull(profile.get().getAttribute("client"));
+
+        when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(true);
+        profile = creator.create(credentials, webContext, new MockSessionStore());
+        assertTrue(profile.isPresent());
+        assertEquals("pac4j", profile.get().getAttribute("client"));
     }
 }


### PR DESCRIPTION
Clients should normally not make any assumptions on the format of access
tokens. When required, this can be re-enabled via
OidcConfiguration.setIncludeAccessTokenClaimsInProfile.

Before submitting any pull request, please read the contribution guide: https://www.pac4j.org/docs/contribute.html