### PR TITLE
Remove xalan dependency

### DIFF
--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -22,7 +22,6 @@
         velocity 1.7. It can be removed as soon as velocity 1.7 is not used anymore-->
         <commons-collections.version>3.2.2</commons-collections.version>
         <cryptacular.version>1.2.4</cryptacular.version>
-        <xalan.version>2.7.2</xalan.version>
         <!-- This version is used to override the version xmlsectool depends on. it should be compatible -->
         <httpcore.version>4.4.8</httpcore.version>
     </properties>
@@ -145,11 +144,6 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>${joda-time.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>xalan</groupId>
-            <artifactId>xalan</artifactId>
-            <version>${xalan.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>


### PR DESCRIPTION
This is a pull request to remove Apache xalan dependency as the OWASP scan of `pac4j-saml:3.9.0` has marked Apache Xalan as having critical vulnerability of CVSSv3 base score `9.8` for `CVE-2022-34169`. Since Apache Xalan project is dormant therefore there are no plans to fix the CVE.