### PR TITLE
Using HTTP-POST binding with signing causes UninitializedComponentException

### DIFF
--- a/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/client/PostSAML2ClientTests.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Collections;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -101,6 +102,16 @@ public final class PostSAML2ClientTests extends AbstractSAML2ClientTests {
         sessionStore.set(context, SAML2StateGenerator.SAML_RELAY_STATE_ATTRIBUTE, "relayState");
         val action = (OkAction) client.getRedirectionAction(new CallContext(context, sessionStore)).get();
         assertTrue(action.getContent().contains("<input type=\"hidden\" name=\"RelayState\" value=\"relayState\"/>"));
+    }
+
+    @Test
+    public void testPostDestinationBindingWithRequestSignedWorks() {
+        val client = getClient();
+        client.getConfiguration().setAuthnRequestBindingType(SAMLConstants.SAML2_POST_BINDING_URI);
+        client.getConfiguration().setAuthnRequestSigned(true);
+
+        val action = (OkAction) client.getRedirectionAction(new CallContext(MockWebContext.create(), new MockSessionStore())).get();
+        assertFalse(getDecodedAuthnRequest(action.getContent()).isBlank());
     }
 
     @Override


### PR DESCRIPTION
Hello everyone! This unit test shows there is a problem in pac4j-saml. The message encoder is initialized in line 85, but is already used in line 82 when using a HTTP-POST binding along with authn signing: https://github.com/pac4j/pac4j/blob/9afab79fe48d54be388c382a775421935541d3a6/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2MessageSender.java#L82

I'm not sure how to fix this best. Do you have any suggestions?