### PR TITLE
Initialize SAMLOutboundProtocolMessageSigningHandler after setSignErrorResponses

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java
@@ -146,8 +146,8 @@ public abstract class AbstractSAML2MessageSender<T extends SAMLObject> implement
                 LOGGER.debug("Signing SAML2 outbound context...");
                 val handler = new
                     SAMLOutboundProtocolMessageSigningHandler();
-                handler.initialize();
                 handler.setSignErrorResponses(this.signErrorResponses);
+                handler.initialize();
                 handler.invoke(messageContext);
             }
         } catch (final Exception e) {


### PR DESCRIPTION
Following up #2565 , now avoiding the following exception

```
net.shibboleth.shared.component.UnmodifiableComponentException: Unidentified Component has already been initialized and can no longer be modified
        at net.shibboleth.shared.component.AbstractInitializableComponent.ifInitializedThrowUnmodifiabledComponentException(AbstractInitializableComponent.java:94) ~[shib-support-9.0.0-SNAPSHOT.jar!/:?]
        at net.shibboleth.shared.component.AbstractInitializableComponent.checkSetterPreconditions(AbstractInitializableComponent.java:104) ~[shib-support-9.0.0-SNAPSHOT.jar!/:?]
        at org.opensaml.saml.common.binding.security.impl.SAMLOutboundProtocolMessageSigningHandler.setSignErrorResponses(SAMLOutboundProtocolMessageSigningHandler.java:62) ~[opensaml-saml-impl-5.0.0-SNAPSHOT.jar!/:?]
        at org.pac4j.saml.profile.impl.AbstractSAML2MessageSender.invokeOutboundMessageHandlers(AbstractSAML2MessageSender.java:150) ~[pac4j-saml-6.0.0-RC7-SNAPSHOT.jar!/:?]
        at org.pac4j.saml.profile.impl.AbstractSAML2MessageSender.sendMessage(AbstractSAML2MessageSender.java:82) ~[pac4j-saml-6.0.0-RC7-SNAPSHOT.jar!/:?]
```

This time the full SAML login / logout process was completed to ensure no more unwanted calls are around.
Sorry for not checking completely before.