### PR TITLE
Looking up ConfigurationManager in local ClassLoader first.

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/Configuration.java
@@ -47,7 +47,9 @@ public final class Configuration {
     }
 
     private static void bootstrap() {
-        final var configurationManagers = ServiceLoader.load(ConfigurationManager.class);
+        var configurationManagers = ServiceLoader.load(ConfigurationManager.class, Configuration.class.getClassLoader());
+        if (configurationManagers.findFirst().isEmpty())
+            configurationManagers = ServiceLoader.load(ConfigurationManager.class);
         final List<ConfigurationManager> configurationManagerList = new ArrayList<>();
         configurationManagers.forEach(configurationManagerList::add);
         if (!configurationManagerList.isEmpty()) {


### PR DESCRIPTION
When PAC4J is loaded from an inner class loader, the prior code did not find the ConfigurationManager class in ContextClassLoader. The code above should fix that.

Before submitting any pull request, please read the contribution guide: https://www.pac4j.org/docs/contribute.html