### PR TITLE
OIDC: allow to explicitly specify token auth methods supported by client

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -91,6 +91,9 @@ public class OidcConfiguration extends BaseClientConfiguration {
     /* client authentication method used at token End Point */
     private ClientAuthenticationMethod clientAuthenticationMethod;
 
+    /* Optional list of authentication methods supported by the client */
+    private Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods;
+
     /* The private key JWT client authentication method configuration */
     private PrivateKeyJWTClientAuthnMethodConfig privateKeyJWTClientAuthnMethodConfig;
 
@@ -217,6 +220,15 @@ public class OidcConfiguration extends BaseClientConfiguration {
 
     public void setClientAuthenticationMethodAsString(final String auth) {
         this.clientAuthenticationMethod = ClientAuthenticationMethod.parse(auth);
+    }
+
+    public Set<ClientAuthenticationMethod> getSupportedClientAuthenticationMethods() {
+        return supportedClientAuthenticationMethods;
+    }
+
+    public void setSupportedClientAuthenticationMethods(
+        Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
+        this.supportedClientAuthenticationMethods = supportedClientAuthenticationMethods;
     }
 
     public CodeChallengeMethod findPkceMethod() {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
@@ -130,13 +130,13 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
                 val _secret = new Secret(configuration.getSecret());
                 return new ClientSecretBasic(_clientID, _secret);
             } else if (ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(chosenMethod)) {
-                val privateKetJwtConfig = configuration.getPrivateKeyJWTClientAuthnMethodConfig();
-                assertNotNull("privateKetJwtConfig", privateKetJwtConfig);
-                val jwsAlgo = privateKetJwtConfig.getJwsAlgorithm();
-                assertNotNull("privateKetJwtConfig.getJwsAlgorithm()", jwsAlgo);
-                val privateKey = privateKetJwtConfig.getPrivateKey();
-                assertNotNull("privateKetJwtConfig.getPrivateKey()", privateKey);
-                val keyID = privateKetJwtConfig.getKeyID();
+                val privateKeyJwtConfig = configuration.getPrivateKeyJWTClientAuthnMethodConfig();
+                assertNotNull("privateKeyJwtConfig", privateKeyJwtConfig);
+                val jwsAlgo = privateKeyJwtConfig.getJwsAlgorithm();
+                assertNotNull("privateKeyJwtConfig.getJwsAlgorithm()", jwsAlgo);
+                val privateKey = privateKeyJwtConfig.getPrivateKey();
+                assertNotNull("privateKeyJwtConfig.getPrivateKey()", privateKey);
+                val keyID = privateKeyJwtConfig.getKeyID();
                 try {
                     return new PrivateKeyJWT(_clientID, this.loaded.getTokenEndpointURI(), jwsAlgo, privateKey, keyID, null);
                 } catch (final JOSEException e) {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
@@ -6,6 +6,7 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.*;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.util.Set;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -99,22 +100,22 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
 
         if (configuration.getSecret() != null) {
             // check authentication methods
-            val metadataMethods = this.loaded.getTokenEndpointAuthMethods();
-
+            val serverSupportedAuthMethods = this.loaded.getTokenEndpointAuthMethods();
             val preferredMethod = getPreferredAuthenticationMethod(configuration);
 
             final ClientAuthenticationMethod chosenMethod;
-            if (isNotEmpty(metadataMethods)) {
+            if (isNotEmpty(serverSupportedAuthMethods)) {
                 if (preferredMethod != null) {
-                    if (metadataMethods.contains(preferredMethod)) {
+                    if (serverSupportedAuthMethods.contains(preferredMethod)) {
                         chosenMethod = preferredMethod;
                     } else {
                         throw new TechnicalException(
                             "Preferred authentication method (" + preferredMethod + ") not supported "
-                                + "by provider according to provider metadata (" + metadataMethods + ").");
+                                + "by provider according to provider metadata (" + serverSupportedAuthMethods + ").");
                     }
                 } else {
-                    chosenMethod = firstSupportedMethod(metadataMethods);
+                    chosenMethod = firstSupportedMethod(serverSupportedAuthMethods,
+                        configuration.getSupportedClientAuthenticationMethods());
                 }
             } else {
                 chosenMethod = preferredMethod != null ? preferredMethod : ClientAuthenticationMethod.getDefault();
@@ -161,14 +162,18 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
         return configurationMethod;
     }
 
-    private ClientAuthenticationMethod firstSupportedMethod(final List<ClientAuthenticationMethod> metadataMethods) {
+    private static ClientAuthenticationMethod firstSupportedMethod(
+        final List<ClientAuthenticationMethod> serverSupportedAuthMethods,
+        Set<ClientAuthenticationMethod> clientSupportedAuthMethods) {
+        Collection<ClientAuthenticationMethod> supportedMethods =
+            clientSupportedAuthMethods != null ? clientSupportedAuthMethods : SUPPORTED_METHODS;
         var firstSupported =
-            metadataMethods.stream().filter(SUPPORTED_METHODS::contains).findFirst();
+            serverSupportedAuthMethods.stream().filter(supportedMethods::contains).findFirst();
         if (firstSupported.isPresent()) {
             return firstSupported.get();
         } else {
             throw new TechnicalException("None of the Token endpoint provider metadata authentication methods are supported: " +
-                metadataMethods);
+                serverSupportedAuthMethods);
         }
     }
 }

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTest.java
@@ -1,0 +1,93 @@
+package org.pac4j.oidc.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.SubjectType;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+import org.pac4j.core.exception.TechnicalException;
+import org.pac4j.oidc.config.OidcConfiguration;
+
+/**
+ * @author Mathias Loesch
+ * @since 6.0.0
+ */
+public class OidcOpMetadataResolverTest {
+
+    public static final JWSAlgorithm JWS_ALGORITHM = JWSAlgorithm.HS256;
+
+    @Test
+    public void shouldUseFirstServerSupportedAuthMethod() throws URISyntaxException {
+        OidcConfiguration configuration = getOidcConfiguration(null);
+
+        OidcOpMetadataResolver metadataResolver = getMetadataResolver(configuration,
+            List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST, ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+
+        assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_POST, metadataResolver.getClientAuthentication().getMethod());
+    }
+
+    @Test
+    public void shouldRespectClientSupportedAuthMethod() throws URISyntaxException {
+        OidcConfiguration configuration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+
+        OidcOpMetadataResolver metadataResolver = getMetadataResolver(configuration,
+            List.of(ClientAuthenticationMethod.PRIVATE_KEY_JWT, ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+
+        assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_BASIC, metadataResolver.getClientAuthentication().getMethod());
+    }
+
+    @Test
+    public void shouldFailInCaseOfNoCommonAuthMethod() throws URISyntaxException {
+        OidcConfiguration oidcConfiguration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+
+        try {
+            getMetadataResolver(oidcConfiguration, List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
+            Assert.fail("TechnicalException expected");
+        } catch (TechnicalException e) {
+            assertEquals("None of the Token endpoint provider metadata authentication methods are supported: [client_secret_post]",
+                e.getMessage());
+        }
+    }
+
+    private static OidcConfiguration getOidcConfiguration(Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
+        OidcConfiguration configuration = new OidcConfiguration();
+        configuration.setClientId("clientId");
+        configuration.setSecret("secret");
+        configuration.setDiscoveryURI("test");
+        configuration.setPreferredJwsAlgorithm(JWS_ALGORITHM);
+        configuration.setSupportedClientAuthenticationMethods(supportedClientAuthenticationMethods);
+        return configuration;
+    }
+
+    private static OidcOpMetadataResolver getMetadataResolver(OidcConfiguration configuration,
+        List<ClientAuthenticationMethod> supportedAuthMethods) throws URISyntaxException {
+        OIDCProviderMetadata providerMetadata = getOidcProviderMetadata(supportedAuthMethods);
+        OidcOpMetadataResolver oidcOpMetadataResolver = new OidcOpMetadataResolver(configuration) {
+            @Override
+            protected OIDCProviderMetadata retrieveMetadata() {
+                return providerMetadata;
+            }
+        };
+
+        oidcOpMetadataResolver.init();
+        return oidcOpMetadataResolver;
+    }
+
+    private static OIDCProviderMetadata getOidcProviderMetadata(List<ClientAuthenticationMethod> supportedClientAuthenticationMethods)
+        throws URISyntaxException {
+        OIDCProviderMetadata providerMetadata = new OIDCProviderMetadata(new Issuer("issuer"), List.of(SubjectType.PUBLIC), new URI(""));
+        providerMetadata.setIDTokenJWSAlgs(List.of(JWS_ALGORITHM));
+        providerMetadata.setTokenEndpointAuthMethods(supportedClientAuthenticationMethods);
+        return providerMetadata;
+    }
+
+
+}


### PR DESCRIPTION
Background: solely relying on the first auth method supported by the server can be problematic in case the first method is e.g. PRIVATE_KEY_JWT, which requires a private key to be present on the client, which may not be the case.

With this change, we allow to optionally also specify a list of auth methods supported by the client. If present, it will be respected when selecting the first supported auth method from the list returned by the IDP.

Note: this PR is porting #2507 to the master branch