### PR TITLE
Only set configuration defaults when undefined

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/adapter/DefaultFrameworkAdapter.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/adapter/DefaultFrameworkAdapter.java
@@ -29,10 +29,9 @@ public class DefaultFrameworkAdapter extends FrameworkAdapter {
         CommonHelper.assertNotNull("config", config);
 
         config.setSecurityLogicIfUndefined(DefaultSecurityLogic.INSTANCE);
-        config.setCallbackLogic(DefaultCallbackLogic.INSTANCE);
-        config.setLogoutLogic(DefaultLogoutLogic.INSTANCE);
-
-        config.setProfileManagerFactory(ProfileManagerFactory.DEFAULT);
+        config.setCallbackLogicIfUndefined(DefaultCallbackLogic.INSTANCE);
+        config.setLogoutLogicIfUndefined(DefaultLogoutLogic.INSTANCE);
+        config.setProfileManagerFactoryIfUndefined(ProfileManagerFactory.DEFAULT);
     }
 
     @Override


### PR DESCRIPTION
A few of the fields in the `Config` object are always overridden to defaults; this PR corrects that to use the *...IfUnefined* variants.