### PR TITLE
Prevent NPE if oidcCredentials is null

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -148,7 +148,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
                 }
             }
 
-            if (oidcCredentials != null && oconfiguration.isIncludeAccessTokenClaimsInProfile()) {
+            if (oidcCredentials != null && configuration.isIncludeAccessTokenClaimsInProfile()) {
                 collectClaimsFromAccessTokenIfAny(oidcCredentials, nonce, profile);
             }
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -148,7 +148,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
                 }
             }
 
-            if (configuration.isIncludeAccessTokenClaimsInProfile()) {
+            if (oidcCredentials != null && oconfiguration.isIncludeAccessTokenClaimsInProfile()) {
                 collectClaimsFromAccessTokenIfAny(oidcCredentials, nonce, profile);
             }
 


### PR DESCRIPTION
Quick fix to Prevent NPE if oidcCredentials is null and isIncludeAccessTokenClaimsInProfile is true
