### PR TITLE
Initialize SAMLOutboundProtocolMessageSigningHandler before invoke

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
@@ -146,6 +146,7 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
                 LOGGER.debug("Signing SAML2 outbound context...");
                 val handler = new
                     SAMLOutboundProtocolMessageSigningHandler();
+                handler.initialize();
                 handler.setSignErrorResponses(this.signErrorResponses);
                 handler.invoke(messageContext);
             }


### PR DESCRIPTION
Avoids

```
org.pac4j.saml.exceptions.SAMLException: net.shibboleth.shared.component.UninitializedComponentException: Unidentified Component has not yet been initialized and cannot be used.
        at org.pac4j.saml.profile.impl.AbstractSAML2MessageSender.invokeOutboundMessageHandlers(AbstractSAML2MessageSender.java:153) ~[pac4j-saml-6.0.0-RC6.jar!/:?]
```