### PR TITLE
Adding support for ByteArrayResource in SpringResourceLoader

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/resource/SpringResourceLoader.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/resource/SpringResourceLoader.java
@@ -1,10 +1,12 @@
 package org.pac4j.core.resource;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.pac4j.core.util.InitializableObject;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 
 import java.util.concurrent.locks.ReentrantLock;
@@ -21,6 +23,7 @@ public abstract class SpringResourceLoader<M> extends InitializableObject {
     private static final long NO_LAST_MODIFIED = -1;
 
     private final ReentrantLock lock = new ReentrantLock();
+    private final AtomicBoolean byteArrayHasChanged = new AtomicBoolean(true);
     @Getter
     private long lastModified = NO_LAST_MODIFIED;
 
@@ -48,6 +51,10 @@ public abstract class SpringResourceLoader<M> extends InitializableObject {
 
     public boolean hasChanged() {
         if (resource != null) {
+            if (resource instanceof ByteArrayResource) {
+                return byteArrayHasChanged.getAndSet(false);
+            }
+
             long newLastModified;
             try {
                 newLastModified = resource.lastModified();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolverTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.saml.config.SAML2Configuration;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.UrlResource;
 
@@ -121,6 +122,20 @@ public class SAML2IdentityProviderMetadataResolverTest {
         var proxy = new Proxy(Proxy.Type.HTTP, addr);
         metadataResolver.setProxy(proxy);
         assertThrows(TechnicalException.class, () -> metadataResolver.internalLoad());
+    }
+
+    @Test
+    public void resolveMetadataFromByteArray() throws Exception {
+        var configuration = new SAML2Configuration();
+        configuration.setIdentityProviderMetadataResource(
+                new ByteArrayResource(new ClassPathResource("idp-metadata.xml").getInputStream().readAllBytes()));
+        metadataResolver = new SAML2IdentityProviderMetadataResolver(configuration);
+
+        var resolver = metadataResolver.resolve();
+        assertNotNull(resolver);
+
+        assertFalse(metadataResolver.hasChanged());
+        assertNotNull(metadataResolver.load());
     }
 
     @Test


### PR DESCRIPTION
This PR adds support to work with Spring's `ByteArrayResource`, to allow the `load()` method to read at least once the underlying byte array.

The current implementation, in fact, is catching the `FileNotFoundException` raised by `ByteArrayResource#lastModified`, thus resulting into the `hasChanged()` method always returing `false` and the `load()` method never reading the byte array.
