### PR TITLE
Update the assertNotBlank for keystorePassword

### DIFF
--- a/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
+++ b/pac4j-saml-opensamlv5/src/main/java/org/pac4j/saml/crypto/KeyStoreCredentialProvider.java
@@ -41,7 +41,7 @@ public class KeyStoreCredentialProvider implements CredentialProvider {
     private final String privateKeyAlias;
 
     public KeyStoreCredentialProvider(final SAML2Configuration configuration) {
-        CommonHelper.assertNotBlank("keystorePassword", configuration.getPrivateKeyPassword());
+        CommonHelper.assertNotBlank("keystorePassword", configuration.getKeystorePassword());
         CommonHelper.assertNotBlank("privateKeyPassword", configuration.getPrivateKeyPassword());
 
         try (var inputStream = configuration.getKeystoreGenerator().retrieve()) {


### PR DESCRIPTION
1. The assertion for keystorePassword was pointing to getPrivateKeyPassword.
2.  In the PR it's been changed to point at getKeystorePassword. Hope this helps with future errors related to this line.
