### PR TITLE
Add setters to SAML2Profile to make it deserializable

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java
@@ -49,35 +49,71 @@ public class SAML2Profile extends CommonProfile {
         return (ZonedDateTime) getAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_BEFORE_ATTRIBUTE);
     }
 
+    public void setNotBefore(ZonedDateTime notBefore) {
+        addAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, notBefore);
+    }
+
     public ZonedDateTime getNotOnOrAfter() {
         return (ZonedDateTime) getAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE);
+    }
+
+    public void setNotOnOrAfter(ZonedDateTime notOnOrAfter) {
+        addAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, notOnOrAfter);
     }
 
     public String getSessionIndex() {
         return (String) getAuthenticationAttribute(SAML2Authenticator.SESSION_INDEX);
     }
 
+    public void setSessionIndex(String sessionIndex) {
+        addAuthenticationAttribute(SAML2Authenticator.SESSION_INDEX, sessionIndex);
+    }
+
     public String getIssuerEntityID() {
         return (String) getAuthenticationAttribute(SAML2Authenticator.ISSUER_ID);
+    }
+
+    public void setIssuerEntityID(String issuerEntityID) {
+        addAuthenticationAttribute(SAML2Authenticator.ISSUER_ID, issuerEntityID);
     }
 
     public List<String> getAuthnContexts() {
         return (List<String>) getAuthenticationAttribute(SAML2Authenticator.AUTHN_CONTEXT);
     }
 
+    public void setAuthnContexts(List<String> authnContexts) {
+        addAuthenticationAttribute(SAML2Authenticator.AUTHN_CONTEXT, authnContexts);
+    }
+
     public String getSamlNameIdFormat() {
         return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_FORMAT);
+    }
+
+    public void setSamlNameIdFormat(String samlNameIdFormat) {
+        addAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_FORMAT, samlNameIdFormat);
     }
 
     public String getSamlNameIdNameQualifier() {
         return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_NAME_QUALIFIER);
     }
 
+    public void setSamlNameIdNameQualifier(String samlNameIdNameQualifier) {
+        addAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_NAME_QUALIFIER, samlNameIdNameQualifier);
+    }
+
     public String getSamlNameIdSpNameQualifier() {
         return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_SP_NAME_QUALIFIER);
     }
 
+    public void setSamlNameIdSpNameQualifier(String samlNameIdSpNameQualifier) {
+        addAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_SP_NAME_QUALIFIER, samlNameIdSpNameQualifier);
+    }
+
     public String getSamlNameIdSpProviderId() {
         return (String) getAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_SP_PROVIDED_ID);
+    }
+
+    public void setSamlNameIdSpProviderId(String samlNameIdSpProviderId) {
+        addAuthenticationAttribute(SAML2Authenticator.SAML_NAME_ID_SP_PROVIDED_ID, samlNameIdSpProviderId);
     }
 }


### PR DESCRIPTION
As per contribution guide i asked before in this mailing about this change : https://groups.google.com/g/pac4j-dev/c/rgeYDT4H_Bg/m/nPE5Hpr1BAAJ?utm_medium=email&utm_source=footer

The issue i had was using pac4j in CAS with a mongodb session store.

In this case the SAML2Profile has to be serialized as json and deserialized which is not possible out of the box when setters are missing