### PR TITLE
OIDC: allow to explicitly specify token auth methods supported by client

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -84,6 +84,9 @@ public class OidcConfiguration extends BaseClientConfiguration {
     /* client authentication method used at token End Point */
     private ClientAuthenticationMethod clientAuthenticationMethod;
 
+    /* Optional list of authentication methods supported by the client */
+    private Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods;
+
     /* The private key JWT client authentication method configuration */
     private PrivateKeyJWTClientAuthnMethodConfig privateKeyJWTClientAuthnMethodConfig;
 
@@ -266,6 +269,15 @@ public class OidcConfiguration extends BaseClientConfiguration {
 
     public void setClientAuthenticationMethod(final ClientAuthenticationMethod clientAuthenticationMethod) {
         this.clientAuthenticationMethod = clientAuthenticationMethod;
+    }
+
+    public Set<ClientAuthenticationMethod> getSupportedClientAuthenticationMethods() {
+        return supportedClientAuthenticationMethods;
+    }
+
+    public void setSupportedClientAuthenticationMethods(
+        Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
+        this.supportedClientAuthenticationMethods = supportedClientAuthenticationMethods;
     }
 
     public void setClientAuthenticationMethodAsString(final String auth) {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -94,13 +94,13 @@ public class OidcAuthenticator implements Authenticator {
                 final var _secret = new Secret(configuration.getSecret());
                 clientAuthentication = new ClientSecretBasic(_clientID, _secret);
             } else if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(chosenMethod)) {
-                final var privateKetJwtConfig = configuration.getPrivateKeyJWTClientAuthnMethodConfig();
-                assertNotNull("privateKetJwtConfig", privateKetJwtConfig);
-                final var jwsAlgo = privateKetJwtConfig.getJwsAlgorithm();
-                assertNotNull("privateKetJwtConfig.getJwsAlgorithm()", jwsAlgo);
-                final var privateKey = privateKetJwtConfig.getPrivateKey();
-                assertNotNull("privateKetJwtConfig.getPrivateKey()", privateKey);
-                final var keyID = privateKetJwtConfig.getKeyID();
+                final var privateKeyJwtConfig = configuration.getPrivateKeyJWTClientAuthnMethodConfig();
+                assertNotNull("privateKeyJwtConfig", privateKeyJwtConfig);
+                final var jwsAlgo = privateKeyJwtConfig.getJwsAlgorithm();
+                assertNotNull("privateKeyJwtConfig.getJwsAlgorithm()", jwsAlgo);
+                final var privateKey = privateKeyJwtConfig.getPrivateKey();
+                assertNotNull("privateKeyJwtConfig.getPrivateKey()", privateKey);
+                final var keyID = privateKeyJwtConfig.getKeyID();
                 try {
                     clientAuthentication = new PrivateKeyJWT(_clientID, configuration.findProviderMetadata().getTokenEndpointURI(),
                         jwsAlgo, privateKey, keyID, null);

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponseParser;
+import java.util.Set;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.session.SessionStore;
 import org.pac4j.core.credentials.Credentials;
@@ -61,23 +62,24 @@ public class OidcAuthenticator implements Authenticator {
 
         if (configuration.getSecret() != null) {
             // check authentication methods
-            final var metadataMethods = configuration.findProviderMetadata()
+            final var serverSupportedAuthMethods = configuration.findProviderMetadata()
                 .getTokenEndpointAuthMethods();
 
             final var preferredMethod = getPreferredAuthenticationMethod(configuration);
 
             final ClientAuthenticationMethod chosenMethod;
-            if (isNotEmpty(metadataMethods)) {
+            if (isNotEmpty(serverSupportedAuthMethods)) {
                 if (preferredMethod != null) {
-                    if (metadataMethods.contains(preferredMethod)) {
+                    if (serverSupportedAuthMethods.contains(preferredMethod)) {
                         chosenMethod = preferredMethod;
                     } else {
                         throw new TechnicalException(
                             "Preferred authentication method (" + preferredMethod + ") not supported "
-                                + "by provider according to provider metadata (" + metadataMethods + ").");
+                                + "by provider according to provider metadata (" + serverSupportedAuthMethods + ").");
                     }
                 } else {
-                    chosenMethod = firstSupportedMethod(metadataMethods);
+                    chosenMethod = firstSupportedMethod(serverSupportedAuthMethods,
+                        configuration.getSupportedClientAuthenticationMethods());
                 }
             } else {
                 chosenMethod = preferredMethod != null ? preferredMethod : ClientAuthenticationMethod.getDefault();
@@ -112,9 +114,8 @@ public class OidcAuthenticator implements Authenticator {
     }
 
     /**
-     * The preferred {@link ClientAuthenticationMethod} specified in the given
-     * {@link OidcConfiguration}, or <code>null</code> meaning that the a
-     * provider-supported method should be chosen.
+     * The preferred {@link ClientAuthenticationMethod} specified in the given {@link OidcConfiguration}, or <code>null</code> meaning that
+     * the a provider-supported method should be chosen.
      */
     private static ClientAuthenticationMethod getPreferredAuthenticationMethod(OidcConfiguration config) {
         final var configurationMethod = config.getClientAuthenticationMethod();
@@ -130,19 +131,22 @@ public class OidcAuthenticator implements Authenticator {
     }
 
     /**
-     * The first {@link ClientAuthenticationMethod} from the given list of
-     * methods that is supported by this implementation.
+     * The first {@link ClientAuthenticationMethod} from the given list of methods that is supported by this implementation.
      *
      * @throws TechnicalException if none of the provider-supported methods is supported.
      */
-    private static ClientAuthenticationMethod firstSupportedMethod(final List<ClientAuthenticationMethod> metadataMethods) {
+    private static ClientAuthenticationMethod firstSupportedMethod(
+        final List<ClientAuthenticationMethod> serverSupportedAuthMethods,
+        Set<ClientAuthenticationMethod> clientSupportedAuthMethods) {
+        Collection<ClientAuthenticationMethod> supportedMethods =
+            clientSupportedAuthMethods != null ? clientSupportedAuthMethods : SUPPORTED_METHODS;
         var firstSupported =
-            metadataMethods.stream().filter(SUPPORTED_METHODS::contains).findFirst();
+            serverSupportedAuthMethods.stream().filter(supportedMethods::contains).findFirst();
         if (firstSupported.isPresent()) {
             return firstSupported.get();
         } else {
             throw new TechnicalException("None of the Token endpoint provider metadata authentication methods are supported: " +
-                metadataMethods);
+                serverSupportedAuthMethods);
         }
     }
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticatorTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticatorTest.java
@@ -1,0 +1,80 @@
+package org.pac4j.oidc.credentials.authenticator;
+
+import static org.junit.Assert.assertEquals;
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.SubjectType;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+
+public class OidcAuthenticatorTest {
+
+
+    @Test
+    public void shouldUseFirstServerSupportedAuthMethod() throws URISyntaxException {
+        OidcConfiguration configuration = new OidcConfiguration();
+        configuration.setClientId("clientId");
+        configuration.setSecret("secret");
+
+        OIDCProviderMetadata providerMetadata = getOidcProviderMetadata(
+            List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST, ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+        configuration.setProviderMetadata(providerMetadata);
+
+        OidcAuthenticator oidcAuthenticator = new OidcAuthenticator(configuration, new OidcClient(configuration));
+
+        assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_POST, oidcAuthenticator.getClientAuthentication().getMethod());
+    }
+
+    @Test
+    public void shouldRespectClientSupportedAuthMethod() throws URISyntaxException {
+        OidcConfiguration configuration = new OidcConfiguration();
+        configuration.setClientId("clientId");
+        configuration.setSecret("secret");
+        configuration.setSupportedClientAuthenticationMethods(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+
+        OIDCProviderMetadata providerMetadata = getOidcProviderMetadata(
+            List.of(ClientAuthenticationMethod.PRIVATE_KEY_JWT, ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+        configuration.setProviderMetadata(providerMetadata);
+
+        OidcAuthenticator oidcAuthenticator = new OidcAuthenticator(configuration, new OidcClient(configuration));
+
+        assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_BASIC, oidcAuthenticator.getClientAuthentication().getMethod());
+    }
+
+    @Test
+    public void shouldFailInCaseOfNoCommonAuthMethod() throws URISyntaxException {
+        OidcConfiguration configuration = new OidcConfiguration();
+        configuration.setClientId("clientId");
+        configuration.setSecret("secret");
+        configuration.setSupportedClientAuthenticationMethods(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+
+        OIDCProviderMetadata providerMetadata = getOidcProviderMetadata(List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
+        configuration.setProviderMetadata(providerMetadata);
+
+        try {
+            new OidcAuthenticator(configuration, new OidcClient(configuration));
+            Assert.fail("TechnicalException expected");
+        } catch (TechnicalException e) {
+            assertEquals("None of the Token endpoint provider metadata authentication methods are supported: [client_secret_post]",
+                e.getMessage());
+        }
+
+    }
+
+
+    private static OIDCProviderMetadata getOidcProviderMetadata(List<ClientAuthenticationMethod> supportedClientAuthenticationMethods)
+        throws URISyntaxException {
+        OIDCProviderMetadata providerMetadata = new OIDCProviderMetadata(new Issuer("issuer"), List.of(SubjectType.PUBLIC), new URI(""));
+        providerMetadata.setTokenEndpointAuthMethods(supportedClientAuthenticationMethods);
+        return providerMetadata;
+    }
+}

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticatorTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticatorTest.java
@@ -16,6 +16,10 @@ import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 
+/**
+ * @author Mathias Loesch
+ * @since 5.7.1
+ */
 public class OidcAuthenticatorTest {
 
 


### PR DESCRIPTION
Background: solely relying on the first auth method supported by the server can be problematic in case the first method is e.g. `PRIVATE_KEY_JWT`, which requires a private key to be present on the client, which may not be the case.

With this change, we allow to optionally also specify a list of auth methods supported by the client. If present, it will be respected when selecting the first supported auth method from the list returned by the IDP.