### PR TITLE
Resolve SAML2 idp metadata on initialization

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -177,6 +177,7 @@ public class SAML2Client extends IndirectClient {
 
     protected void initIdentityProviderMetadataResolver() {
         this.identityProviderMetadataResolver = this.configuration.getIdentityProviderMetadataResolver();
+        this.identityProviderMetadataResolver.resolve();
     }
 
     protected void initDecrypter() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ContextProvider.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2ContextProvider.java
@@ -56,7 +56,7 @@ public class SAML2ContextProvider implements SAMLContextProvider {
 
     @Override
     public final SAML2MessageContext buildServiceProviderContext(final CallContext ctx, final SAML2Client client) {
-        val context = new SAML2MessageContext();
+        val context = new SAML2MessageContext(ctx);
         context.setSaml2Configuration(client.getConfiguration());
         addTransportContext(ctx.webContext(), ctx.sessionStore(), context);
         addSPContext(context);
@@ -67,7 +67,6 @@ public class SAML2ContextProvider implements SAMLContextProvider {
     public SAML2MessageContext buildContext(final CallContext ctx, final SAML2Client client) {
         val context = buildServiceProviderContext(ctx, client);
         addIDPContext(context);
-        context.setCallContext(ctx);
         return context;
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
@@ -45,7 +45,7 @@ public class SAML2MessageContext {
 
     private SAML2Configuration saml2Configuration;
 
-    private CallContext callContext;
+    private final CallContext callContext;
 
     /* valid subject assertion */
     private Assertion subjectAssertion;
@@ -57,8 +57,8 @@ public class SAML2MessageContext {
 
     private SAMLMessageStore samlMessageStore;
 
-    public SAML2MessageContext() {
-        super();
+    public SAML2MessageContext(final CallContext callContext) {
+        this.callContext = callContext;
     }
 
     public SAML2ConfigurationContext getConfigurationContext() {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
@@ -1,5 +1,7 @@
 package org.pac4j.saml.profile.impl;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import net.shibboleth.shared.component.ComponentInitializationException;
 import org.opensaml.messaging.context.MessageContext;
@@ -24,8 +26,6 @@ import org.pac4j.saml.transport.Pac4jHTTPPostSimpleSignEncoder;
 import org.pac4j.saml.transport.Pac4jHTTPRedirectDeflateEncoder;
 import org.pac4j.saml.util.SAML2Utils;
 import org.pac4j.saml.util.VelocityEngineFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Common message sender.
@@ -33,23 +33,13 @@ import org.slf4j.LoggerFactory;
  * @author Jerome Leleu
  * @since 3.4.0
  */
+@RequiredArgsConstructor
+@Slf4j
 public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implements SAML2MessageSender<T> {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
-
     protected final SignatureSigningParametersProvider signatureSigningParametersProvider;
     protected final String destinationBindingType;
     protected final boolean signErrorResponses;
     protected final boolean isRequestSigned;
-
-    public AbstractSAML2MessageSender(final SignatureSigningParametersProvider signatureSigningParametersProvider,
-                                      final String destinationBindingType,
-                                      final boolean signErrorResponses,
-                                      final boolean isRequestSigned) {
-        this.signatureSigningParametersProvider = signatureSigningParametersProvider;
-        this.destinationBindingType = destinationBindingType;
-        this.signErrorResponses = signErrorResponses;
-        this.isRequestSigned = isRequestSigned;
-    }
 
     @Override
     public void sendMessage(final SAML2MessageContext context,
@@ -63,7 +53,7 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
 
         val encoder = getMessageEncoder(spDescriptor, idpssoDescriptor, context);
 
-        val outboundContext = new SAML2MessageContext();
+        val outboundContext = new SAML2MessageContext(context.getCallContext());
         outboundContext.setMessageContext(context.getMessageContext());
         outboundContext.getProfileRequestContext().setProfileId(outboundContext.getProfileRequestContext().getProfileId());
 
@@ -133,7 +123,7 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
 
             if (!destinationBindingType.equals(SAMLConstants.SAML2_REDIRECT_BINDING_URI) &&
                     mustSignRequest(spDescriptor, idpssoDescriptor)) {
-                logger.debug("Signing SAML2 outbound context...");
+                LOGGER.debug("Signing SAML2 outbound context...");
                 val handler = new
                     SAMLOutboundProtocolMessageSigningHandler();
                 handler.setSignErrorResponses(this.signErrorResponses);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/artifact/SAML2ArtifactBindingDecoder.java
@@ -12,7 +12,7 @@ import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.security.SecurityException;
 import org.opensaml.soap.client.http.PipelineFactoryHttpSOAPClient;
 import org.opensaml.soap.common.SOAPException;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.metadata.SAML2MetadataResolver;
 import org.pac4j.saml.transport.AbstractPac4jDecoder;
@@ -33,8 +33,8 @@ public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
 
     private final SOAPPipelineProvider soapPipelineProvider;
 
-    public SAML2ArtifactBindingDecoder(final WebContext context, final SAML2MetadataResolver idpMetadataResolver,
-            final SAML2MetadataResolver spMetadataResolver, final SOAPPipelineProvider soapPipelineProvider) {
+    public SAML2ArtifactBindingDecoder(final CallContext context, final SAML2MetadataResolver idpMetadataResolver,
+                                       final SAML2MetadataResolver spMetadataResolver, final SOAPPipelineProvider soapPipelineProvider) {
         super(context);
         this.idpMetadataResolver = idpMetadataResolver;
         this.spMetadataResolver = spMetadataResolver;
@@ -56,7 +56,7 @@ public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
                     idpMetadataResolver.resolve());
             roleResolver.initialize();
 
-            val messageContext = new SAML2MessageContext();
+            val messageContext = new SAML2MessageContext(getCallContext());
 
             val soapClient = new PipelineFactoryHttpSOAPClient() {
                 @SuppressWarnings("rawtypes")
@@ -71,12 +71,12 @@ public class SAML2ArtifactBindingDecoder extends AbstractPac4jDecoder {
             soapClient.setHttpClient(soapPipelineProvider.getHttpClientBuilder().buildClient());
 
             val artifactDecoder = new Pac4jHTTPArtifactDecoder();
-            artifactDecoder.setWebContext(context);
+            artifactDecoder.setCallContext(callContext);
             artifactDecoder.setSelfEntityIDResolver(new FixedEntityIdResolver(spMetadataResolver));
             artifactDecoder.setRoleDescriptorResolver(roleResolver);
             artifactDecoder.setArtifactEndpointResolver(endpointResolver);
             artifactDecoder.setPeerEntityRole(IDPSSODescriptor.DEFAULT_ELEMENT_NAME);
-            artifactDecoder.setSOAPClient(soapClient);
+            artifactDecoder.setSoapClient(soapClient);
             artifactDecoder.setParserPool(getParserPool());
             artifactDecoder.initialize();
             artifactDecoder.decode();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2WebSSOMessageSender.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.sso.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.saml.saml2.metadata.Endpoint;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
@@ -11,6 +12,7 @@ import org.pac4j.saml.profile.impl.AbstractSAML2MessageSender;
 /**
  * @author Misagh Moayyed
  */
+@Slf4j
 public class SAML2WebSSOMessageSender extends AbstractSAML2MessageSender<AuthnRequest> {
 
     public SAML2WebSSOMessageSender(final SignatureSigningParametersProvider signatureSigningParametersProvider,
@@ -24,13 +26,13 @@ public class SAML2WebSSOMessageSender extends AbstractSAML2MessageSender<AuthnRe
     protected boolean mustSignRequest(final SPSSODescriptor spDescriptor, final IDPSSODescriptor idpssoDescriptor) {
         var signOutboundContext = false;
         if (this.isRequestSigned) {
-            logger.debug("Requests are expected to be always signed before submission");
+            LOGGER.debug("Requests are expected to be always signed before submission");
             signOutboundContext = true;
         } else if (spDescriptor.isAuthnRequestsSigned()) {
-            logger.debug("The service provider metadata indicates that authn requests are signed");
+            LOGGER.debug("The service provider metadata indicates that authn requests are signed");
             signOutboundContext = true;
         } else if (idpssoDescriptor.getWantAuthnRequestsSigned()) {
-            logger.debug("The identity provider metadata indicates that authn requests may be signed");
+            LOGGER.debug("The identity provider metadata indicates that authn requests may be signed");
             signOutboundContext = true;
         }
         return signOutboundContext;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/AbstractPac4jDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/AbstractPac4jDecoder.java
@@ -2,6 +2,7 @@ package org.pac4j.saml.transport;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import lombok.Getter;
 import lombok.val;
 import net.shibboleth.shared.codec.Base64Support;
 import net.shibboleth.shared.component.ComponentInitializationException;
@@ -16,7 +17,7 @@ import org.opensaml.messaging.decoder.AbstractMessageDecoder;
 import org.opensaml.messaging.decoder.MessageDecodingException;
 import org.opensaml.saml.common.binding.SAMLBindingSupport;
 import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.slf4j.Logger;
@@ -41,23 +42,24 @@ public abstract class AbstractPac4jDecoder extends AbstractMessageDecoder {
     /** Parser pool used to deserialize the message. */
     protected ParserPool parserPool;
 
-    protected final WebContext context;
+    @Getter
+    protected final CallContext callContext;
 
-    public AbstractPac4jDecoder(final WebContext context) {
+    public AbstractPac4jDecoder(final CallContext context) {
         CommonHelper.assertNotNull("context", context);
-        this.context = context;
+        this.callContext = context;
     }
 
     protected byte[] getBase64DecodedMessage() throws MessageDecodingException {
         Optional<String> encodedMessage = Optional.empty();
         for (val parameter : SAML_PARAMETERS) {
-            encodedMessage = this.context.getRequestParameter(parameter);
+            encodedMessage = this.callContext.webContext().getRequestParameter(parameter);
             if (encodedMessage.isPresent()) {
                 break;
             }
         }
         if (!encodedMessage.isPresent()) {
-            encodedMessage = Optional.ofNullable(this.context.getRequestContent());
+            encodedMessage = Optional.ofNullable(this.callContext.webContext().getRequestContent());
             // we have a body, it may be the SAML request/response directly
             // but we also try to parse it as a list key=value where the value is the SAML request/response
             if (encodedMessage.isPresent()) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPPostDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPPostDecoder.java
@@ -8,7 +8,7 @@ import org.opensaml.saml.common.binding.SAMLBindingSupport;
 import org.opensaml.saml.common.binding.impl.SAMLSOAPDecoderBodyHandler;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.soap.soap11.Envelope;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.WebContextHelper;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.util.SAML2Utils;
@@ -24,16 +24,16 @@ import java.io.ByteArrayInputStream;
  */
 public class Pac4jHTTPPostDecoder extends AbstractPac4jDecoder {
 
-    public Pac4jHTTPPostDecoder(final WebContext context) {
+    public Pac4jHTTPPostDecoder(final CallContext context) {
         super(context);
     }
 
     @Override
     protected void doDecode() throws MessageDecodingException {
-        val messageContext = new SAML2MessageContext();
+        val messageContext = new SAML2MessageContext(callContext);
 
-        if (WebContextHelper.isPost(context)) {
-            val relayState = this.context.getRequestParameter("RelayState").orElse(null);
+        if (WebContextHelper.isPost(callContext.webContext())) {
+            val relayState = this.callContext.webContext().getRequestParameter("RelayState").orElse(null);
             logger.debug("Decoded SAML relay state of: {}", relayState);
             SAMLBindingSupport.setRelayState(messageContext.getMessageContext(), relayState);
             val base64DecodedMessage = this.getBase64DecodedMessage();

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPRedirectDeflateDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPRedirectDeflateDecoder.java
@@ -5,7 +5,7 @@ import org.opensaml.messaging.decoder.MessageDecodingException;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.common.binding.SAMLBindingSupport;
 import org.opensaml.saml.common.xml.SAMLConstants;
-import org.pac4j.core.context.WebContext;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.WebContextHelper;
 import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.util.SAML2Utils;
@@ -26,16 +26,16 @@ import java.util.zip.InflaterInputStream;
  */
 public class Pac4jHTTPRedirectDeflateDecoder extends AbstractPac4jDecoder {
 
-    public Pac4jHTTPRedirectDeflateDecoder(final WebContext context) {
+    public Pac4jHTTPRedirectDeflateDecoder(final CallContext context) {
         super(context);
     }
 
     @Override
     protected void doDecode() throws MessageDecodingException {
-        val messageContext = new SAML2MessageContext();
+        val messageContext = new SAML2MessageContext(callContext);
 
-        if (WebContextHelper.isGet(context)) {
-            val relayState = this.context.getRequestParameter("RelayState").orElse(null);
+        if (WebContextHelper.isGet(callContext.webContext())) {
+            val relayState = this.callContext.webContext().getRequestParameter("RelayState").orElse(null);
             logger.debug("Decoded SAML relay state of: {}", relayState);
             SAMLBindingSupport.setRelayState(messageContext.getMessageContext(), relayState);
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/logout/impl/SAML2LogoutValidatorTests.java
@@ -64,7 +64,7 @@ public class SAML2LogoutValidatorTests {
     }
 
     private static SAML2MessageContext getSaml2MessageContext(final MockWebContext webContext, final String xml) {
-        val context = new SAML2MessageContext();
+        val context = new SAML2MessageContext(new CallContext(webContext, new MockSessionStore()));
         context.setSaml2Configuration(getSaml2Configuration());
 
         val samlMessage = new MessageContext();
@@ -74,7 +74,6 @@ public class SAML2LogoutValidatorTests {
         context.setMessageContext(samlMessage);
         val entityDescriptor = new EntityDescriptorBuilder().buildObject();
         context.getSAMLPeerMetadataContext().setEntityDescriptor(entityDescriptor);
-        context.setCallContext(new CallContext(webContext, new MockSessionStore()));
 
         val spDescriptor = new SPSSODescriptorBuilder().buildObject();
         val logoutService = new SingleLogoutServiceBuilder().buildObject();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilderTests.java
@@ -77,11 +77,10 @@ public class SAML2AuthnRequestBuilderTests extends AbstractSAML2ClientTests {
         val spDescriptor = mock(SPSSODescriptor.class);
         when(spDescriptor.getAssertionConsumerServices()).thenReturn(Collections.singletonList(acs));
 
-        val context = new SAML2MessageContext();
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.getSAMLPeerMetadataContext().setRoleDescriptor(idpDescriptor);
         context.getSAMLSelfMetadataContext().setRoleDescriptor(spDescriptor);
         context.getSAMLSelfEntityContext().setEntityId("entity-id");
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(configuration);
         return context;
     }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -108,8 +108,7 @@ public class SAML2DefaultResponseValidatorTests {
     public void testDoesNotWantAssertionsSignedWithNullSPSSODescriptor() {
         var saml2Configuration = getSaml2Configuration(false, false);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
         assertFalse("Expected wantAssertionsSigned == false", validator.wantsAssertionsSigned(context));
@@ -119,8 +118,7 @@ public class SAML2DefaultResponseValidatorTests {
     public void testWantsAssertionsSignedWithNullSPSSODescriptor() {
         var saml2Configuration = getSaml2Configuration(true, false);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         assertNull("Expected SPSSODescriptor to be null", context.getSPSSODescriptor());
         assertTrue("Expected wantAssertionsSigned == true", validator.wantsAssertionsSigned(context));
@@ -130,8 +128,7 @@ public class SAML2DefaultResponseValidatorTests {
     public void testDoesNotWantAssertionsSignedWithValidSPSSODescriptor() {
         var saml2Configuration = getSaml2Configuration(false, false);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
 
         val samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
@@ -147,8 +144,7 @@ public class SAML2DefaultResponseValidatorTests {
     public void testWantsAssertionsSignedWithValidSPSSODescriptor() {
         var saml2Configuration = getSaml2Configuration(true, false);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
 
         val samlSelfMetadataContext = context.getSAMLSelfMetadataContext();
@@ -171,8 +167,7 @@ public class SAML2DefaultResponseValidatorTests {
         response.setSignature(null);
         response.getAssertions().get(0).setSignature(null);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         context.getMessageContext().setMessage(response);
 
@@ -204,9 +199,8 @@ public class SAML2DefaultResponseValidatorTests {
         response.setSignature(null);
         response.getAssertions().get(0).setSignature(null);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.getMessageContext().setMessage(response);
 
         val samlSelfEntityContext = context.getSAMLSelfEntityContext();
@@ -228,9 +222,8 @@ public class SAML2DefaultResponseValidatorTests {
     public void testAuthenticatedResponseAndAssertionWithoutSignatureThrowsException() {
         val saml2Configuration = getSaml2Configuration(true, false);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         val peerEntityContext = new SAMLPeerEntityContext();
         peerEntityContext.setAuthenticated(true);
         context.getMessageContext().addSubcontext(peerEntityContext);
@@ -241,8 +234,7 @@ public class SAML2DefaultResponseValidatorTests {
     public void testResponseWithoutSignatureThrowsException() {
         val saml2Configuration = getSaml2Configuration(false, false);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         val peerEntityContext = new SAMLPeerEntityContext();
         peerEntityContext.setAuthenticated(false);
@@ -265,8 +257,7 @@ public class SAML2DefaultResponseValidatorTests {
 
         var saml2Configuration = getSaml2Configuration(false, true);
         val validator = createResponseValidatorWithSigningValidationOf(saml2Configuration);
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         val peerEntityContext = new SAMLPeerEntityContext();
         peerEntityContext.setAuthenticated(true);
@@ -287,8 +278,7 @@ public class SAML2DefaultResponseValidatorTests {
         // (See SAML protocol specification, paragraph 3.2.2, line 1542)
         response.setInResponseTo(null);
 
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         context.getMessageContext().setMessage(response);
 
@@ -321,8 +311,7 @@ public class SAML2DefaultResponseValidatorTests {
         // But the default SAML configuration forbids this case.
         response.setDestination(null);
 
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         context.getMessageContext().setMessage(response);
 
@@ -356,8 +345,7 @@ public class SAML2DefaultResponseValidatorTests {
         // But this SAML configuration tolerates it.
         response.setDestination(null);
 
-        val context = new SAML2MessageContext();
-        context.setCallContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
+        val context = new SAML2MessageContext(new CallContext(MockWebContext.create(), new MockSessionStore()));
         context.setSaml2Configuration(saml2Configuration);
         context.getMessageContext().setMessage(response);
 

--- a/pac4j-saml/src/test/java/org/pac4j/saml/transport/Pac4jHTTPPostDecoderTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/transport/Pac4jHTTPPostDecoderTest.java
@@ -5,7 +5,9 @@ import net.shibboleth.shared.component.ComponentInitializationException;
 import org.junit.Test;
 import org.opensaml.messaging.decoder.MessageDecodingException;
 import org.opensaml.saml.saml2.core.impl.ResponseImpl;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.saml.util.Configuration;
 
 import java.net.URLDecoder;
@@ -99,7 +101,7 @@ public class Pac4jHTTPPostDecoderTest {
 
         webContext.setRequestMethod("POST");
         val decoder =
-            new Pac4jHTTPPostDecoder(webContext);
+            new Pac4jHTTPPostDecoder(new CallContext(webContext, new MockSessionStore()));
         val message = "SAMLResponse=" + SAML_RESPONSE
                 + "&RelayState=https%3A%2F%2Flocalhost%3A8443%2Fanzo_authenticate%3Fclient_name%3DGSAML";
 
@@ -114,7 +116,7 @@ public class Pac4jHTTPPostDecoderTest {
 
         webContext.setRequestMethod("POST");
         val decoder =
-            new Pac4jHTTPPostDecoder(webContext);
+            new Pac4jHTTPPostDecoder(new CallContext(webContext, new MockSessionStore()));
         val message = URLDecoder.decode(SAML_RESPONSE, StandardCharsets.UTF_8.name());
 
         webContext.setRequestContent(message);
@@ -128,7 +130,7 @@ public class Pac4jHTTPPostDecoderTest {
 
         webContext.setRequestMethod("POST");
         val decoder =
-            new Pac4jHTTPPostDecoder(webContext);
+            new Pac4jHTTPPostDecoder(new CallContext(webContext, new MockSessionStore()));
         val message = URLDecoder.decode(SAML_RESPONSE, StandardCharsets.UTF_8.name());
         webContext.addRequestParameter("SAMLResponse", message);
         decode(decoder);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/transport/Pac4jHTTPRedirectDeflateDecoderTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/transport/Pac4jHTTPRedirectDeflateDecoderTest.java
@@ -6,7 +6,9 @@ import org.opensaml.core.xml.util.XMLObjectSupport;
 import org.opensaml.messaging.context.MessageContext;
 import org.opensaml.saml.common.SAMLObject;
 import org.opensaml.saml.saml2.core.impl.AuthnRequestImpl;
+import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.session.MockSessionStore;
 import org.pac4j.saml.util.Configuration;
 
 import java.io.StringReader;
@@ -47,7 +49,7 @@ public class Pac4jHTTPRedirectDeflateDecoderTest {
         val message = encoder.deflateAndBase64Encode((SAMLObject) xmlObject);
 
         webContext.addRequestParameter("SAMLResponse", message);
-        val decoder = new Pac4jHTTPRedirectDeflateDecoder(webContext);
+        val decoder = new Pac4jHTTPRedirectDeflateDecoder(new CallContext(webContext, new MockSessionStore()));
         decoder.setParserPool(Configuration.getParserPool());
         decoder.initialize();
         decoder.decode();


### PR DESCRIPTION
This pull request also makes sure SAML2 message contexts always have access to an active `CallContext`, to avoid NPEs. It also removes a number of deprecated API calls from OpenSAML, and uses Lombok in certain cases instead of manual logger/getter/setter constructs. 