### PR TITLE
Fix the ProfileManagerFactory usage

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/client/CasProxyReceptor.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/client/CasProxyReceptor.java
@@ -42,7 +42,7 @@ public final class CasProxyReceptor extends IndirectClient {
     protected void internalInit(final boolean forceReinit) {
         assertNotNull("store", this.store);
 
-        setRedirectionActionBuilderIfUndefined((ctx, store)
+        setRedirectionActionBuilderIfUndefined((ctx, store, pmf)
             -> { throw new TechnicalException("Not supported by the CAS proxy receptor"); });
         setCredentialsExtractorIfUndefined((ctx, store, factory) -> {
             // like CommonUtils.readAndRespondToProxyReceptorRequest in CAS client

--- a/pac4j-cas/src/main/java/org/pac4j/cas/redirect/CasRedirectionActionBuilder.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/redirect/CasRedirectionActionBuilder.java
@@ -9,6 +9,7 @@ import org.pac4j.cas.config.CasProtocol;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
@@ -36,7 +37,8 @@ public class CasRedirectionActionBuilder implements RedirectionActionBuilder {
     }
 
     @Override
-    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
+    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore,
+                                                            final ProfileManagerFactory profileManagerFactory) {
         var computeLoginUrl = configuration.computeFinalLoginUrl(context);
         val computedCallbackUrl = client.computeFinalCallbackUrl(context);
 

--- a/pac4j-cas/src/test/java/org/pac4j/cas/client/CasClientTests.java
+++ b/pac4j-cas/src/test/java/org/pac4j/cas/client/CasClientTests.java
@@ -115,7 +115,7 @@ public final class CasClientTests implements TestsConstants {
         val casClient = new CasClient(configuration);
         casClient.setCallbackUrl(CALLBACK_URL);
         val context = MockWebContext.create();
-        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertFalse(action.getLocation().indexOf("renew=true") >= 0);
     }
 
@@ -127,7 +127,7 @@ public final class CasClientTests implements TestsConstants {
         casClient.setCallbackUrl(CALLBACK_URL);
         configuration.setRenew(true);
         val context = MockWebContext.create();
-        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action.getLocation().indexOf("renew=true") >= 0);
     }
 
@@ -138,7 +138,7 @@ public final class CasClientTests implements TestsConstants {
         val casClient = new CasClient(configuration);
         casClient.setCallbackUrl(CALLBACK_URL);
         val context = MockWebContext.create();
-        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertFalse(action.getLocation().indexOf("gateway=true") >= 0);
     }
 
@@ -150,7 +150,7 @@ public final class CasClientTests implements TestsConstants {
         casClient.setCallbackUrl(CALLBACK_URL);
         val context = MockWebContext.create();
         configuration.setGateway(true);
-        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) casClient.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action.getLocation().indexOf("gateway=true") >= 0);
         val credentials = casClient.getCredentials(context, new MockSessionStore(),
             ProfileManagerFactory.DEFAULT);

--- a/pac4j-cas/src/test/java/org/pac4j/cas/redirect/CasRedirectionActionBuilderTest.java
+++ b/pac4j-cas/src/test/java/org/pac4j/cas/redirect/CasRedirectionActionBuilderTest.java
@@ -8,6 +8,7 @@ import org.pac4j.cas.config.CasProtocol;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.TestsConstants;
 
@@ -25,7 +26,7 @@ public final class CasRedirectionActionBuilderTest implements TestsConstants {
     @Test
     public void testRedirect() {
         val builder = newBuilder(new CasConfiguration());
-        val action = builder.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = builder.getRedirectionAction(MockWebContext.create(), new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action instanceof FoundAction);
         assertEquals(LOGIN_URL + "?service=http%3A%2F%2Fwww.pac4j.org%2Ftest.html%3Fclient_name%3DCasClient",
             ((FoundAction) action).getLocation());
@@ -36,7 +37,7 @@ public final class CasRedirectionActionBuilderTest implements TestsConstants {
         val builder = newBuilder(new CasConfiguration());
         val context = MockWebContext.create();
         context.setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_PASSIVE, true);
-        val action = builder.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = builder.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action instanceof FoundAction);
         assertTrue(((FoundAction) action).getLocation().contains("gateway=true"));
     }
@@ -46,7 +47,7 @@ public final class CasRedirectionActionBuilderTest implements TestsConstants {
         val builder = newBuilder(new CasConfiguration());
         val context = MockWebContext.create();
         context.setRequestAttribute(RedirectionActionBuilder.ATTRIBUTE_FORCE_AUTHN, true);
-        val action = builder.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = builder.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action instanceof FoundAction);
         assertTrue(((FoundAction) action).getLocation().contains("renew=true"));
     }
@@ -56,7 +57,7 @@ public final class CasRedirectionActionBuilderTest implements TestsConstants {
         val config = new CasConfiguration();
         config.setMethod("post");
         val builder = newBuilder(config);
-        val action = builder.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = builder.getRedirectionAction(MockWebContext.create(), new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action instanceof FoundAction);
         assertEquals(LOGIN_URL + "?service=http%3A%2F%2Fwww.pac4j.org%2Ftest.html%3Fclient_name%3DCasClient&method=post",
             ((FoundAction) action).getLocation());
@@ -67,7 +68,7 @@ public final class CasRedirectionActionBuilderTest implements TestsConstants {
         val config = new CasConfiguration();
         config.setProtocol(CasProtocol.SAML);
         val builder = newBuilder(config);
-        val action = builder.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = builder.getRedirectionAction(MockWebContext.create(), new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertTrue(action instanceof FoundAction);
         assertEquals(LOGIN_URL + "?TARGET=http%3A%2F%2Fwww.pac4j.org%2Ftest.html%3Fclient_name%3DCasClient",
             ((FoundAction) action).getLocation());

--- a/pac4j-core/src/main/java/org/pac4j/core/client/Client.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/Client.java
@@ -41,9 +41,11 @@ public interface Client {
      *
      * @param context the current web context
      * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @return the redirection to perform (optional)
      */
-    Optional<RedirectionAction> getRedirectionAction(WebContext context, SessionStore sessionStore);
+    Optional<RedirectionAction> getRedirectionAction(WebContext context, SessionStore sessionStore,
+                                                     ProfileManagerFactory profileManagerFactory);
 
     /**
      * <p>Get the credentials from the web context. If no validation was made remotely (direct client), credentials must be validated at
@@ -82,10 +84,12 @@ public interface Client {
      *
      * @param context the current web context
      * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @param currentProfile the currentProfile
      * @param targetUrl the target url after logout
      * @return the redirection to perform (optional)
      */
     Optional<RedirectionAction> getLogoutAction(WebContext context, SessionStore sessionStore,
+                                                ProfileManagerFactory profileManagerFactory,
                                                 UserProfile currentProfile, String targetUrl);
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/client/DirectClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/DirectClient.java
@@ -35,7 +35,8 @@ public abstract class DirectClient extends BaseClient {
     }
 
     @Override
-    public final Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
+    public final Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore,
+                                                                  final ProfileManagerFactory profileManagerFactory) {
         return Optional.empty();
     }
 
@@ -48,6 +49,7 @@ public abstract class DirectClient extends BaseClient {
 
     @Override
     public final Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                             final ProfileManagerFactory profileManagerFactory,
                                                              final UserProfile currentProfile, final String targetUrl) {
         return Optional.empty();
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
@@ -97,15 +97,19 @@ public abstract class IndirectClient extends BaseClient {
      * <p>If an authentication has already been tried for this client and has failed (<code>null</code> credentials) or if the request is
      * an AJAX one, an unauthorized response is thrown instead of a "redirection".</p>
      *
-     * @param context context
+     * @param context the web context
+     * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @return the "redirection" action
      */
     @Override
-    public final Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
+    public final Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore,
+                                                                  final ProfileManagerFactory profileManagerFactory) {
         init();
         // it's an AJAX request -> appropriate action
         if (ajaxRequestResolver.isAjax(context, sessionStore)) {
-            val httpAction = ajaxRequestResolver.buildAjaxResponse(context, sessionStore, redirectionActionBuilder);
+            val httpAction = ajaxRequestResolver.buildAjaxResponse(context, sessionStore,
+                profileManagerFactory, redirectionActionBuilder);
             logger.debug("AJAX request detected -> returning " + httpAction + " for " + context.getFullRequestURL());
             cleanRequestedUrl(context, sessionStore);
             throw httpAction;
@@ -119,7 +123,7 @@ public abstract class IndirectClient extends BaseClient {
             throw HttpActionHelper.buildUnauthenticatedAction(context);
         }
 
-        return redirectionActionBuilder.getRedirectionAction(context, sessionStore);
+        return redirectionActionBuilder.getRedirectionAction(context, sessionStore, profileManagerFactory);
     }
 
     private void cleanRequestedUrl(final WebContext context, final SessionStore sessionStore) {
@@ -167,9 +171,10 @@ public abstract class IndirectClient extends BaseClient {
 
     @Override
     public final Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                             final ProfileManagerFactory profileManagerFactory,
                                                              final UserProfile currentProfile, final String targetUrl) {
         init();
-        return logoutActionBuilder.getLogoutAction(context, sessionStore, currentProfile, targetUrl);
+        return logoutActionBuilder.getLogoutAction(context, sessionStore, profileManagerFactory, currentProfile, targetUrl);
     }
 
     public String computeFinalCallbackUrl(final WebContext context) {

--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultLogoutLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultLogoutLogic.java
@@ -130,7 +130,7 @@ public class DefaultLogoutLogic extends AbstractExceptionAwareLogic implements L
                                 }
                             }
                             val logoutAction =
-                                client.get().getLogoutAction(context, sessionStore, profile, targetUrl);
+                                client.get().getLogoutAction(context, sessionStore, profileManagerFactory, profile, targetUrl);
                             LOGGER.debug("Logout action: {}", logoutAction);
                             if (logoutAction.isPresent()) {
                                 action = logoutAction.get();

--- a/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/engine/DefaultSecurityLogic.java
@@ -26,6 +26,7 @@ import org.pac4j.core.matching.checker.DefaultMatchingChecker;
 import org.pac4j.core.matching.checker.MatchingChecker;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.HttpActionHelper;
 
 import java.util.Collections;
@@ -163,7 +164,7 @@ public class DefaultSecurityLogic extends AbstractExceptionAwareLogic implements
                     if (startAuthentication(context, sessionStore, currentClients)) {
                         LOGGER.debug("Starting authentication");
                         saveRequestedUrl(context, sessionStore, currentClients, config.getClients().getAjaxRequestResolver());
-                        action = redirectToIdentityProvider(context, sessionStore, currentClients);
+                        action = redirectToIdentityProvider(context, sessionStore, profileManagerFactory, currentClients);
                     } else {
                         LOGGER.debug("unauthorized");
                         action = unauthorized(context, sessionStore, currentClients);
@@ -244,13 +245,15 @@ public class DefaultSecurityLogic extends AbstractExceptionAwareLogic implements
      *
      * @param context the web context
      * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @param currentClients the current clients
      * @return the performed redirection
      */
     protected HttpAction redirectToIdentityProvider(final WebContext context, final SessionStore sessionStore,
+                                                    final ProfileManagerFactory profileManagerFactory,
                                                     final List<Client> currentClients) {
         val currentClient = (IndirectClient) currentClients.get(0);
-        return currentClient.getRedirectionAction(context, sessionStore).get();
+        return currentClient.getRedirectionAction(context, sessionStore, profileManagerFactory).get();
     }
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/http/ajax/AjaxRequestResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/ajax/AjaxRequestResolver.java
@@ -3,6 +3,7 @@ package org.pac4j.core.http.ajax;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.HttpAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 
 /**
@@ -27,8 +28,10 @@ public interface AjaxRequestResolver {
      *
      * @param context the web context
      * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @param redirectionActionBuilder the builder of the redirection, is case the redirect URL calculation needs to be performed
      * @return the AJAX response
      */
-    HttpAction buildAjaxResponse(WebContext context, SessionStore sessionStore, RedirectionActionBuilder redirectionActionBuilder);
+    HttpAction buildAjaxResponse(WebContext context, SessionStore sessionStore,
+                                 ProfileManagerFactory profileManagerFactory, RedirectionActionBuilder redirectionActionBuilder);
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/http/ajax/DefaultAjaxRequestResolver.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/http/ajax/DefaultAjaxRequestResolver.java
@@ -9,6 +9,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.WithLocationAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
@@ -40,10 +41,11 @@ public class DefaultAjaxRequestResolver implements AjaxRequestResolver, HttpCons
 
     @Override
     public HttpAction buildAjaxResponse(final WebContext context, final SessionStore sessionStore,
+                                        final ProfileManagerFactory profileManagerFactory,
                                         final RedirectionActionBuilder redirectionActionBuilder) {
         String url = null;
         if (addRedirectionUrlAsHeader) {
-            val action = redirectionActionBuilder.getRedirectionAction(context, sessionStore).orElse(null);
+            val action = redirectionActionBuilder.getRedirectionAction(context, sessionStore, profileManagerFactory).orElse(null);
             if (action instanceof WithLocationAction) {
                 url = ((WithLocationAction) action).getLocation();
             }

--- a/pac4j-core/src/main/java/org/pac4j/core/logout/CasLogoutActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/logout/CasLogoutActionBuilder.java
@@ -6,6 +6,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.HttpActionHelper;
 
 import java.util.Optional;
@@ -36,6 +37,7 @@ public class CasLogoutActionBuilder implements LogoutActionBuilder {
 
     @Override
     public Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                       final ProfileManagerFactory profileManagerFactory,
                                                        final UserProfile currentProfile, final String targetUrl) {
         if (isBlank(serverLogoutUrl)) {
             return Optional.empty();

--- a/pac4j-core/src/main/java/org/pac4j/core/logout/GoogleLogoutActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/logout/GoogleLogoutActionBuilder.java
@@ -6,6 +6,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.HttpActionHelper;
 
 import java.util.Optional;
@@ -21,6 +22,7 @@ public class GoogleLogoutActionBuilder implements LogoutActionBuilder {
 
     @Override
     public Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                       final ProfileManagerFactory profileManagerFactory,
                                                        final UserProfile currentProfile, final String targetUrl) {
 
         val redirectUrl = "https://accounts.google.com/Logout";

--- a/pac4j-core/src/main/java/org/pac4j/core/logout/LogoutActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/logout/LogoutActionBuilder.java
@@ -1,9 +1,10 @@
 package org.pac4j.core.logout;
 
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.profile.UserProfile;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 
 import java.util.Optional;
 
@@ -21,10 +22,11 @@ public interface LogoutActionBuilder {
      *
      * @param context the web context
      * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @param currentProfile the current profile
      * @param targetUrl the target URL after logout
      * @return the redirection (optional)
      */
     Optional<RedirectionAction> getLogoutAction(WebContext context, SessionStore sessionStore,
-                                                UserProfile currentProfile, String targetUrl);
+                                                ProfileManagerFactory profileManagerFactory, UserProfile currentProfile, String targetUrl);
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/logout/NoLogoutActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/logout/NoLogoutActionBuilder.java
@@ -1,9 +1,10 @@
 package org.pac4j.core.logout;
 
+import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.profile.UserProfile;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 
 import java.util.Optional;
 
@@ -19,6 +20,7 @@ public class NoLogoutActionBuilder implements LogoutActionBuilder {
 
     @Override
     public Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                       final ProfileManagerFactory profileManagerFactory,
                                                        final UserProfile currentProfile, final String targetUrl) {
         return Optional.empty();
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectionActionBuilder.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/redirect/RedirectionActionBuilder.java
@@ -3,6 +3,7 @@ package org.pac4j.core.redirect;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 
 import java.util.Optional;
 
@@ -36,7 +37,9 @@ public interface RedirectionActionBuilder {
      *
      * @param context the web context
      * @param sessionStore the session store
+     * @param profileManagerFactory the profile manager factory
      * @return the "redirection" action (optional)
      */
-    Optional<RedirectionAction> getRedirectionAction(WebContext context, SessionStore sessionStore);
+    Optional<RedirectionAction> getRedirectionAction(WebContext context, SessionStore sessionStore,
+                                                     ProfileManagerFactory profileManagerFactory);
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/client/BaseClientTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/client/BaseClientTests.java
@@ -34,7 +34,7 @@ public final class BaseClientTests implements TestsConstants {
         client.setCallbackUrl(CALLBACK_URL);
         val context = MockWebContext.create();
         final SessionStore sessionStore = new MockSessionStore();
-        val action = (FoundAction) client.getRedirectionAction(context, sessionStore).get();
+        val action = (FoundAction) client.getRedirectionAction(context, sessionStore, ProfileManagerFactory.DEFAULT).get();
         val redirectionUrl = action.getLocation();
         assertEquals(LOGIN_URL, redirectionUrl);
         val credentials = client.getCredentials(context, sessionStore, ProfileManagerFactory.DEFAULT);
@@ -47,7 +47,7 @@ public final class BaseClientTests implements TestsConstants {
             new MockIndirectClient(TYPE, new FoundAction(LOGIN_URL), Optional.empty(), new CommonProfile());
         client.setCallbackUrl(CALLBACK_URL);
         val context = MockWebContext.create();
-        val action = (FoundAction) client.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         val redirectionUrl = action.getLocation();
         assertEquals(LOGIN_URL, redirectionUrl);
     }
@@ -79,7 +79,8 @@ public final class BaseClientTests implements TestsConstants {
         client.setCallbackUrl(CALLBACK_URL);
         val context = MockWebContext.create()
                                         .addRequestHeader(HttpConstants.AJAX_HEADER_NAME, HttpConstants.AJAX_HEADER_VALUE);
-        val e = (HttpAction) TestsHelper.expectException(() -> client.getRedirectionAction(context, new MockSessionStore()));
+        val e = (HttpAction) TestsHelper.expectException(() -> client.getRedirectionAction(context, new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT));
         assertEquals(401, e.getCode());
     }
 
@@ -91,7 +92,8 @@ public final class BaseClientTests implements TestsConstants {
         val context = MockWebContext.create();
         final SessionStore sessionStore = new MockSessionStore();
         sessionStore.set(context, client.getName() + IndirectClient.ATTEMPTED_AUTHENTICATION_SUFFIX, "true");
-        val e = (HttpAction) TestsHelper.expectException(() -> client.getRedirectionAction(context, sessionStore));
+        val e = (HttpAction) TestsHelper.expectException(() -> client.getRedirectionAction(context, sessionStore,
+            ProfileManagerFactory.DEFAULT));
         assertEquals(401, e.getCode());
     }
 
@@ -111,6 +113,6 @@ public final class BaseClientTests implements TestsConstants {
         val client =
             new MockIndirectClient(TYPE, new FoundAction(LOGIN_URL), Optional.empty(), new CommonProfile());
         val context = MockWebContext.create();
-        TestsHelper.expectException(() -> client.getRedirectionAction(context, null));
+        TestsHelper.expectException(() -> client.getRedirectionAction(context, null, ProfileManagerFactory.DEFAULT));
     }
 }

--- a/pac4j-core/src/test/java/org/pac4j/core/client/MockIndirectClient.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/client/MockIndirectClient.java
@@ -39,7 +39,7 @@ public final class MockIndirectClient extends IndirectClient {
 
     @Override
     protected void internalInit(final boolean forceReinit) {
-        setRedirectionActionBuilderIfUndefined((ctx, store) -> Optional.of(redirectAction));
+        setRedirectionActionBuilderIfUndefined((ctx, store, pmf) -> Optional.of(redirectAction));
         setCredentialsExtractorIfUndefined((ctx, store, factory) -> returnCredentials.get());
         setAuthenticatorIfUndefined((cred, ctx, store) -> {
             cred.setUserProfile(profile);

--- a/pac4j-core/src/test/java/org/pac4j/core/engine/DefaultLogoutLogicTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/engine/DefaultLogoutLogicTests.java
@@ -154,7 +154,7 @@ public final class DefaultLogoutLogicTests implements TestsConstants {
         profile.setClientName(NAME);
         val client = new MockIndirectClient(NAME);
         client.setCallbackUrl(PAC4J_BASE_URL);
-        client.setLogoutActionBuilder((ctx, store, p, targetUrl) -> Optional.of(new FoundAction(CALLBACK_URL + "?p=" + targetUrl)));
+        client.setLogoutActionBuilder((ctx, store, pmf, p, targetUrl) -> Optional.of(new FoundAction(CALLBACK_URL + "?p=" + targetUrl)));
         config.setClients(new Clients(client));
         profiles.put(NAME, profile);
         addProfilesToContext();
@@ -173,7 +173,7 @@ public final class DefaultLogoutLogicTests implements TestsConstants {
         profile.setClientName(NAME);
         val client = new MockIndirectClient(NAME);
         client.setCallbackUrl(PAC4J_BASE_URL);
-        client.setLogoutActionBuilder((ctx, store, p, targetUrl) -> Optional.of(new FoundAction(CALLBACK_URL + "?p=" + targetUrl)));
+        client.setLogoutActionBuilder((ctx, store, pmf, p, targetUrl) -> Optional.of(new FoundAction(CALLBACK_URL + "?p=" + targetUrl)));
         config.setClients(new Clients(client));
         profiles.put(NAME, profile);
         addProfilesToContext();

--- a/pac4j-core/src/test/java/org/pac4j/core/run/RunClient.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/run/RunClient.java
@@ -36,7 +36,7 @@ public abstract class RunClient implements TestsConstants {
         val client = getClient();
         val context = MockWebContext.create();
         final SessionStore sessionStore = new MockSessionStore();
-        val url = ((FoundAction) client.getRedirectionAction(context, sessionStore).get()).getLocation();
+        val url = ((FoundAction) client.getRedirectionAction(context, sessionStore, ProfileManagerFactory.DEFAULT).get()).getLocation();
         logger.warn("Redirect to: \n{}", url);
         if (CommonHelper.isNotBlank(getLogin()) && CommonHelper.isNotBlank(getPassword())) {
             logger.warn("Use credentials: {} / {}", getLogin(), getPassword());

--- a/pac4j-gae/src/main/java/org/pac4j/gae/client/GaeUserServiceClient.java
+++ b/pac4j-gae/src/main/java/org/pac4j/gae/client/GaeUserServiceClient.java
@@ -33,7 +33,7 @@ public class GaeUserServiceClient extends IndirectClient {
     protected void internalInit(final boolean forceReinit) {
         service = UserServiceFactory.getUserService();
         CommonHelper.assertNotNull("service", this.service);
-        setRedirectionActionBuilderIfUndefined((ctx, session) -> {
+        setRedirectionActionBuilderIfUndefined((ctx, session, profileManagerFactory) -> {
             val destinationUrl = computeFinalCallbackUrl(ctx);
             val loginUrl = authDomain == null ?  service.createLoginURL(destinationUrl)
                 : service.createLoginURL(destinationUrl, authDomain);

--- a/pac4j-gae/src/test/java/org/pac4j/gae/client/GaeUserServiceClientTests.java
+++ b/pac4j-gae/src/test/java/org/pac4j/gae/client/GaeUserServiceClientTests.java
@@ -57,12 +57,12 @@ public final class GaeUserServiceClientTests implements TestsConstants {
     @Test(expected = TechnicalException.class)
     public void testCallbackMandatory() {
         val localClient = new GaeUserServiceClient();
-        localClient.getRedirectionAction(context, new MockSessionStore());
+        localClient.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT);
     }
 
     @Test
     public void testRedirect() {
-        final HttpAction action = client.getRedirectionAction(context, new MockSessionStore()).get();
+        final HttpAction action = client.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertEquals(HttpConstants.FOUND, action.getCode());
         assertEquals("/_ah/login?continue=" + CommonHelper.urlEncode(CALLBACK_URL + "?" +
             Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER + "=" + client.getName()), ((FoundAction) action).getLocation());

--- a/pac4j-http/src/main/java/org/pac4j/http/client/indirect/FormClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/indirect/FormClient.java
@@ -74,7 +74,7 @@ public class FormClient extends IndirectClient {
         assertNotBlank("usernameParameter", this.usernameParameter);
         assertNotBlank("passwordParameter", this.passwordParameter);
 
-        setRedirectionActionBuilderIfUndefined((ctx, session) -> {
+        setRedirectionActionBuilderIfUndefined((ctx, session, profileManagerFactory) -> {
             val finalLoginUrl = getUrlResolver().compute(this.loginUrl, ctx);
             return Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, finalLoginUrl));
         });

--- a/pac4j-http/src/main/java/org/pac4j/http/client/indirect/IndirectBasicAuthClient.java
+++ b/pac4j-http/src/main/java/org/pac4j/http/client/indirect/IndirectBasicAuthClient.java
@@ -58,7 +58,7 @@ public class IndirectBasicAuthClient extends IndirectClient {
     protected void internalInit(final boolean forceReinit) {
         assertNotBlank("realmName", this.realmName);
 
-        setRedirectionActionBuilderIfUndefined((webContext, sessionStore) ->
+        setRedirectionActionBuilderIfUndefined((webContext, sessionStore, profileManagerFactory) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(webContext, computeFinalCallbackUrl(webContext))));
         setCredentialsExtractorIfUndefined(new BasicAuthExtractor());
     }

--- a/pac4j-http/src/test/java/org/pac4j/http/client/indirect/FormClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/indirect/FormClientTests.java
@@ -70,7 +70,7 @@ public final class FormClientTests implements TestsConstants {
     public void testRedirectionUrl() {
         val formClient = getFormClient();
         var context = MockWebContext.create();
-        val action = (FoundAction) formClient.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) formClient.getRedirectionAction(context, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         assertEquals(LOGIN_URL, action.getLocation());
     }
 

--- a/pac4j-http/src/test/java/org/pac4j/http/client/indirect/IndirectBasicAuthClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/indirect/IndirectBasicAuthClientTests.java
@@ -77,7 +77,8 @@ public final class IndirectBasicAuthClientTests implements TestsConstants {
     public void testRedirectionUrl() {
         val basicAuthClient = getBasicAuthClient();
         var context = MockWebContext.create();
-        val action = (FoundAction) basicAuthClient.getRedirectionAction(context, new MockSessionStore()).get();
+        val action = (FoundAction) basicAuthClient.getRedirectionAction(context, new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         assertEquals(CALLBACK_URL + "?" + Pac4jConstants.DEFAULT_CLIENT_NAME_PARAMETER + "=" + basicAuthClient.getName(),
             action.getLocation());
     }

--- a/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/indirect/IndirectKerberosClient.java
+++ b/pac4j-kerberos/src/main/java/org/pac4j/kerberos/client/indirect/IndirectKerberosClient.java
@@ -37,7 +37,7 @@ public class IndirectKerberosClient extends IndirectClient {
 
     @Override
     protected void internalInit(final boolean forceReinit) {
-        setRedirectionActionBuilderIfUndefined((webContext, sessionStore) ->
+        setRedirectionActionBuilderIfUndefined((webContext, sessionStore, profileManagerFactory) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(webContext, computeFinalCallbackUrl(webContext))));
         setCredentialsExtractorIfUndefined(new KerberosExtractor());
     }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/BitbucketClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/BitbucketClient.java
@@ -29,7 +29,7 @@ public class BitbucketClient extends OAuth10Client {
     protected void internalInit(final boolean forceReinit) {
         configuration.setApi(new BitBucketApi());
         configuration.setProfileDefinition(new BitbucketProfileDefinition());
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://bitbucket.org/account/signout/")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/DropBoxClient.java
@@ -1,9 +1,9 @@
 package org.pac4j.oauth.client;
 
 import org.pac4j.core.util.HttpActionHelper;
+import org.pac4j.oauth.profile.dropbox.DropBoxProfile;
 import org.pac4j.oauth.profile.dropbox.DropBoxProfileCreator;
 import org.pac4j.oauth.profile.dropbox.DropBoxProfileDefinition;
-import org.pac4j.oauth.profile.dropbox.DropBoxProfile;
 import org.pac4j.scribe.builder.api.DropboxApi20;
 
 import java.util.Optional;
@@ -31,7 +31,7 @@ public class DropBoxClient extends OAuth20Client {
         configuration.setApi(DropboxApi20.INSTANCE);
         configuration.setProfileDefinition(new DropBoxProfileDefinition());
 
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://www.dropbox.com/logout")));
         setProfileCreatorIfUndefined(new DropBoxProfileCreator(configuration, this));
 

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FigShareClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FigShareClient.java
@@ -32,7 +32,7 @@ public class FigShareClient extends OAuth20Client {
         configuration.setWithState(true);
 
         setProfileCreatorIfUndefined(new FigShareProfileCreator(configuration, this));
-        setLogoutActionBuilderIfUndefined((ctx, store, profile, targetUrl) -> Optional
+        setLogoutActionBuilderIfUndefined((ctx, store, pmf, profile, targetUrl) -> Optional
             .of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://figshare.com/account/logout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FoursquareClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/FoursquareClient.java
@@ -1,8 +1,8 @@
 package org.pac4j.oauth.client;
 
 import com.github.scribejava.apis.Foursquare2Api;
-import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.oauth.profile.foursquare.FoursquareProfile;
 import org.pac4j.oauth.profile.foursquare.FoursquareProfileCreator;
 import org.pac4j.oauth.profile.foursquare.FoursquareProfileDefinition;
@@ -33,7 +33,7 @@ public class FoursquareClient extends OAuth20Client {
         configuration.setProfileDefinition(new FoursquareProfileDefinition());
         configuration.setScope("user");
         setProfileCreatorIfUndefined(new FoursquareProfileCreator(configuration, this));
-        setLogoutActionBuilderIfUndefined((ctx, store, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, store, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://www.foursquare.com/logout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GitHubClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/GitHubClient.java
@@ -36,7 +36,7 @@ public class GitHubClient extends OAuth20Client {
         configuration.setApi(GitHubApi.instance());
         configuration.setProfileDefinition(new GitHubProfileDefinition());
         configuration.setTokenAsHeader(true);
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://github.com/logout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/HiOrgServerClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/HiOrgServerClient.java
@@ -45,7 +45,7 @@ public class HiOrgServerClient extends OAuth20Client {
             }
         });
         configuration.setWithState(true);
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, LOGOUT_URL)));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedIn2Client.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/LinkedIn2Client.java
@@ -51,7 +51,7 @@ public class LinkedIn2Client extends OAuth20Client {
             }
             return false;
         });
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://www.linkedin.com/uas/logout")));
         setProfileCreatorIfUndefined(new LinkedIn2ProfileCreator(configuration, this));
 

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/PayPalClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/PayPalClient.java
@@ -1,7 +1,7 @@
 package org.pac4j.oauth.client;
 
-import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.core.util.CommonHelper;
+import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.oauth.profile.paypal.PayPalProfile;
 import org.pac4j.oauth.profile.paypal.PayPalProfileDefinition;
 import org.pac4j.scribe.builder.api.PayPalApi20;
@@ -39,7 +39,7 @@ public class PayPalClient extends OAuth20Client {
         configuration.setApi(new PayPalApi20());
         configuration.setProfileDefinition(new PayPalProfileDefinition());
         configuration.setTokenAsHeader(true);
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://www.paypal.com/myaccount/logout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/StravaClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/StravaClient.java
@@ -38,7 +38,7 @@ public class StravaClient extends OAuth20Client {
     protected void internalInit(final boolean forceReinit) {
         configuration.setApi(new StravaApi20(approvalPrompt));
         configuration.setProfileDefinition(new StravaProfileDefinition());
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://www.strava.com/session")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/TwitterClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/TwitterClient.java
@@ -51,7 +51,7 @@ public class TwitterClient extends OAuth10Client {
                 return false;
             }
         });
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://twitter.com/logout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WindowsLiveClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WindowsLiveClient.java
@@ -30,7 +30,7 @@ public class WindowsLiveClient extends OAuth20Client {
         configuration.setApi(LiveApi.instance());
         configuration.setProfileDefinition(new WindowsLiveProfileDefinition());
         configuration.setScope("wl.basic");
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://account.microsoft.com/auth/complete-signout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WordPressClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/WordPressClient.java
@@ -1,8 +1,8 @@
 package org.pac4j.oauth.client;
 
 import org.pac4j.core.util.HttpActionHelper;
-import org.pac4j.oauth.profile.wordpress.WordPressProfileDefinition;
 import org.pac4j.oauth.profile.wordpress.WordPressProfile;
+import org.pac4j.oauth.profile.wordpress.WordPressProfileDefinition;
 import org.pac4j.scribe.builder.api.WordPressApi20;
 
 import java.util.Optional;
@@ -30,7 +30,7 @@ public class WordPressClient extends OAuth20Client {
         configuration.setApi(new WordPressApi20());
         configuration.setProfileDefinition(new WordPressProfileDefinition());
         configuration.setTokenAsHeader(true);
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "https://wordpress.com/wp-login.php?action=logout")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/client/YahooClient.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/client/YahooClient.java
@@ -31,7 +31,7 @@ public class YahooClient extends OAuth10Client {
         configuration.setApi(YahooApi.instance());
         configuration.setProfileDefinition(new YahooProfileDefinition());
         setProfileCreatorIfUndefined(new YahooProfileCreator(configuration, this));
-        setLogoutActionBuilderIfUndefined((ctx, session, profile, targetUrl) ->
+        setLogoutActionBuilderIfUndefined((ctx, session, pmf, profile, targetUrl) ->
             Optional.of(HttpActionHelper.buildRedirectUrlAction(ctx, "http://login.yahoo.com/config/login?logout=1")));
 
         super.internalInit(forceReinit);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/redirect/OAuth10RedirectionActionBuilder.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/redirect/OAuth10RedirectionActionBuilder.java
@@ -11,6 +11,7 @@ import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.HttpCommunicationException;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
@@ -41,7 +42,8 @@ public class OAuth10RedirectionActionBuilder implements RedirectionActionBuilder
     }
 
     @Override
-    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
+    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore,
+                                                            final ProfileManagerFactory profileManagerFactory) {
         try {
 
             val service = (OAuth10aService) this.configuration.buildService(context, client);

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/redirect/OAuth20RedirectionActionBuilder.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/redirect/OAuth20RedirectionActionBuilder.java
@@ -10,6 +10,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
@@ -38,7 +39,8 @@ public class OAuth20RedirectionActionBuilder implements RedirectionActionBuilder
     }
 
     @Override
-    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
+    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore,
+                                                            final ProfileManagerFactory profileManagerFactory) {
         try {
 
             final String state;

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/client/OAuth20ClientTests.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/client/OAuth20ClientTests.java
@@ -6,6 +6,7 @@ import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
 import org.pac4j.core.util.generator.StaticValueGenerator;
@@ -36,7 +37,8 @@ public final class OAuth20ClientTests implements TestsConstants {
         var client = new FacebookClient(KEY, SECRET);
         client.setCallbackUrl(CALLBACK_URL);
         client.getConfiguration().setStateGenerator(new StaticValueGenerator("OK"));
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         var url = new URL(action.getLocation());
         assertTrue(url.getQuery().contains("state=OK"));
     }
@@ -47,11 +49,12 @@ public final class OAuth20ClientTests implements TestsConstants {
         client.setCallbackUrl(CALLBACK_URL);
         client.getConfiguration().setStateGenerator(new StaticValueGenerator("oldstate"));
         val mockWebContext = MockWebContext.create();
-        var action = (FoundAction) client.getRedirectionAction(mockWebContext, new MockSessionStore()).get();
+        var action = (FoundAction) client.getRedirectionAction(mockWebContext, new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         var url = new URL(action.getLocation());
         val stringMap = TestsHelper.splitQuery(url);
         assertEquals(stringMap.get("state"), "oldstate");
-        action = (FoundAction) client.getRedirectionAction(mockWebContext, new MockSessionStore()).get();
+        action = (FoundAction) client.getRedirectionAction(mockWebContext, new MockSessionStore(), ProfileManagerFactory.DEFAULT).get();
         var url2 = new URL(action.getLocation());
         val stringMap2 = TestsHelper.splitQuery(url2);
         assertEquals(stringMap2.get("state"), "oldstate");
@@ -61,12 +64,14 @@ public final class OAuth20ClientTests implements TestsConstants {
     public void testStateRandom() throws MalformedURLException {
         OAuth20Client client = new FacebookClient(KEY, SECRET);
         client.setCallbackUrl(CALLBACK_URL);
-        var action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        var action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         var url = new URL(action.getLocation());
         val stringMap = TestsHelper.splitQuery(url);
         assertNotNull(stringMap.get("state"));
 
-        action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         var url2 = new URL(action.getLocation());
         val stringMap2 = TestsHelper.splitQuery(url2);
         assertNotNull(stringMap2.get("state"));
@@ -75,7 +80,8 @@ public final class OAuth20ClientTests implements TestsConstants {
 
     @Test
     public void testGetRedirectionGithub() {
-        val action = (FoundAction) getClient().getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) getClient().getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         val url = action.getLocation();
         assertTrue(url != null && !url.isEmpty());
     }
@@ -97,16 +103,16 @@ public final class OAuth20ClientTests implements TestsConstants {
     public void testMissingKey() {
         val client = getClient();
         client.setKey(null);
-        TestsHelper.expectException(() -> client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()),
-            TechnicalException.class, "key cannot be blank");
+        TestsHelper.expectException(() -> client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+                ProfileManagerFactory.DEFAULT), TechnicalException.class, "key cannot be blank");
     }
 
     @Test
     public void testMissingSecret() {
         val client = getClient();
         client.setSecret(null);
-        TestsHelper.expectException(() -> client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()),
-            TechnicalException.class, "secret cannot be blank");
+        TestsHelper.expectException(() -> client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+                ProfileManagerFactory.DEFAULT), TechnicalException.class, "secret cannot be blank");
     }
 
     @Test
@@ -132,7 +138,7 @@ public final class OAuth20ClientTests implements TestsConstants {
 
     @Test
     public void testDefaultScopeGoogle() {
-        getGoogleClient().getRedirectionAction(MockWebContext.create(), new MockSessionStore());
+        getGoogleClient().getRedirectionAction(MockWebContext.create(), new MockSessionStore(), ProfileManagerFactory.DEFAULT);
     }
 
     @Test

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/logout/OidcLogoutActionBuilder.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/logout/OidcLogoutActionBuilder.java
@@ -12,6 +12,7 @@ import org.pac4j.core.http.ajax.AjaxRequestResolver;
 import org.pac4j.core.http.ajax.DefaultAjaxRequestResolver;
 import org.pac4j.core.logout.LogoutActionBuilder;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.core.util.Pac4jConstants;
@@ -41,6 +42,7 @@ public class OidcLogoutActionBuilder implements LogoutActionBuilder {
 
     @Override
     public Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                       final ProfileManagerFactory profileManagerFactory,
                                                        final UserProfile currentProfile, final String targetUrl) {
         val logoutUrl = configuration.findLogoutUrl();
         if (CommonHelper.isNotBlank(logoutUrl) && currentProfile instanceof OidcProfile) {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilder.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilder.java
@@ -11,6 +11,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
@@ -42,7 +43,8 @@ public class OidcRedirectionActionBuilder implements RedirectionActionBuilder {
     }
 
     @Override
-    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore) {
+    public Optional<RedirectionAction> getRedirectionAction(final WebContext context, final SessionStore sessionStore,
+                                                            final ProfileManagerFactory profileManagerFactory) {
         val configContext = new OidcConfigurationContext(context, client.getConfiguration());
         val params = buildParams(context);
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
@@ -12,6 +12,7 @@ import org.pac4j.core.exception.http.FoundAction;
 import org.pac4j.core.exception.http.HttpAction;
 import org.pac4j.core.exception.http.StatusAction;
 import org.pac4j.core.http.ajax.AjaxRequestResolver;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.TestsHelper;
@@ -71,20 +72,22 @@ public final class OidcRedirectTests implements TestsConstants {
             }
             @Override
             public HttpAction buildAjaxResponse(final WebContext context, final SessionStore sessionStore,
+                                                final ProfileManagerFactory profileManagerFactory,
                                                 final RedirectionActionBuilder redirectionActionBuilder) {
                 return new StatusAction(401);
             }
         });
 
-        var context = MockWebContext.create();
-        final SessionStore sessionStore = new MockSessionStore();
+        val context = MockWebContext.create();
+        val sessionStore = new MockSessionStore();
+        val pmf = ProfileManagerFactory.DEFAULT;
 
-        val firstRequestAction = (FoundAction) client.getRedirectionAction(context, sessionStore).orElse(null);
+        val firstRequestAction = (FoundAction) client.getRedirectionAction(context, sessionStore, pmf).orElse(null);
         var state = TestsHelper.splitQuery(new URL(firstRequestAction.getLocation())).get("state");
 
         try {
             //noinspection ThrowableNotThrown
-            client.getRedirectionAction(context, sessionStore);
+            client.getRedirectionAction(context, sessionStore, pmf);
             fail("Ajax request should throw exception");
         } catch (Exception e) {
             var stateAfterAjax = (State) sessionStore.get(context, client.getStateSessionAttributeName()).orElse(null);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ContextProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ContextProvider.java
@@ -15,6 +15,7 @@ import org.opensaml.saml.saml2.metadata.RoleDescriptor;
 import org.opensaml.saml.saml2.metadata.SPSSODescriptor;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.exceptions.SAMLException;
@@ -65,11 +66,13 @@ public class SAML2ContextProvider implements SAMLContextProvider {
     }
 
     @Override
-    public SAML2MessageContext buildContext(final SAML2Client client, final WebContext webContext, final SessionStore sessionStore) {
+    public SAML2MessageContext buildContext(final SAML2Client client, final WebContext webContext,
+                                            final SessionStore sessionStore, final ProfileManagerFactory profileManagerFactory) {
         val context = buildServiceProviderContext(client, webContext, sessionStore);
         addIDPContext(context);
         context.setWebContext(webContext);
         context.setSessionStore(sessionStore);
+        context.setProfileManagerFactory(profileManagerFactory);
         return context;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAMLContextProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAMLContextProvider.java
@@ -2,6 +2,7 @@ package org.pac4j.saml.context;
 
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.saml.client.SAML2Client;
 
 /**
@@ -12,5 +13,6 @@ import org.pac4j.saml.client.SAML2Client;
 public interface SAMLContextProvider {
     SAML2MessageContext buildServiceProviderContext(SAML2Client client, WebContext webContext, SessionStore sessionStore);
 
-    SAML2MessageContext buildContext(SAML2Client client, WebContext webContext, SessionStore sessionStore);
+    SAML2MessageContext buildContext(SAML2Client client, WebContext webContext,
+                                     SessionStore sessionStore, ProfileManagerFactory profileManagerFactory);
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/extractor/SAML2CredentialsExtractor.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/extractor/SAML2CredentialsExtractor.java
@@ -62,7 +62,7 @@ public class SAML2CredentialsExtractor implements CredentialsExtractor {
     @Override
     public Optional<Credentials> extract(final WebContext context, final SessionStore sessionStore,
                                          final ProfileManagerFactory profileManagerFactory) {
-        val samlContext = this.contextProvider.buildContext(this.saml2Client, context, sessionStore);
+        val samlContext = this.contextProvider.buildContext(this.saml2Client, context, sessionStore, profileManagerFactory);
         val logoutEndpoint = isLogoutEndpointRequest(context, samlContext);
         if (logoutEndpoint) {
             receiveLogout(samlContext);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/SAML2LogoutActionBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/SAML2LogoutActionBuilder.java
@@ -9,6 +9,7 @@ import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
 import org.pac4j.core.logout.LogoutActionBuilder;
 import org.pac4j.core.profile.UserProfile;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.HttpActionHelper;
 import org.pac4j.core.util.generator.ValueGenerator;
 import org.pac4j.saml.client.SAML2Client;
@@ -52,11 +53,12 @@ public class SAML2LogoutActionBuilder implements LogoutActionBuilder {
 
     @Override
     public Optional<RedirectionAction> getLogoutAction(final WebContext context, final SessionStore sessionStore,
+                                                       final ProfileManagerFactory profileManagerFactory,
                                                        final UserProfile currentProfile, final String targetUrl) {
         try {
             if (currentProfile instanceof SAML2Profile) {
                 val saml2Profile = (SAML2Profile) currentProfile;
-                val samlContext = this.contextProvider.buildContext(this.saml2Client, context, sessionStore);
+                val samlContext = this.contextProvider.buildContext(this.saml2Client, context, sessionStore, profileManagerFactory);
                 val relayState = this.stateGenerator.generateValue(context, sessionStore);
 
                 val logoutRequest = this.saml2LogoutRequestBuilder.build(samlContext, saml2Profile);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageReceiver.java
@@ -86,6 +86,7 @@ public abstract class AbstractSAML2MessageReceiver implements SAML2MessageReceiv
         decodedCtx.getSAMLSelfMetadataContext().setRoleDescriptor(context.getSPSSODescriptor());
         decodedCtx.setWebContext(context.getWebContext());
         decodedCtx.setSessionStore(context.getSessionStore());
+        decodedCtx.setProfileManagerFactory(context.getProfileManagerFactory());
         return decodedCtx;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectionActionBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/redirect/SAML2RedirectionActionBuilder.java
@@ -6,6 +6,7 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.RedirectionAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.redirect.RedirectionActionBuilder;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.core.util.HttpActionHelper;
@@ -33,8 +34,9 @@ public class SAML2RedirectionActionBuilder implements RedirectionActionBuilder {
     }
 
     @Override
-    public Optional<RedirectionAction> getRedirectionAction(final WebContext wc, final SessionStore sessionStore) {
-        val context = this.client.getContextProvider().buildContext(this.client, wc, sessionStore);
+    public Optional<RedirectionAction> getRedirectionAction(final WebContext wc, final SessionStore sessionStore,
+                                                            final ProfileManagerFactory profileManagerFactory) {
+        val context = this.client.getContextProvider().buildContext(this.client, wc, sessionStore, profileManagerFactory);
         val relayState = this.client.getStateGenerator().generateValue(wc, sessionStore);
 
         val authnRequest = this.saml2ObjectBuilder.build(context);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -9,6 +9,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.OkAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.metadata.SAML2MetadataContactPerson;
 import org.pac4j.saml.metadata.SAML2MetadataUIInfo;
@@ -53,7 +54,8 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
         uiInfo.setLogos(Collections.singletonList(new SAML2MetadataUIInfo.SAML2MetadataUILogo("https://pac4j.org/logo.png", 16, 16)));
         client.getConfiguration().getMetadataUIInfos().add(uiInfo);
 
-        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
 
         val issuerJdk11 = "<saml2:Issuer "
                 + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\" "
@@ -67,7 +69,8 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testStandardSpEntityIdForPostBinding() {
         val client = getClient();
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/cb");
-        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
 
         val issuerJdk11 = "<saml2:Issuer "
             + "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\" "
@@ -80,7 +83,8 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testForceAuthIsSetForPostBinding() {
         val client =  getClient();
         client.getConfiguration().setForceAuth(true);
-        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         assertTrue(getDecodedAuthnRequest(action.getContent()).contains("ForceAuthn=\"true\""));
     }
 
@@ -88,7 +92,8 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testSetComparisonTypeWithPostBinding() {
         val client = getClient();
         client.getConfiguration().setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
-        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (OkAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         assertTrue(getDecodedAuthnRequest(action.getContent()).contains("Comparison=\"exact\""));
     }
 
@@ -98,7 +103,7 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
         final WebContext context = MockWebContext.create();
         final SessionStore sessionStore = new MockSessionStore();
         sessionStore.set(context, SAML2StateGenerator.SAML_RELAY_STATE_ATTRIBUTE, "relayState");
-        val action = (OkAction) client.getRedirectionAction(context, sessionStore).get();
+        val action = (OkAction) client.getRedirectionAction(context, sessionStore, ProfileManagerFactory.DEFAULT).get();
         assertTrue(action.getContent().contains("<input type=\"hidden\" name=\"RelayState\" value=\"relayState\"/>"));
     }
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/RedirectSAML2ClientTests.java
@@ -10,6 +10,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.exception.http.FoundAction;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
 import org.pac4j.saml.state.SAML2StateGenerator;
 
 import java.io.BufferedReader;
@@ -39,7 +40,8 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/callback");
         client.getConfiguration().setUseNameQualifier(true);
 
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         val inflated = getInflatedAuthnRequest(action.getLocation());
 
         val issuerJdk11 = "<saml2:Issuer "
@@ -54,7 +56,8 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         val client = getClient();
         client.getConfiguration().setServiceProviderEntityId("http://localhost:8080/callback");
 
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         val inflated = getInflatedAuthnRequest(action.getLocation());
 
         val issuerJdk11 = "<saml2:Issuer "
@@ -67,7 +70,8 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testForceAuthIsSetForRedirectBinding() {
         val client = getClient();
         client.getConfiguration().setForceAuth(true);
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("ForceAuthn=\"true\""));
     }
 
@@ -75,7 +79,8 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testSetComparisonTypeWithRedirectBinding() {
         val client = getClient();
         client.getConfiguration().setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         assertTrue(getInflatedAuthnRequest(action.getLocation()).contains("Comparison=\"exact\""));
     }
 
@@ -83,7 +88,8 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
     public void testNameIdPolicyFormat() {
         val client = getClient();
         client.getConfiguration().setNameIdPolicyFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress");
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
         val loc = action.getLocation();
         assertTrue(getInflatedAuthnRequest(loc).contains("<saml2p:NameIDPolicy AllowCreate=\"true\" " +
                 "Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\"/></saml2p:AuthnRequest>"));
@@ -95,7 +101,8 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         client.getConfiguration().setComparisonType(AuthnContextComparisonTypeEnumeration.EXACT.toString());
         client.getConfiguration()
             .setAuthnContextClassRefs(Arrays.asList("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"));
-        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore()).get();
+        val action = (FoundAction) client.getRedirectionAction(MockWebContext.create(), new MockSessionStore(),
+            ProfileManagerFactory.DEFAULT).get();
 
         val checkClass = "<saml2p:RequestedAuthnContext Comparison=\"exact\"><saml2:AuthnContextClassRef " +
                 "xmlns:saml2=\"urn:oasis:names:tc:SAML:2.0:assertion\">" +
@@ -111,7 +118,7 @@ public final class RedirectSAML2ClientTests extends AbstractSAML2ClientTests {
         final WebContext context = MockWebContext.create();
         final SessionStore sessionStore = new MockSessionStore();
         sessionStore.set(context, SAML2StateGenerator.SAML_RELAY_STATE_ATTRIBUTE, "relayState");
-        val action = (FoundAction) client.getRedirectionAction(context, sessionStore).get();
+        val action = (FoundAction) client.getRedirectionAction(context, sessionStore, ProfileManagerFactory.DEFAULT).get();
         assertTrue(action.getLocation().contains("RelayState=relayState"));
     }
 


### PR DESCRIPTION
To avoid the following error when receiving a SAML logout request:

```java
java.lang.NullPointerException: Cannot invoke "org.pac4j.core.profile.factory.ProfileManagerFactory.apply(Object, Object)" because "profileManagerFactory" is null
    at org.pac4j.core.logout.handler.DefaultLogoutHandler.destroy(DefaultLogoutHandler.java:96) ~[pac4j-core-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.core.logout.handler.DefaultLogoutHandler.destroySessionBack(DefaultLogoutHandler.java:133) ~[pac4j-core-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.core.logout.handler.DefaultLogoutHandler.destroySessionFront(DefaultLogoutHandler.java:88) ~[pac4j-core-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.saml.logout.impl.SAML2LogoutValidator.validateLogoutRequest(SAML2LogoutValidator.java:147) ~[pac4j-saml-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.saml.logout.impl.SAML2LogoutValidator.validate(SAML2LogoutValidator.java:80) ~[pac4j-saml-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.saml.profile.impl.AbstractSAML2MessageReceiver.receiveMessage(AbstractSAML2MessageReceiver.java:54) ~[pac4j-saml-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.saml.logout.impl.SAML2LogoutProfileHandler.receive(SAML2LogoutProfileHandler.java:36) ~[pac4j-saml-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.saml.credentials.extractor.SAML2CredentialsExtractor.receiveLogout(SAML2CredentialsExtractor.java:101) ~[pac4j-saml-6.0.0-RC5-SNAPSHOT.jar:?]
    at org.pac4j.saml.credentials.extractor.SAML2CredentialsExtractor.extract(SAML2CredentialsExtractor.java:68) ~[pac4j-saml-6.0.0-RC5-SNAPSHOT.jar:?]
```
