### PR TITLE
Support Mongo for SAML2 SP metadata

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -237,6 +237,35 @@ of the file is the fully qualified class name of the SPI implementation: `com.ex
 will only activate if the metadata generator is not explicitly configured. It will also override the default logic for configuring
 service provider metadata generators if an implementation is discovered.
 
+### Managing metadata via MongoDb
+
+Service provider metadata can alternatively be stored and managed via MongoDb.
+
+```java
+var configuration = new SAML2Configuration();
+...
+var generator = new SAML2MongoMetadataGenerator(this.mongoClient);
+generator.setMetadataDatabase(...);
+generator.setMetadataCollection(...);
+configuration.setMetadataGenerator(generator);
+...
+configuration.init();
+```
+
+The `SAML2MongoMetadataGenerator` has the ability to either insert or update metadata in the underlying database collection.
+By default, the database name is expected to be `saml2` and the collection is expected to be `metadata`.
+
+This functionality expects mongo dependencies to already be available and does not explicitly declare or export those.
+You will need to include the following module, at a minimum, in your build:
+
+```xml
+<dependency>
+    <groupId>org.mongodb</groupId>
+    <artifactId>mongodb-driver-core</artifactId>
+    <version>...</version>
+</dependency>
+```
+
 ## 3.2) Identity provider metadata resolution:
 
 Resolution of identity provider metadata can also be controlled and overridden as shown below:

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -9,6 +9,7 @@ title: Release notes&#58;
 - Created a new `pac4j-cas-clientv4` module based on the Apereo CAS client v4 (JDK 17)
 - Deprecated old modules (`pac4j-javaee`, `pac4j-cas`, `pac4j-springboot` and `pac4j-saml`)
 - SAML2 service provider metadata generators can be discovered using [Java's `ServiceLoader` API](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/ServiceLoader.html).
+- Added support for `SAML2MongoMetadataGenerator` to manage SAML2 metadata via `pac4j-saml-opensamlv5`.
 
 **v5.6.1**:
 - Allow to override the "computation" of the `defaultUrl` in the `DefaultLogoutLogic`

--- a/pac4j-core/src/main/java/org/pac4j/core/util/CommonHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/CommonHelper.java
@@ -343,4 +343,8 @@ public final class CommonHelper {
         }
         return constructor;
     }
+
+    public static String ifBlank(final String value, final String defaultValue) {
+        return isBlank(value) ? defaultValue : value;
+    }
 }

--- a/pac4j-mongo/pom.xml
+++ b/pac4j-mongo/pom.xml
@@ -12,11 +12,6 @@
     <packaging>jar</packaging>
     <name>pac4j for MongoDB</name>
 
-    <properties>
-        <mongo-driver.version>4.7.2</mongo-driver.version>
-        <flapdoodle.version>2.2.0</flapdoodle.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.pac4j</groupId>
@@ -25,17 +20,14 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
-            <version>${mongo-driver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>bson</artifactId>
-            <version>${mongo-driver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-core</artifactId>
-            <version>${mongo-driver.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -66,8 +58,6 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>${flapdoodle.version}</version>
-            <scope>test</scope>
         </dependency>
         <!-- for testing -->
     </dependencies>

--- a/pac4j-mongo/src/test/java/org/pac4j/mongo/test/tools/MongoServer.java
+++ b/pac4j-mongo/src/test/java/org/pac4j/mongo/test/tools/MongoServer.java
@@ -3,7 +3,7 @@ package org.pac4j.mongo.test.tools;
 import com.mongodb.client.MongoClients;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodStarter;
-import de.flapdoodle.embed.mongo.config.MongodConfigBuilder;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
@@ -33,7 +33,7 @@ public final class MongoServer implements TestsConstants {
         var starter = MongodStarter.getDefaultInstance();
 
         try {
-            var mongodConfig = new MongodConfigBuilder()
+            var mongodConfig = MongodConfig.builder()
                     .version(Version.Main.PRODUCTION)
                     .net(new Net(port, Network.localhostIsIPv6()))
                     .build();

--- a/pac4j-saml-opensamlv5/pom.xml
+++ b/pac4j-saml-opensamlv5/pom.xml
@@ -17,9 +17,6 @@
         <joda-time.version>2.11.2</joda-time.version>
         <velocity.version>2.3</velocity.version>
         <xmlsec.version>3.0.1</xmlsec.version>
-        <!-- The dependency to commons-collections 3.2.2 is explicitly made to replace 3.2.1 (vulnerable) used by
-        velocity 1.7. It can be removed as soon as velocity 1.7 is not used anymore-->
-        <commons-collections.version>3.2.2</commons-collections.version>
         <cryptacular.version>1.2.5</cryptacular.version>
         <hazelcast.version>5.1.3</hazelcast.version>
         <java.version>17</java.version>
@@ -153,11 +150,6 @@
             <version>${velocity.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-            <version>${commons-collections.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
@@ -172,6 +164,25 @@
             <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.pac4j</groupId>
+            <artifactId>pac4j-core</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-core</artifactId>
         </dependency>
         <!-- for testing -->
         <dependency>
@@ -198,6 +209,11 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- for testing -->

--- a/pac4j-saml-opensamlv5/pom.xml
+++ b/pac4j-saml-opensamlv5/pom.xml
@@ -136,6 +136,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -148,6 +152,12 @@
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
             <version>${velocity.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -157,17 +167,18 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-jcl</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
             <version>${spring.version}</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.pac4j</groupId>
-            <artifactId>pac4j-core</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pac4j-saml-opensamlv5/pom.xml
+++ b/pac4j-saml-opensamlv5/pom.xml
@@ -194,6 +194,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-core</artifactId>
+            <optional>true</optional>
         </dependency>
         <!-- for testing -->
         <dependency>

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -988,7 +988,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
                     try {
                         return serviceProviderMetadataResource instanceof UrlResource
                             ? new SAML2HttpUrlMetadataGenerator(serviceProviderMetadataResource.getURL(), getHttpClient())
-                            : new SAML2FileSystemMetadataGenerator();
+                            : new SAML2FileSystemMetadataGenerator(serviceProviderMetadataResource);
                     } catch (final Exception e) {
                         throw new TechnicalException(e);
                     }

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -974,7 +974,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
     }
 
     protected void determineSingleSignOutServiceUrl(final BaseSAML2MetadataGenerator generator) {
-        final var url = StringUtils.defaultIfBlank(this.singleSignOutServiceUrl, callbackUrl);
+        final var url = CommonHelper.ifBlank(this.singleSignOutServiceUrl, callbackUrl);
         final var logoutUrl = CommonHelper.addParameter(url, Pac4jConstants.LOGOUT_ENDPOINT_PARAMETER, "true");
         // the logout URL is callback URL with an extra parameter
         generator.setSingleLogoutServiceUrl(logoutUrl);

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -1,7 +1,6 @@
 package org.pac4j.saml.logout.impl;
 
 import net.shibboleth.shared.net.URIComparator;
-import org.apache.commons.lang3.StringUtils;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.LogoutRequest;
@@ -16,6 +15,7 @@ import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.OkAction;
 import org.pac4j.core.logout.handler.LogoutHandler;
+import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.credentials.SAML2Credentials;
@@ -97,7 +97,7 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     }
 
     protected HttpAction handlePostLogoutResponse(final SAML2MessageContext context) {
-        if (StringUtils.isNotBlank(postLogoutURL)) {
+        if (CommonHelper.isNotBlank(postLogoutURL)) {
             // if custom post logout URL is present then redirect to it
             return new FoundAction(postLogoutURL);
         }
@@ -179,7 +179,7 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
 
     protected void validateDestinationEndpoint(final LogoutResponse logoutResponse, final SAML2MessageContext context) {
         final List<String> expected = new ArrayList<>();
-        if (StringUtils.isBlank(this.expectedDestination)) {
+        if (CommonHelper.isBlank(this.expectedDestination)) {
             final Endpoint endpoint = Objects.requireNonNull(context.getSPSSODescriptor().getSingleLogoutServices().get(0));
             if (endpoint.getLocation() != null) {
                 expected.add(endpoint.getLocation());

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
@@ -17,7 +17,7 @@ import org.opensaml.saml.ext.saml2mdui.Logo;
 import org.opensaml.saml.ext.saml2mdui.PrivacyStatementURL;
 import org.opensaml.saml.ext.saml2mdui.UIInfo;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import org.opensaml.saml.metadata.resolver.impl.AbstractBatchMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
 import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
@@ -48,7 +48,6 @@ import org.pac4j.saml.util.Configuration;
 import org.pac4j.saml.util.SAML2Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -119,15 +118,14 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
     private SAML2MetadataSigner metadataSigner;
 
     @Override
-    public MetadataResolver buildMetadataResolver(final Resource metadataResource) throws Exception {
-        final AbstractBatchMetadataResolver resolver;
-        if (metadataResource != null) {
-            resolver = createMetadataResolver(metadataResource);
-        } else {
+    public MetadataResolver buildMetadataResolver() throws Exception {
+        var resolver = createMetadataResolver();
+        if (resolver == null) {
             final var md = buildEntityDescriptor();
             final var entityDescriptorElement = this.marshallerFactory.getMarshaller(md).marshall(md);
             resolver = new DOMMetadataResolver(entityDescriptorElement);
         }
+
         resolver.setRequireValidMetadata(true);
         resolver.setFailFastInitialization(true);
         resolver.setId(resolver.getClass().getCanonicalName());
@@ -136,7 +134,7 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
         return resolver;
     }
 
-    protected abstract AbstractBatchMetadataResolver createMetadataResolver(final Resource metadataResource) throws Exception;
+    protected abstract AbstractMetadataResolver createMetadataResolver() throws Exception;
 
     @Override
     public String getMetadata(final EntityDescriptor entityDescriptor) throws Exception {

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
@@ -43,6 +43,7 @@ import org.opensaml.xmlsec.algorithm.AlgorithmRegistry;
 import org.opensaml.xmlsec.algorithm.AlgorithmSupport;
 import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.opensaml.xmlsec.signature.KeyInfo;
+import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.crypto.CredentialProvider;
 import org.pac4j.saml.util.Configuration;
 import org.pac4j.saml.util.SAML2Utils;
@@ -295,7 +296,7 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
                     break;
             }
 
-            if (StringUtils.isNotBlank(p.getSurname())) {
+            if (CommonHelper.isNotBlank(p.getSurname())) {
                 final var surnameBuilder =
                     (SAMLObjectBuilder<SurName>) this.builderFactory
                         .getBuilder(SurName.DEFAULT_ELEMENT_NAME);
@@ -304,7 +305,7 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
                 person.setSurName(surName);
             }
 
-            if (StringUtils.isNotBlank(p.getGivenName())) {
+            if (CommonHelper.isNotBlank(p.getGivenName())) {
                 final var givenNameBuilder =
                     (SAMLObjectBuilder<GivenName>) this.builderFactory
                         .getBuilder(GivenName.DEFAULT_ELEMENT_NAME);

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
@@ -1,6 +1,6 @@
 package org.pac4j.saml.metadata;
 
-import org.opensaml.saml.metadata.resolver.impl.AbstractBatchMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
 import org.pac4j.core.util.CommonHelper;
 import org.springframework.core.io.Resource;
@@ -22,13 +22,19 @@ import java.nio.charset.StandardCharsets;
  */
 public class SAML2FileSystemMetadataGenerator extends BaseSAML2MetadataGenerator {
 
+    private final Resource metadataResource;
+
+    public SAML2FileSystemMetadataGenerator(Resource metadataResource) {
+        this.metadataResource = metadataResource;
+    }
+
     @Override
-    protected AbstractBatchMetadataResolver createMetadataResolver(final Resource metadataResource) throws Exception {
+    protected AbstractMetadataResolver createMetadataResolver() throws Exception {
         return new FilesystemMetadataResolver(metadataResource.getFile());
     }
 
     @Override
-    public boolean storeMetadata(final String metadata, final Resource metadataResource, final boolean force) throws Exception {
+    public boolean storeMetadata(final String metadata, final boolean force) throws Exception {
         if (metadataResource == null || CommonHelper.isBlank(metadata)) {
             logger.info("No metadata or resource is provided");
             return false;

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2HttpUrlMetadataGenerator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2HttpUrlMetadataGenerator.java
@@ -7,9 +7,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.opensaml.saml.metadata.resolver.impl.AbstractBatchMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.HTTPMetadataResolver;
-import org.springframework.core.io.Resource;
 
 import java.net.URL;
 import java.time.Duration;
@@ -34,7 +33,7 @@ public class SAML2HttpUrlMetadataGenerator extends BaseSAML2MetadataGenerator {
     }
 
     @Override
-    protected AbstractBatchMetadataResolver createMetadataResolver(final Resource metadataResource) throws Exception {
+    protected AbstractMetadataResolver createMetadataResolver() throws Exception {
         final var resolver = new HTTPMetadataResolver(httpClient, this.metadataUrl.toExternalForm());
         if (minRefreshDelay != null) {
             resolver.setMinRefreshDelay(minRefreshDelay);
@@ -49,7 +48,7 @@ public class SAML2HttpUrlMetadataGenerator extends BaseSAML2MetadataGenerator {
     }
 
     @Override
-    public boolean storeMetadata(final String metadata, final Resource resource, final boolean force) throws Exception {
+    public boolean storeMetadata(final String metadata, final boolean force) throws Exception {
         HttpResponse response = null;
 
         try {
@@ -72,7 +71,7 @@ public class SAML2HttpUrlMetadataGenerator extends BaseSAML2MetadataGenerator {
                     return true;
                 }
             }
-            logger.error("Unable to store metadata successfully via {}", resource);
+            logger.error("Unable to store metadata successfully via {}", metadataUrl.toExternalForm());
             return false;
         } finally {
             if (response != null && response instanceof CloseableHttpResponse) {

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
@@ -2,18 +2,17 @@ package org.pac4j.saml.metadata;
 
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
-import org.springframework.core.io.Resource;
 
 /**
  * Builds metadata and the relevant resolvers.
  * @author Misagh Moayyed
  */
 public interface SAML2MetadataGenerator {
-    MetadataResolver buildMetadataResolver(Resource metadataResource) throws Exception;
+    MetadataResolver buildMetadataResolver() throws Exception;
 
     String getMetadata(EntityDescriptor entityDescriptor) throws Exception;
 
     EntityDescriptor buildEntityDescriptor();
 
-    boolean storeMetadata(String metadata, Resource resource, boolean force) throws Exception;
+    boolean storeMetadata(String metadata, boolean force) throws Exception;
 }

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2MetadataSigner.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2MetadataSigner.java
@@ -1,6 +1,6 @@
 package org.pac4j.saml.metadata;
 
-import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.opensaml.xmlsec.signature.SignableXMLObject;
 
 import java.io.File;
 
@@ -11,7 +11,9 @@ import java.io.File;
  * @since 5.0.0
  */
 public interface SAML2MetadataSigner {
-    default void sign(final EntityDescriptor descriptor) {}
+    void sign(SignableXMLObject descriptor);
 
-    default void sign(final File metadataFile) {}
+    void sign(File metadataFile);
+
+    String sign(String metadata);
 }

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -43,10 +43,9 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
                 final var entity = metadataGenerator.buildEntityDescriptor();
                 final var metadata = metadataGenerator.getMetadata(entity);
                 metadataGenerator.storeMetadata(metadata,
-                    resource,
                     configuration.isForceServiceProviderMetadataGeneration());
             }
-            return metadataGenerator.buildMetadataResolver(resource);
+            return metadataGenerator.buildMetadataResolver();
         } catch (final Exception e) {
             throw new SAMLException("Unable to generate metadata for service provider", e);
         }

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/mongo/SAML2MongoMetadataGenerator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/metadata/mongo/SAML2MongoMetadataGenerator.java
@@ -1,0 +1,102 @@
+package org.pac4j.saml.metadata.mongo;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.metadata.BaseSAML2MetadataGenerator;
+import org.pac4j.saml.util.Configuration;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import static com.mongodb.client.model.Filters.eq;
+
+/**
+ * This is {@link SAML2MongoMetadataGenerator}
+ * that stores service provider metadata in a MongoDb database.
+ *
+ * @author Misagh Moayyed
+ * @since 5.7.0
+ */
+public class SAML2MongoMetadataGenerator extends BaseSAML2MetadataGenerator {
+    private static final String ID = "saml2-metadata";
+
+    private final MongoClient mongoClient;
+
+    private String metadataDatabase = "saml2";
+
+    private String metadataCollection = "metadata";
+
+    public SAML2MongoMetadataGenerator(final MongoClient mongoClient) {
+        this.mongoClient = mongoClient;
+    }
+
+    @Override
+    public AbstractMetadataResolver createMetadataResolver() throws Exception {
+        var documents = Objects.requireNonNull(getCollection().find(buildMetadataDocumentFilter()));
+        var foundDoc = documents.first();
+        if (foundDoc != null) {
+            var metadata = foundDoc.getString("metadata");
+            try (var is = new ByteArrayInputStream(metadata.getBytes(StandardCharsets.UTF_8))) {
+                var document = Configuration.getParserPool().parse(is);
+                var root = document.getDocumentElement();
+                return new DOMMetadataResolver(root);
+            }
+        }
+        throw new SAMLException("Unable to locate metadata document " + ID);
+    }
+
+    protected Bson buildMetadataDocumentFilter() {
+        return eq("id", ID);
+    }
+
+    @Override
+    public boolean storeMetadata(final String metadata, final boolean force) {
+        if (CommonHelper.isBlank(metadata)) {
+            logger.info("No metadata is provided");
+            return false;
+        }
+
+        var metadataToUse = isSignMetadata() ? getMetadataSigner().sign(metadata) : metadata;
+        CommonHelper.assertNotBlank("metadata", metadataToUse);
+
+        var filter = buildMetadataDocumentFilter();
+        var foundDoc = getCollection().find(filter).first();
+        if (foundDoc == null) {
+            final var doc = new Document();
+            doc.put("metadata", metadataToUse);
+            doc.put("id", ID);
+            return getCollection().insertOne(doc).getInsertedId() != null;
+        }
+        foundDoc.put("metadata", metadataToUse);
+        var updateResult = getCollection().updateOne(filter, new Document("$set", foundDoc));
+        return updateResult.getMatchedCount() == 1;
+    }
+
+    protected MongoCollection<Document> getCollection() {
+        final var db = mongoClient.getDatabase(metadataDatabase);
+        return Objects.requireNonNull(db.getCollection(metadataCollection));
+    }
+
+    public String getMetadataDatabase() {
+        return metadataDatabase;
+    }
+
+    public void setMetadataDatabase(String metadataDatabase) {
+        this.metadataDatabase = metadataDatabase;
+    }
+
+    public String getMetadataCollection() {
+        return metadataCollection;
+    }
+
+    public void setMetadataCollection(String metadataCollection) {
+        this.metadataCollection = metadataCollection;
+    }
+}

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -1,6 +1,5 @@
 package org.pac4j.saml.sso.impl;
 
-import org.apache.commons.lang3.StringUtils;
 import org.opensaml.core.xml.XMLObjectBuilderFactory;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.common.SAMLObjectBuilder;
@@ -19,6 +18,7 @@ import org.opensaml.saml.saml2.core.impl.RequestedAuthnContextBuilder;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.RequestedAttribute;
 import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.profile.api.SAML2ObjectBuilder;
 import org.pac4j.saml.util.Configuration;
@@ -88,7 +88,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
         request.setIsPassive(configContext.isPassive());
         request.setForceAuthn(configContext.isForceAuth());
 
-        if (StringUtils.isNotBlank(configContext.getProviderName())) {
+        if (CommonHelper.isNotBlank(configContext.getProviderName())) {
             request.setProviderName(configContext.getProviderName());
         }
 

--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -1,7 +1,6 @@
 package org.pac4j.saml.sso.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.commons.collections.CollectionUtils;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.SAMLVersion;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -48,11 +47,11 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Class responsible for executing every required checks for validating a SAML response.
@@ -642,8 +641,10 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
             logger.debug("Required authentication context class refs are {}", configContext.getAuthnContextClassRefs());
             logger.debug("Found authentication context class refs are {}", providedAuthnContextClassRefs);
 
-            final Collection<String> results = CollectionUtils.intersection(
-                configContext.getAuthnContextClassRefs(), providedAuthnContextClassRefs);
+            var results = configContext.getAuthnContextClassRefs().stream()
+                .distinct()
+                .filter(providedAuthnContextClassRefs::contains)
+                .collect(Collectors.toSet());
             if (results.size() != configContext.getAuthnContextClassRefs().size()) {
                 throw new SAMLAuthnContextClassRefException("Requested authentication context class refs do not match "
                     + " those in authentication statements from IDP.");

--- a/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSignerTests.java
+++ b/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/DefaultSAML2MetadataSignerTests.java
@@ -50,7 +50,7 @@ public class DefaultSAML2MetadataSignerTests {
         final var metadata = metadataGenerator.getMetadata(entity);
         assertNotNull(metadata);
 
-        metadataGenerator.storeMetadata(metadata, configuration.getServiceProviderMetadataResource(), true);
-        assertNotNull(metadataGenerator.buildMetadataResolver(configuration.getServiceProviderMetadataResource()));
+        metadataGenerator.storeMetadata(metadata, true);
+        assertNotNull(metadataGenerator.buildMetadataResolver());
     }
 }

--- a/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGeneratorTests.java
+++ b/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGeneratorTests.java
@@ -30,14 +30,14 @@ public class SAML2FileSystemMetadataGeneratorTests {
         configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
         configuration.init();
 
-        final SAML2MetadataGenerator metadataGenerator = new SAML2FileSystemMetadataGenerator();
+        var metadataGenerator = new SAML2FileSystemMetadataGenerator(configuration.getServiceProviderMetadataResource());
         final var entity = metadataGenerator.buildEntityDescriptor();
         assertNotNull(entity);
         final var metadata = metadataGenerator.getMetadata(entity);
         assertNotNull(metadata);
 
-        metadataGenerator.storeMetadata(metadata, configuration.getServiceProviderMetadataResource(), true);
-        assertNotNull(metadataGenerator.buildMetadataResolver(configuration.getServiceProviderMetadataResource()));
+        metadataGenerator.storeMetadata(metadata, true);
+        assertNotNull(metadataGenerator.buildMetadataResolver());
     }
 
 }

--- a/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/SAML2HttpUrlMetadataGeneratorTests.java
+++ b/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/SAML2HttpUrlMetadataGeneratorTests.java
@@ -55,14 +55,13 @@ public class SAML2HttpUrlMetadataGeneratorTests {
                     .withHeader("Content-Type", ContentType.APPLICATION_XML.getMimeType())));
         wireMockServer.start();
         try {
-            final var configuration = initialConfiguration();
-            final SAML2MetadataGenerator metadataGenerator =
+            var metadataGenerator =
                 new SAML2HttpUrlMetadataGenerator(new URL("http://localhost:8088/saml"), new SAML2HttpClientBuilder().build());
             final var entity = metadataGenerator.buildEntityDescriptor();
             assertNotNull(entity);
             final var metadata = metadataGenerator.getMetadata(entity);
             assertNotNull(metadata);
-            assertTrue(metadataGenerator.storeMetadata(metadata, configuration.getServiceProviderMetadataResource(), true));
+            assertTrue(metadataGenerator.storeMetadata(metadata, true));
         } finally {
             wireMockServer.stop();
         }
@@ -84,7 +83,7 @@ public class SAML2HttpUrlMetadataGeneratorTests {
             final var configuration = initialConfiguration();
             final SAML2MetadataGenerator metadataGenerator =
                 new SAML2HttpUrlMetadataGenerator(new URL("http://localhost:8087/saml"), new SAML2HttpClientBuilder().build());
-            final var resolver = metadataGenerator.buildMetadataResolver(configuration.getServiceProviderMetadataResource());
+            final var resolver = metadataGenerator.buildMetadataResolver();
             assertNotNull(resolver);
 
             var entity = resolver.resolveSingle(

--- a/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/mongo/SAML2MongoMetadataGeneratorIT.java
+++ b/pac4j-saml-opensamlv5/src/test/java/org/pac4j/saml/metadata/mongo/SAML2MongoMetadataGeneratorIT.java
@@ -1,0 +1,115 @@
+package org.pac4j.saml.metadata.mongo;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.process.runtime.Network;
+import net.shibboleth.shared.resolver.CriteriaSet;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.metadata.SAML2MetadataGenerator;
+import org.pac4j.saml.util.DefaultConfigurationManager;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This is {@link SAML2MongoMetadataGeneratorIT}.
+ *
+ * @author Misagh Moayyed
+ * @since 5.7.0
+ */
+public class SAML2MongoMetadataGeneratorIT implements TestsConstants {
+    private static final int PORT = 37018;
+    private static final String ENTITY_ID = "org:pac4j:example";
+
+    private final MongoServer mongoServer = new MongoServer();
+
+    private SAML2MetadataGenerator mongoMetadataGenerator;
+
+    @Before
+    public void setUp() {
+        mongoServer.start(PORT);
+        mongoMetadataGenerator = new SAML2MongoMetadataGenerator(getClient());
+    }
+
+    @After
+    public void tearDown() {
+        mongoServer.stop();
+    }
+
+    private static MongoClient getClient() {
+        return MongoClients.create(String.format("mongodb://localhost:%d", PORT));
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        var mgr = new DefaultConfigurationManager();
+        mgr.configure();
+
+        final var configuration = new SAML2Configuration();
+        configuration.setForceKeystoreGeneration(true);
+        configuration.setKeystorePath("target/keystore.jks");
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+        configuration.setSignMetadata(true);
+        configuration.setServiceProviderEntityId(ENTITY_ID);
+        configuration.setMetadataGenerator(this.mongoMetadataGenerator);
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.init();
+
+        var metadataGenerator = configuration.toMetadataGenerator();
+        final var entity = metadataGenerator.buildEntityDescriptor();
+        assertNotNull(entity);
+        final var metadata = metadataGenerator.getMetadata(entity);
+        assertNotNull(metadata);
+
+        assertTrue(metadataGenerator.storeMetadata(metadata, true));
+        var resolver = metadataGenerator.buildMetadataResolver();
+        assertNotNull(resolver);
+        var entityDescriptor = resolver.resolveSingle(new CriteriaSet(new EntityIdCriterion(configuration.getServiceProviderEntityId())));
+        assertNotNull(entityDescriptor);
+
+        // now update
+        assertTrue(metadataGenerator.storeMetadata(metadata, true));
+    }
+
+    private static class MongoServer {
+        private MongodExecutable mongodExecutable;
+
+        public void start(final int port) {
+            var starter = MongodStarter.getDefaultInstance();
+            try {
+                var mongodConfig = MongodConfig.builder()
+                    .version(Version.Main.PRODUCTION)
+                    .net(new Net(port, Network.localhostIsIPv6()))
+                    .build();
+
+                mongodExecutable = starter.prepare(mongodConfig);
+                mongodExecutable.start();
+                final var mongo = MongoClients.create(String.format("mongodb://localhost:%d", port));
+                final var db = mongo.getDatabase("saml2");
+                db.createCollection("metadata");
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void stop() {
+            if (mongodExecutable != null) {
+                mongodExecutable.stop();
+            }
+        }
+    }
+}

--- a/pac4j-saml-opensamlv5/src/test/resources/logback.xml
+++ b/pac4j-saml-opensamlv5/src/test/resources/logback.xml
@@ -7,6 +7,7 @@
 
 <!--	<logger name="org.pac4j" level="INFO" />-->
 
+    <logger name="de.flapdoodle.embed.mongo" level="WARN" />
 	<logger name="PROTOCOL_MESSAGE" level="DEBUG" />
 
 	<root level="WARN">

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -179,6 +179,12 @@
             <artifactId>spring-core</artifactId>
             <scope>compile</scope>
             <version>${spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>spring-jcl</artifactId>
+                    <groupId>org.springframework</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
 		<logback.version>1.4.3</logback.version>
 		<commons-codec.version>1.15</commons-codec.version>
 		<commons-io.version>2.11.0</commons-io.version>
+		<commons-lang3.version>3.12.0</commons-lang3.version>
 		<guava.version>31.1-jre</guava.version>
 		<nimbus-jose-jwt.version>9.25.4</nimbus-jose-jwt.version>
 		<spring.version>5.3.23</spring.version>
@@ -187,6 +188,11 @@
 				<artifactId>commons-io</artifactId>
 				<version>${commons-io.version}</version>
 			</dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>javax.servlet-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,8 @@
 	</modules>
 
 	<properties>
+        <mongo-driver.version>4.7.2</mongo-driver.version>
+        <flapdoodle.version>3.4.11</flapdoodle.version>
 		<junit.version>4.13.2</junit.version>
 		<servlet-api.version>4.0.1</servlet-api.version>
         <jakarta-servlet-api.version>6.0.0</jakarta-servlet-api.version>
@@ -139,6 +141,21 @@
                 <groupId>org.pac4j</groupId>
                 <artifactId>pac4j-jwt</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-sync</artifactId>
+                <version>${mongo-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>bson</artifactId>
+                <version>${mongo-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>mongodb-driver-core</artifactId>
+                <version>${mongo-driver.version}</version>
             </dependency>
             <dependency>
 				<groupId>org.slf4j</groupId>
@@ -229,6 +246,12 @@
                 <artifactId>pac4j-http</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>de.flapdoodle.embed</groupId>
+                <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                <version>${flapdoodle.version}</version>
+                <scope>test</scope>
             </dependency>
 			<dependency>
 				<groupId>junit</groupId>
@@ -367,6 +390,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.10.1</version>
 				<configuration>
+                    <source>${java.version}</source>
                     <release>${java.version}</release>
 					<encoding>UTF-8</encoding>
 				</configuration>
@@ -426,6 +450,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <source>${java.version}</source>
+                    <release>${java.version}</release>
+                </configuration>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>


### PR DESCRIPTION
This PR adds `SAML2MongoMetadataGenerator` to the pac4j SAML2 portfolio. This feature is only available to pac4j-SAML that is based on OpenSAML v5. 

Surrounding components have been re-worked and refactored to support the change. Mongo dependencies are also made as optional, and need to be re-declared by users when used. 

Typical use case:

```java
var configuration = new SAML2Configuration();
...
configuration.setMetadataGenerator(new SAML2MongoMetadataGenerator(this.mongoClient));
....
configuration.init();
```