### PR TITLE
Remove backticks from SQL table-name for SAML2 JDBC metadata

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -241,7 +241,7 @@ service provider metadata generators if an implementation is discovered.
 
 Service provider metadata can alternatively be stored and managed via relational databases.
 The generator expects an instance of `JdbcTemplate` to work with your relational database. By default, the expected
-database table is named `sp-metadata` with two columns, `entityId` and `metadata` (which should allow for large text values).
+database table is named `sp_metadata` with two columns, `entityId` and `metadata` (which should allow for large text values).
 Metadata is base-64 encoded/decoded by this generator on save and/or fetch operations.
 
 ```java

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/jdbc/SAML2JdbcMetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/jdbc/SAML2JdbcMetadataGenerator.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
  * @since 5.7.0
  */
 public class SAML2JdbcMetadataGenerator extends BaseSAML2MetadataGenerator {
-    private String tableName = "sp-metadata";
+    private String tableName = "sp_metadata";
 
     private final JdbcTemplate template;
 
@@ -38,7 +38,7 @@ public class SAML2JdbcMetadataGenerator extends BaseSAML2MetadataGenerator {
     @Override
     @SuppressWarnings("PMD.NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public AbstractMetadataResolver createMetadataResolver() throws Exception {
-        var sql = String.format("SELECT metadata FROM `%s` WHERE entityId='%s'", this.tableName, this.entityId);
+        var sql = String.format("SELECT metadata FROM %s WHERE entityId='%s'", this.tableName, this.entityId);
         var metadata = decodeMetadata(template.queryForObject(sql, String.class));
         try (var is = new ByteArrayInputStream(metadata)) {
             var document = Configuration.getParserPool().parse(is);
@@ -71,16 +71,16 @@ public class SAML2JdbcMetadataGenerator extends BaseSAML2MetadataGenerator {
         }
 
         try {
-            var sql = String.format("SELECT entityId FROM `%s` WHERE entityId='%s'", this.tableName, this.entityId);
+            var sql = String.format("SELECT entityId FROM %s WHERE entityId='%s'", this.tableName, this.entityId);
             var metadataId = template.queryForObject(sql, String.class);
             logger.debug("Updating metadata entity [{}]", metadataId);
-            sql = String.format("UPDATE `%s` SET metadata='%s' WHERE entityId='%s'", this.tableName,
+            sql = String.format("UPDATE %s SET metadata='%s' WHERE entityId='%s'", this.tableName,
                 encodeMetadata(metadataToUse), metadataId);
             var count = template.update(sql);
             return count > 0;
         } catch (final EmptyResultDataAccessException e) {
             var insert = new SimpleJdbcInsert(this.template)
-                .withTableName(String.format("`%s`", this.tableName))
+                .withTableName(String.format("%s", this.tableName))
                 .usingColumns("entityId", "metadata");
             var parameters = new HashMap<String, Object>();
             parameters.put("entityId", this.entityId);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/jdbc/SAML2JdbcMetadataGeneratorIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/jdbc/SAML2JdbcMetadataGeneratorIT.java
@@ -34,7 +34,7 @@ public class SAML2JdbcMetadataGeneratorIT implements TestsConstants {
             .setType(EmbeddedDatabaseType.H2)
             .build();
         var template = new JdbcTemplate(dataSource);
-        template.execute("CREATE TABLE `sp-metadata` (entityId VARCHAR(255), metadata CHARACTER LARGE OBJECT)");
+        template.execute("CREATE TABLE sp_metadata (entityId VARCHAR(255), metadata CHARACTER LARGE OBJECT)");
         jdbcMetadataGenerator = new SAML2JdbcMetadataGenerator(template, ENTITY_ID);
     }
 


### PR DESCRIPTION
Backticks are only supported by MySQL, and should be removed from the code. If necessary, they can always be added back via the table-name setting.