### PR TITLE
Allow serializing oidc credentials/profile into JSON

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -26,7 +26,7 @@ title: Release notes&#58;
 - Renamed the `LogoutHandler` as `SessionLogoutHandler`
 - Created the `SpringResourceLoader` for OIDC/SAML metadata loading: for the OIDC support, the `discoveryURI` can use the "file:", "classpath:" or "resource:" prefix in addition to HTTP/HTTPS URLs
 - The `DefaultSessionLogoutHandler` smartly tries a front channel logout and then a back channel logout
-
+- The `OidcProfile` will internally encode/decode codes, access and refresh tokens. Asking the profile to return back the actual object will effectively reconstruct it, to avoid  issues with JSON serialization.
 ---
 
 ### JDK11:

--- a/pac4j-core/pom.xml
+++ b/pac4j-core/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
@@ -1,5 +1,6 @@
 package org.pac4j.core.credentials;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -35,6 +36,7 @@ public abstract class Credentials implements Serializable {
      *
      * @return a boolean
      */
+    @JsonIgnore
     public boolean isForAuthentication() {
         return logoutType == null;
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
@@ -345,7 +345,7 @@ public class BasicUserProfile implements UserProfile, Externalizable {
         return getAttributeByType(name, clazz, attribute);
     }
 
-    private <T> T getAttributeByType(final String name, final Class<T> clazz, final Object attribute) {
+    private static <T> T getAttributeByType(final String name, final Class<T> clazz, final Object attribute) {
 
         if (attribute == null) {
             return null;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
@@ -1,5 +1,6 @@
 package org.pac4j.core.profile;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Streams;
 import lombok.Getter;
 import lombok.Setter;
@@ -115,6 +116,7 @@ public class BasicUserProfile implements UserProfile, Externalizable {
      * This identifier is unique through all providers.
      */
     @Override
+    @JsonIgnore
     public String getTypedId() {
         return this.getClass().getName() + Pac4jConstants.TYPED_ID_SEPARATOR + this.id;
     }
@@ -125,8 +127,7 @@ public class BasicUserProfile implements UserProfile, Externalizable {
         return null;
     }
 
-    private void addAttributeToMap(final Map<String, Object> map, final String key, final Object value)
-    {
+    private void addAttributeToMap(final Map<String, Object> map, final String key, final Object value) {
         if (value != null) {
             logger.debug("adding => key: {} / value: {} / {}", key, value, value.getClass());
             var valueForMap = getValueForMap(map, key, value);
@@ -154,28 +155,16 @@ public class BasicUserProfile implements UserProfile, Externalizable {
         return this.canAttributesBeMerged && preparedValue instanceof Collection && map.get(key) instanceof Collection;
     }
 
-    private <T> Collection<T> mergeCollectionAttributes(final Collection<T> existingCollection, final Collection<T> newCollection)
+    private static <T> Collection<T> mergeCollectionAttributes(final Collection<T> existingCollection, final Collection<T> newCollection)
     {
         return Streams.concat(existingCollection.stream(), newCollection.stream()).collect(Collectors.toList());
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * Add an attribute.
-     *
-     * If existing attribute value is collection and the new value is collection - merge the collections
-     */
     @Override
     public void addAttribute(final String key, final Object value) {
         addAttributeToMap(this.attributes, key, value);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * Add an authentication-related attribute
-     */
     @Override
     public void addAuthenticationAttribute(final String key, final Object value) {
         addAttributeToMap(this.authenticationAttributes, key, value);

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/CommonProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/CommonProfile.java
@@ -1,5 +1,6 @@
 package org.pac4j.core.profile;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.ToString;
 import lombok.val;
 import org.pac4j.core.profile.definition.CommonProfileDefinition;
@@ -45,6 +46,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the email of the user
      */
+    @JsonIgnore
     public String getEmail() {
         return getAttributeAsString(CommonProfileDefinition.EMAIL);
     }
@@ -54,6 +56,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the first name of the user
      */
+    @JsonIgnore
     public String getFirstName() {
         return getAttributeAsString(CommonProfileDefinition.FIRST_NAME);
     }
@@ -63,6 +66,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the family name of the user
      */
+    @JsonIgnore
     public String getFamilyName() {
         return getAttributeAsString(CommonProfileDefinition.FAMILY_NAME);
     }
@@ -72,6 +76,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the displayed name of the user
      */
+    @JsonIgnore
     public String getDisplayName() {
         return getAttributeAsString(CommonProfileDefinition.DISPLAY_NAME);
     }
@@ -81,6 +86,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * Return the username of the user. It can be a login or a specific username.
      */
+    @JsonIgnore
     @Override
     public String getUsername() {
         return getAttributeAsString(Pac4jConstants.USERNAME);
@@ -91,6 +97,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the gender of the user
      */
+    @JsonIgnore
     public Gender getGender() {
         return getAttributeAsType(CommonProfileDefinition.GENDER, Gender.class, Gender.UNSPECIFIED);
     }
@@ -100,6 +107,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the locale of the user
      */
+    @JsonIgnore
     public Locale getLocale() {
         return getAttributeAsType(CommonProfileDefinition.LOCALE, Locale.class, null);
     }
@@ -109,6 +117,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the url of the picture of the user.
      */
+    @JsonIgnore
     public URI getPictureUrl() {
         return getAttributeAsType(CommonProfileDefinition.PICTURE_URL, URI.class, null);
     }
@@ -118,6 +127,7 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the url of the profile of the user.
      */
+    @JsonIgnore
     public URI getProfileUrl() {
         return getAttributeAsType(CommonProfileDefinition.PROFILE_URL, URI.class, null);
     }
@@ -127,11 +137,12 @@ public class CommonProfile extends BasicUserProfile {
      *
      * @return the location of the user
      */
+    @JsonIgnore
     public String getLocation() {
         return getAttributeAsString(CommonProfileDefinition.LOCATION);
     }
 
-    /** {@inheritDoc} */
+    @JsonIgnore
     @Override
     public boolean isExpired() {
         return false;

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/jwt/AbstractJwtProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/jwt/AbstractJwtProfile.java
@@ -1,5 +1,6 @@
 package org.pac4j.core.profile.jwt;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.ToString;
 import org.pac4j.core.profile.CommonProfile;
 
@@ -19,56 +20,32 @@ public abstract class AbstractJwtProfile extends CommonProfile {
     @Serial
     private static final long serialVersionUID = -6146872796913837767L;
 
-    /**
-     * <p>getSubject.</p>
-     *
-     * @return a {@link String} object
-     */
+    @JsonIgnore
     public String getSubject() {
         return getId();
     }
 
-    /**
-     * <p>getIssuer.</p>
-     *
-     * @return a {@link String} object
-     */
+    @JsonIgnore
     public String getIssuer() {
         return (String) getAttribute(JwtClaims.ISSUER);
     }
 
-    /**
-     * <p>getAudience.</p>
-     *
-     * @return a {@link List} object
-     */
+    @JsonIgnore
     public List<String> getAudience() {
         return extractAttributeValues(JwtClaims.AUDIENCE);
     }
 
-    /**
-     * <p>getExpirationDate.</p>
-     *
-     * @return a {@link Date} object
-     */
+    @JsonIgnore
     public Date getExpirationDate() {
         return (Date) getAttribute(JwtClaims.EXPIRATION_TIME);
     }
 
-    /**
-     * <p>getNotBefore.</p>
-     *
-     * @return a {@link Date} object
-     */
+    @JsonIgnore
     public Date getNotBefore() {
         return (Date) getAttribute(JwtClaims.NOT_BEFORE);
     }
 
-    /**
-     * <p>getIssuedAt.</p>
-     *
-     * @return a {@link Date} object
-     */
+    @JsonIgnore
     public Date getIssuedAt() {
         return (Date) getAttribute(JwtClaims.ISSUED_AT);
     }

--- a/pac4j-jwt/pom.xml
+++ b/pac4j-jwt/pom.xml
@@ -30,6 +30,10 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>${bcprov.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
         <!-- for testing -->
         <dependency>
             <groupId>org.pac4j</groupId>

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -78,7 +78,7 @@ public class OidcClient extends IndirectClient {
         val refreshToken = oidcProfile.getRefreshToken();
         if (refreshToken != null) {
             val credentials = new OidcCredentials();
-            credentials.setRefreshToken(refreshToken);
+            credentials.setRefreshToken(refreshToken.toJSONObject());
             val authenticator = new OidcAuthenticator(getConfiguration(), this);
             authenticator.refresh(credentials);
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
@@ -1,38 +1,20 @@
 package org.pac4j.oidc.credentials;
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
-import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.val;
 import net.minidev.json.JSONObject;
 import org.pac4j.core.credentials.Credentials;
 
-import java.io.IOException;
 import java.io.Serial;
+import java.util.Map;
 
 /**
  * Credentials containing the authorization code sent by the OpenID Connect server.
@@ -51,218 +33,43 @@ public class OidcCredentials extends Credentials {
     private static final long serialVersionUID = 6772331801527223938L;
 
     @EqualsAndHashCode.Include
-    @JsonSerialize(using = ToStringSerializer.class)
-    @JsonDeserialize(using = AuthorizationCodeDeserializer.class)
-    private AuthorizationCode code;
+    private String code;
 
-    @JsonSerialize(using = AccessTokenSerializer.class)
-    @JsonDeserialize(using = AccessTokenDeserializer.class)
-    private AccessToken accessToken;
+    private Map<String, ?> accessToken;
 
-    @JsonSerialize(using = RefreshTokenSerializer.class)
-    @JsonDeserialize(using = RefreshTokenDeserializer.class)
-    private RefreshToken refreshToken;
+    private Map<String, ?> refreshToken;
 
-    @JsonSerialize(using = JWTSerializer.class)
-    @JsonDeserialize(using = JWTDeserializer.class)
-    private JWT idToken;
+    private String idToken;
 
-    static class JWTSerializer extends ToStringSerializerBase {
+    @JsonIgnore
+    public AuthorizationCode toAuthorizationCode() {
+        return code != null ? new AuthorizationCode(this.code) : null;
+    }
 
-        public JWTSerializer() {
-            super(JWT.class);
-        }
-
-        @Override
-        public String valueToString(final Object value) {
-            return ((JWT) value).serialize();
-        }
-
-        @Override
-        public void serializeWithType(final Object value, JsonGenerator jgen,
-                                      SerializerProvider provider, TypeSerializer typeSer) throws IOException {
-            val typeId = typeSer.typeId(value, JsonToken.START_OBJECT);
-            typeSer.writeTypePrefix(jgen, typeId);
-            jgen.writeStringField("value", ((JWT) value).serialize());
-            typeId.wrapperWritten = !jgen.canWriteTypeId();
-            typeSer.writeTypeSuffix(jgen, typeId);
+    @JsonIgnore
+    public AccessToken toAccessToken() {
+        try {
+            return accessToken != null ? AccessToken.parse(new JSONObject(accessToken)) : null;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
         }
     }
 
-    static class RefreshTokenSerializer extends StdSerializer<RefreshToken> {
-        public RefreshTokenSerializer() {
-            this(null);
-        }
-
-        public RefreshTokenSerializer(final Class<RefreshToken> t) {
-            super(t);
-        }
-
-        @Override
-        public void serialize(final RefreshToken refreshToken, final JsonGenerator jsonGenerator,
-                              final SerializerProvider serializerProvider) throws IOException {
-            jsonGenerator.writeObject(refreshToken.toJSONObject());
-        }
-
-        @Override
-        public void serializeWithType(final RefreshToken accessToken,
-                                      final JsonGenerator jgen,
-                                      final SerializerProvider provider,
-                                      final TypeSerializer typeSer) throws IOException {
-            val typeId = typeSer.typeId(accessToken, JsonToken.START_OBJECT);
-            typeSer.writeTypePrefix(jgen, typeId);
-            accessToken.toJSONObject().forEach((name, value) -> {
-                try {
-                    jgen.writeObjectField(name, value);
-                } catch (final IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            typeId.wrapperWritten = !jgen.canWriteTypeId();
-            typeSer.writeTypeSuffix(jgen, typeId);
+    @JsonIgnore
+    public RefreshToken toRefreshToken() {
+        try {
+            return refreshToken != null ? RefreshToken.parse(new JSONObject(refreshToken)) : null;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
         }
     }
 
-    static class AccessTokenSerializer extends StdSerializer<AccessToken> {
-        public AccessTokenSerializer() {
-            this(null);
-        }
-
-        public AccessTokenSerializer(final Class<AccessToken> t) {
-            super(t);
-        }
-
-        @Override
-        public void serialize(final AccessToken accessToken, final JsonGenerator jsonGenerator,
-                              final SerializerProvider serializerProvider) throws IOException {
-            jsonGenerator.writeObject(accessToken.toJSONObject());
-        }
-
-        @Override
-        public void serializeWithType(final AccessToken accessToken,
-                                      final JsonGenerator jgen,
-                                      final SerializerProvider provider,
-                                      final TypeSerializer typeSer) throws IOException {
-            val typeId = typeSer.typeId(accessToken, JsonToken.START_OBJECT);
-            typeSer.writeTypePrefix(jgen, typeId);
-            accessToken.toJSONObject().forEach((name, value) -> {
-                try {
-                    jgen.writeObjectField(name, value);
-                } catch (final IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-            typeId.wrapperWritten = !jgen.canWriteTypeId();
-            typeSer.writeTypeSuffix(jgen, typeId);
+    @JsonIgnore
+    public JWT toIdToken() {
+        try {
+            return idToken != null ? JWTParser.parse(this.idToken) : null;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
         }
     }
-
-
-    static class AuthorizationCodeDeserializer extends StdDeserializer<AuthorizationCode> {
-
-        protected AuthorizationCodeDeserializer() {
-            super(AuthorizationCode.class);
-        }
-
-        protected AuthorizationCodeDeserializer(final JavaType valueType) {
-            super(valueType);
-        }
-
-        @Override
-        public AuthorizationCode deserialize(final JsonParser jsonParser,
-                                             final DeserializationContext deserializationContext) throws IOException {
-            val node = (JsonNode) jsonParser.getCodec().readTree(jsonParser);
-            return new AuthorizationCode(node.asText());
-        }
-    }
-
-    static class RefreshTokenDeserializer extends StdDeserializer<RefreshToken> {
-
-        protected RefreshTokenDeserializer() {
-            super(AuthorizationCode.class);
-        }
-
-        protected RefreshTokenDeserializer(final JavaType valueType) {
-            super(valueType);
-        }
-
-        @Override
-        public RefreshToken deserialize(final JsonParser jsonParser,
-                                        final DeserializationContext deserializationContext) throws IOException {
-            final JsonNode node = jsonParser.getCodec().readTree(jsonParser);
-            return new RefreshToken(node.asText());
-        }
-    }
-
-    static class JWTDeserializer extends StdDeserializer<JWT> {
-
-        protected JWTDeserializer() {
-            super(JWT.class);
-        }
-
-        protected JWTDeserializer(final JavaType valueType) {
-            super(valueType);
-        }
-
-        @Override
-        public JWT deserialize(final JsonParser jsonParser,
-                               final DeserializationContext deserializationContext) throws IOException {
-            try {
-                final JsonNode node = jsonParser.getCodec().readTree(jsonParser);
-                return JWTParser.parse(node.asText());
-            } catch (final Exception e) {
-                throw new IOException(e);
-            }
-        }
-
-        @Override
-        public Object deserializeWithType(final JsonParser jp, final DeserializationContext ctxt,
-                                          final TypeDeserializer typeDeserializer) throws IOException {
-            try {
-                val node = (JsonNode) jp.getCodec().readTree(jp);
-                val objectMapper = new ObjectMapper();
-                val jsonObject = objectMapper.readValue(node.get(1).toString(), JSONObject.class);
-                return JWTParser.parse(jsonObject.get("value").toString());
-            } catch (final Exception e) {
-                throw new IOException(e);
-            }
-        }
-    }
-
-    static class AccessTokenDeserializer extends StdDeserializer<AccessToken> {
-
-        protected AccessTokenDeserializer() {
-            super(AccessToken.class);
-        }
-
-        protected AccessTokenDeserializer(final JavaType valueType) {
-            super(valueType);
-        }
-
-        @Override
-        public AccessToken deserialize(final JsonParser jsonParser,
-                                       final DeserializationContext deserializationContext) throws IOException {
-            try {
-                val objectMapper = new ObjectMapper();
-                val jsonObject = objectMapper.readValue(jsonParser, JSONObject.class);
-                return AccessToken.parse(jsonObject);
-            } catch (ParseException e) {
-                throw new RuntimeException(e);
-            }
-        }
-
-        @Override
-        public Object deserializeWithType(final JsonParser jsonParser, final DeserializationContext deserializationContext,
-                                          final TypeDeserializer typeDeserializer) throws IOException, JacksonException {
-            try {
-                val node = (JsonNode) jsonParser.getCodec().readTree(jsonParser);
-                val objectMapper = new ObjectMapper();
-                val jsonObject = objectMapper.readValue(node.get(1).toString(), JSONObject.class);
-                return AccessToken.parse(jsonObject);
-            } catch (ParseException e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
@@ -1,15 +1,37 @@
 package org.pac4j.oidc.credentials;
 
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializerBase;
 import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.val;
+import net.minidev.json.JSONObject;
 import org.pac4j.core.credentials.Credentials;
 
+import java.io.IOException;
 import java.io.Serial;
 
 /**
@@ -22,15 +44,225 @@ import java.io.Serial;
 @Getter
 @Setter
 @ToString
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
 public class OidcCredentials extends Credentials {
 
     @Serial
     private static final long serialVersionUID = 6772331801527223938L;
 
     @EqualsAndHashCode.Include
+    @JsonSerialize(using = ToStringSerializer.class)
+    @JsonDeserialize(using = AuthorizationCodeDeserializer.class)
     private AuthorizationCode code;
+
+    @JsonSerialize(using = AccessTokenSerializer.class)
+    @JsonDeserialize(using = AccessTokenDeserializer.class)
     private AccessToken accessToken;
+
+    @JsonSerialize(using = RefreshTokenSerializer.class)
+    @JsonDeserialize(using = RefreshTokenDeserializer.class)
     private RefreshToken refreshToken;
+
+    @JsonSerialize(using = JWTSerializer.class)
+    @JsonDeserialize(using = JWTDeserializer.class)
     private JWT idToken;
+
+    static class JWTSerializer extends ToStringSerializerBase {
+
+        public JWTSerializer() {
+            super(JWT.class);
+        }
+
+        @Override
+        public String valueToString(final Object value) {
+            return ((JWT) value).serialize();
+        }
+
+        @Override
+        public void serializeWithType(final Object value, JsonGenerator jgen,
+                                      SerializerProvider provider, TypeSerializer typeSer) throws IOException {
+            val typeId = typeSer.typeId(value, JsonToken.START_OBJECT);
+            typeSer.writeTypePrefix(jgen, typeId);
+            jgen.writeStringField("value", ((JWT) value).serialize());
+            typeId.wrapperWritten = !jgen.canWriteTypeId();
+            typeSer.writeTypeSuffix(jgen, typeId);
+        }
+    }
+
+    static class RefreshTokenSerializer extends StdSerializer<RefreshToken> {
+        public RefreshTokenSerializer() {
+            this(null);
+        }
+
+        public RefreshTokenSerializer(final Class<RefreshToken> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(final RefreshToken refreshToken, final JsonGenerator jsonGenerator,
+                              final SerializerProvider serializerProvider) throws IOException {
+            jsonGenerator.writeObject(refreshToken.toJSONObject());
+        }
+
+        @Override
+        public void serializeWithType(final RefreshToken accessToken,
+                                      final JsonGenerator jgen,
+                                      final SerializerProvider provider,
+                                      final TypeSerializer typeSer) throws IOException {
+            val typeId = typeSer.typeId(accessToken, JsonToken.START_OBJECT);
+            typeSer.writeTypePrefix(jgen, typeId);
+            accessToken.toJSONObject().forEach((name, value) -> {
+                try {
+                    jgen.writeObjectField(name, value);
+                } catch (final IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            typeId.wrapperWritten = !jgen.canWriteTypeId();
+            typeSer.writeTypeSuffix(jgen, typeId);
+        }
+    }
+
+    static class AccessTokenSerializer extends StdSerializer<AccessToken> {
+        public AccessTokenSerializer() {
+            this(null);
+        }
+
+        public AccessTokenSerializer(final Class<AccessToken> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(final AccessToken accessToken, final JsonGenerator jsonGenerator,
+                              final SerializerProvider serializerProvider) throws IOException {
+            jsonGenerator.writeObject(accessToken.toJSONObject());
+        }
+
+        @Override
+        public void serializeWithType(final AccessToken accessToken,
+                                      final JsonGenerator jgen,
+                                      final SerializerProvider provider,
+                                      final TypeSerializer typeSer) throws IOException {
+            val typeId = typeSer.typeId(accessToken, JsonToken.START_OBJECT);
+            typeSer.writeTypePrefix(jgen, typeId);
+            accessToken.toJSONObject().forEach((name, value) -> {
+                try {
+                    jgen.writeObjectField(name, value);
+                } catch (final IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            typeId.wrapperWritten = !jgen.canWriteTypeId();
+            typeSer.writeTypeSuffix(jgen, typeId);
+        }
+    }
+
+
+    static class AuthorizationCodeDeserializer extends StdDeserializer<AuthorizationCode> {
+
+        protected AuthorizationCodeDeserializer() {
+            super(AuthorizationCode.class);
+        }
+
+        protected AuthorizationCodeDeserializer(final JavaType valueType) {
+            super(valueType);
+        }
+
+        @Override
+        public AuthorizationCode deserialize(final JsonParser jsonParser,
+                                             final DeserializationContext deserializationContext) throws IOException {
+            val node = (JsonNode) jsonParser.getCodec().readTree(jsonParser);
+            return new AuthorizationCode(node.asText());
+        }
+    }
+
+    static class RefreshTokenDeserializer extends StdDeserializer<RefreshToken> {
+
+        protected RefreshTokenDeserializer() {
+            super(AuthorizationCode.class);
+        }
+
+        protected RefreshTokenDeserializer(final JavaType valueType) {
+            super(valueType);
+        }
+
+        @Override
+        public RefreshToken deserialize(final JsonParser jsonParser,
+                                        final DeserializationContext deserializationContext) throws IOException {
+            final JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+            return new RefreshToken(node.asText());
+        }
+    }
+
+    static class JWTDeserializer extends StdDeserializer<JWT> {
+
+        protected JWTDeserializer() {
+            super(JWT.class);
+        }
+
+        protected JWTDeserializer(final JavaType valueType) {
+            super(valueType);
+        }
+
+        @Override
+        public JWT deserialize(final JsonParser jsonParser,
+                               final DeserializationContext deserializationContext) throws IOException {
+            try {
+                final JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+                return JWTParser.parse(node.asText());
+            } catch (final Exception e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public Object deserializeWithType(final JsonParser jp, final DeserializationContext ctxt,
+                                          final TypeDeserializer typeDeserializer) throws IOException {
+            try {
+                val node = (JsonNode) jp.getCodec().readTree(jp);
+                val objectMapper = new ObjectMapper();
+                val jsonObject = objectMapper.readValue(node.get(1).toString(), JSONObject.class);
+                return JWTParser.parse(jsonObject.get("value").toString());
+            } catch (final Exception e) {
+                throw new IOException(e);
+            }
+        }
+    }
+
+    static class AccessTokenDeserializer extends StdDeserializer<AccessToken> {
+
+        protected AccessTokenDeserializer() {
+            super(AccessToken.class);
+        }
+
+        protected AccessTokenDeserializer(final JavaType valueType) {
+            super(valueType);
+        }
+
+        @Override
+        public AccessToken deserialize(final JsonParser jsonParser,
+                                       final DeserializationContext deserializationContext) throws IOException {
+            try {
+                val objectMapper = new ObjectMapper();
+                val jsonObject = objectMapper.readValue(jsonParser, JSONObject.class);
+                return AccessToken.parse(jsonObject);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public Object deserializeWithType(final JsonParser jsonParser, final DeserializationContext deserializationContext,
+                                          final TypeDeserializer typeDeserializer) throws IOException, JacksonException {
+            try {
+                val node = (JsonNode) jsonParser.getCodec().readTree(jsonParser);
+                val objectMapper = new ObjectMapper();
+                val jsonObject = objectMapper.readValue(node.get(1).toString(), JSONObject.class);
+                return AccessToken.parse(jsonObject);
+            } catch (ParseException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -53,7 +53,7 @@ public class OidcAuthenticator implements Authenticator {
     @Override
     public Optional<Credentials> validate(final CallContext ctx, final Credentials cred) {
         if (cred instanceof OidcCredentials credentials) {
-            val code = credentials.getCode();
+            val code = credentials.toAuthorizationCode();
             // if we have a code
             if (code != null) {
                 try {
@@ -77,7 +77,7 @@ public class OidcAuthenticator implements Authenticator {
      * @param credentials a {@link OidcCredentials} object
      */
     public void refresh(final OidcCredentials credentials) {
-        val refreshToken = credentials.getRefreshToken();
+        val refreshToken = credentials.toRefreshToken();
         if (refreshToken != null) {
             try {
                 val request = createTokenRequest(new RefreshTokenGrant(refreshToken));
@@ -123,10 +123,10 @@ public class OidcAuthenticator implements Authenticator {
         val tokenSuccessResponse = (OIDCTokenResponse) response;
 
         val oidcTokens = tokenSuccessResponse.getOIDCTokens();
-        credentials.setAccessToken(oidcTokens.getAccessToken());
-        credentials.setRefreshToken(oidcTokens.getRefreshToken());
+        credentials.setAccessToken(oidcTokens.getAccessToken().toJSONObject());
+        credentials.setRefreshToken(oidcTokens.getRefreshToken().toJSONObject());
         if (oidcTokens.getIDToken() != null) {
-            credentials.setIdToken(oidcTokens.getIDToken());
+            credentials.setIdToken(oidcTokens.getIDToken().serialize());
         }
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcCredentialsExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcCredentialsExtractor.java
@@ -133,17 +133,17 @@ public class OidcCredentialsExtractor implements CredentialsExtractor {
             // get authorization code
             val code = successResponse.getAuthorizationCode();
             if (code != null) {
-                credentials.setCode(code);
+                credentials.setCode(code.getValue());
             }
             // get ID token
             val idToken = successResponse.getIDToken();
             if (idToken != null) {
-                credentials.setIdToken(idToken);
+                credentials.setIdToken(idToken.serialize());
             }
             // get access token
             val accessToken = successResponse.getAccessToken();
             if (accessToken != null) {
-                credentials.setAccessToken(accessToken);
+                credentials.setAccessToken(accessToken.toJSONObject());
             }
 
             return Optional.of(credentials);

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -80,7 +80,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
         val regularOidcFlow = credentials instanceof OidcCredentials;
         if (regularOidcFlow) {
             oidcCredentials = (OidcCredentials) credentials;
-            accessToken = oidcCredentials.getAccessToken();
+            accessToken = oidcCredentials.toAccessToken();
         } else {
             // we assume the access token only has been passed: it can be a bearer call (HTTP client)
             val token = ((TokenCredentials) credentials).getToken();
@@ -93,10 +93,10 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
 
         if (oidcCredentials != null) {
             if (oidcCredentials.getIdToken() != null) {
-                profile.setIdTokenString(oidcCredentials.getIdToken().getParsedString());
+                profile.setIdTokenString(oidcCredentials.toIdToken().getParsedString());
             }
             // Check if there is a refresh token
-            val refreshToken = oidcCredentials.getRefreshToken();
+            val refreshToken = oidcCredentials.toRefreshToken();
             if (refreshToken != null && !refreshToken.getValue().isEmpty()) {
                 profile.setRefreshToken(refreshToken);
                 LOGGER.debug("Refresh Token successful retrieved");
@@ -113,7 +113,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
             }
             // Check ID Token
             if (oidcCredentials != null && oidcCredentials.getIdToken() != null) {
-                val claimsSet = configuration.getOpMetadataResolver().getTokenValidator().validate(oidcCredentials.getIdToken(), nonce);
+                val claimsSet = configuration.getOpMetadataResolver().getTokenValidator().validate(oidcCredentials.toIdToken(), nonce);
                 assertNotNull("claimsSet", claimsSet);
                 profile.setId(ProfileHelper.sanitizeIdentifier(claimsSet.getSubject()));
 
@@ -138,7 +138,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
 
             // add attributes of the ID token if they don't already exist
             if (oidcCredentials != null && oidcCredentials.getIdToken() != null) {
-                for (val entry : oidcCredentials.getIdToken().getJWTClaimsSet().getClaims().entrySet()) {
+                for (val entry : oidcCredentials.toIdToken().getJWTClaimsSet().getClaims().entrySet()) {
                     val key = entry.getKey();
                     val value = entry.getValue();
                     // it's not the subject and this attribute does not already exist, add it
@@ -198,7 +198,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
     private void collectClaimsFromAccessTokenIfAny(final OidcCredentials credentials,
                                                    final Nonce nonce, UserProfile profile) {
         try {
-            final AccessToken accessToken = credentials.getAccessToken();
+            var accessToken = credentials.toAccessToken();
             if (accessToken != null) {
                 var accessTokenJwt = JWTParser.parse(accessToken.getValue());
                 var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validate(accessTokenJwt, nonce);

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/OidcCredentialsTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/OidcCredentialsTests.java
@@ -1,8 +1,6 @@
 package org.pac4j.oidc.credentials;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jwt.JWTParser;
-import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
@@ -43,26 +41,26 @@ public final class OidcCredentialsTests implements TestsConstants {
     @Test
     public void testSerialization() throws ParseException {
         val credentials = new OidcCredentials();
-        credentials.setCode(new AuthorizationCode(VALUE));
-        credentials.setAccessToken(new BearerAccessToken(VALUE, 0L, Scope.parse("oidc email")));
-        credentials.setRefreshToken(new RefreshToken(VALUE));
-        credentials.setIdToken(JWTParser.parse(ID_TOKEN));
+        credentials.setCode(VALUE);
+        credentials.setAccessToken(new BearerAccessToken(VALUE, 0L, Scope.parse("oidc email")).toJSONObject());
+        credentials.setRefreshToken(new RefreshToken(VALUE).toJSONObject());
+        credentials.setIdToken(ID_TOKEN);
         var result = serializer.serializeToBytes(credentials);
         val credentials2 = (OidcCredentials) serializer.deserializeFromBytes(result);
         assertEquals(credentials.getAccessToken(), credentials2.getAccessToken());
         assertEquals(credentials.getRefreshToken(), credentials2.getRefreshToken());
-        assertEquals(credentials.getIdToken().getParsedString(), credentials2.getIdToken().getParsedString());
+        assertEquals(credentials.toIdToken().getParsedString(), credentials2.toIdToken().getParsedString());
     }
 
     @Test
     public void testJsonSerializationOfOidcCredentials() throws Exception {
         val oidcCredentials = new OidcCredentials();
-        oidcCredentials.setCode(new AuthorizationCode("authcode"));
-        oidcCredentials.setAccessToken(new BearerAccessToken("value", 0L, Scope.parse("oidc email")));
-        oidcCredentials.setIdToken(JWTParser.parse(ID_TOKEN));
+        oidcCredentials.setCode("authcode");
+        oidcCredentials.setAccessToken(new BearerAccessToken("value", 0L, Scope.parse("oidc email")).toJSONObject());
+        oidcCredentials.setIdToken(ID_TOKEN);
         val oidcProfile = new OidcProfile();
         oidcProfile.setId("id");
-        oidcProfile.setIdTokenString(oidcCredentials.getIdToken().serialize());
+        oidcProfile.setIdTokenString(oidcCredentials.toIdToken().serialize());
         val container = new Container(oidcProfile, List.of(oidcCredentials));
         val jsonSerializer = new JsonSerializer(Container.class);
         val jsonContainer = jsonSerializer.serializeToString(container);
@@ -73,12 +71,12 @@ public final class OidcCredentialsTests implements TestsConstants {
     @Test
     public void testJsonSerializationOfOidcCredentialsWithTyping() throws Exception {
         val oidcCredentials = new OidcCredentials();
-        oidcCredentials.setCode(new AuthorizationCode("authcode"));
-        oidcCredentials.setAccessToken(new BearerAccessToken("accesstoken-1233456", 0L, Scope.parse("oidc email")));
-        oidcCredentials.setIdToken(JWTParser.parse(ID_TOKEN));
+        oidcCredentials.setCode("authcode");
+        oidcCredentials.setAccessToken(new BearerAccessToken("value", 0L, Scope.parse("oidc email")).toJSONObject());
+        oidcCredentials.setIdToken(ID_TOKEN);
         val oidcProfile = new OidcProfile();
         oidcProfile.setId("id");
-        oidcProfile.setIdTokenString(oidcCredentials.getIdToken().serialize());
+        oidcProfile.setIdTokenString(oidcCredentials.toIdToken().serialize());
         val container = new Container(oidcProfile, List.of(oidcCredentials));
         val jsonSerializer = new JsonSerializer(Container.class);
         jsonSerializer.getObjectMapper().enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/OidcCredentialsTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/credentials/OidcCredentialsTests.java
@@ -1,18 +1,29 @@
 package org.pac4j.oidc.credentials;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTParser;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.val;
 import org.junit.Test;
 import org.pac4j.core.util.TestsConstants;
 import org.pac4j.core.util.serializer.JavaSerializer;
+import org.pac4j.core.util.serializer.JsonSerializer;
+import org.pac4j.oidc.profile.OidcProfile;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.text.ParseException;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Tests {@link OidcCredentials}.
@@ -25,9 +36,9 @@ public final class OidcCredentialsTests implements TestsConstants {
     private static final JavaSerializer serializer = new JavaSerializer();
 
     private static final String ID_TOKEN = """
-eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbX
-BsZS5jb20iLCJzdWIiOiJtYWlsdG86cGVyc29uQGV4YW1wbGUuY29tIiwibmJmIjoxNDQwMTEyMDE1LCJleHAiOjE0NDAxMTU2
-MTUsImlhdCI6MTQ0MDExMjAxNSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0.""";
+        eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbX
+        BsZS5jb20iLCJzdWIiOiJtYWlsdG86cGVyc29uQGV4YW1wbGUuY29tIiwibmJmIjoxNDQwMTEyMDE1LCJleHAiOjE0NDAxMTU2
+        MTUsImlhdCI6MTQ0MDExMjAxNSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUuY29tL3JlZ2lzdGVyIn0.""";
 
     @Test
     public void testSerialization() throws ParseException {
@@ -41,5 +52,49 @@ MTUsImlhdCI6MTQ0MDExMjAxNSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczovL2V4YW1wbGUu
         assertEquals(credentials.getAccessToken(), credentials2.getAccessToken());
         assertEquals(credentials.getRefreshToken(), credentials2.getRefreshToken());
         assertEquals(credentials.getIdToken().getParsedString(), credentials2.getIdToken().getParsedString());
+    }
+
+    @Test
+    public void testJsonSerializationOfOidcCredentials() throws Exception {
+        val oidcCredentials = new OidcCredentials();
+        oidcCredentials.setCode(new AuthorizationCode("authcode"));
+        oidcCredentials.setAccessToken(new BearerAccessToken("value", 0L, Scope.parse("oidc email")));
+        oidcCredentials.setIdToken(JWTParser.parse(ID_TOKEN));
+        val oidcProfile = new OidcProfile();
+        oidcProfile.setId("id");
+        oidcProfile.setIdTokenString(oidcCredentials.getIdToken().serialize());
+        val container = new Container(oidcProfile, List.of(oidcCredentials));
+        val jsonSerializer = new JsonSerializer(Container.class);
+        val jsonContainer = jsonSerializer.serializeToString(container);
+        val result = jsonSerializer.deserializeFromString(jsonContainer);
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testJsonSerializationOfOidcCredentialsWithTyping() throws Exception {
+        val oidcCredentials = new OidcCredentials();
+        oidcCredentials.setCode(new AuthorizationCode("authcode"));
+        oidcCredentials.setAccessToken(new BearerAccessToken("accesstoken-1233456", 0L, Scope.parse("oidc email")));
+        oidcCredentials.setIdToken(JWTParser.parse(ID_TOKEN));
+        val oidcProfile = new OidcProfile();
+        oidcProfile.setId("id");
+        oidcProfile.setIdTokenString(oidcCredentials.getIdToken().serialize());
+        val container = new Container(oidcProfile, List.of(oidcCredentials));
+        val jsonSerializer = new JsonSerializer(Container.class);
+        jsonSerializer.getObjectMapper().enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        val jsonContainer = jsonSerializer.serializeToString(container);
+        val result = jsonSerializer.deserializeFromString(jsonContainer);
+        assertNotNull(result);
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    static class Container implements Serializable {
+        @Serial
+        private static final long serialVersionUID = 7527789439433199010L;
+        public OidcProfile profile;
+        public List<OidcCredentials> credential;
     }
 }

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/OidcProfileTests.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.*;
  */
 public final class OidcProfileTests implements TestsConstants {
 
-    private static final JavaSerializer serializer = new JavaSerializer();
+    private static final JavaSerializer JAVA_SERIALIZER = new JavaSerializer();
 
     public static final String ID_TOKEN = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJpc3MiOiJodHRwczovL2p3dC1pZHAuZXhhbX"
             + "BsZS5jb20iLCJzdWIiOiJtYWlsdG86cGVyc29uQGV4YW1wbGUuY29tIiwibmJmIjoxNDQwMTEyMDE1LCJleHAiOjE0NDAxMTU2"
@@ -66,8 +66,8 @@ public final class OidcProfileTests implements TestsConstants {
         profile.setIdTokenString(ID_TOKEN);
         profile.setRefreshToken(new RefreshToken(REFRESH_TOKEN));
 
-        var result = serializer.serializeToBytes(profile);
-        profile = (OidcProfile) serializer.deserializeFromBytes(result);
+        var result = JAVA_SERIALIZER.serializeToBytes(profile);
+        profile = (OidcProfile) JAVA_SERIALIZER.deserializeFromBytes(result);
 
         assertNotNull("accessToken", profile.getAccessToken());
         assertNotNull("value", profile.getAccessToken().getValue());
@@ -85,8 +85,8 @@ public final class OidcProfileTests implements TestsConstants {
         var profile = new OidcProfile();
         profile.setIdTokenString(ID_TOKEN);
         profile.setRefreshToken(new RefreshToken(REFRESH_TOKEN));
-        var result = serializer.serializeToBytes(profile);
-        profile = (OidcProfile) serializer.deserializeFromBytes(result);
+        var result = JAVA_SERIALIZER.serializeToBytes(profile);
+        profile = (OidcProfile) JAVA_SERIALIZER.deserializeFromBytes(result);
         assertNull(profile.getAccessToken());
         assertEquals(profile.getIdTokenString(), ID_TOKEN);
         assertEquals(profile.getRefreshToken().getValue(), REFRESH_TOKEN);
@@ -100,8 +100,8 @@ public final class OidcProfileTests implements TestsConstants {
         var profile = new OidcProfile();
         profile.setAccessToken(populatedAccessToken);
         profile.setRefreshToken(new RefreshToken(REFRESH_TOKEN));
-        var result = serializer.serializeToBytes(profile);
-        profile = (OidcProfile) serializer.deserializeFromBytes(result);
+        var result = JAVA_SERIALIZER.serializeToBytes(profile);
+        profile = (OidcProfile) JAVA_SERIALIZER.deserializeFromBytes(result);
         assertNotNull("accessToken", profile.getAccessToken());
         assertNotNull("value", profile.getAccessToken().getValue());
         assertEquals(profile.getAccessToken().getLifetime(), populatedAccessToken.getLifetime());
@@ -118,8 +118,8 @@ public final class OidcProfileTests implements TestsConstants {
         var profile = new OidcProfile();
         profile.setAccessToken(populatedAccessToken);
         profile.setIdTokenString(ID_TOKEN);
-        var result = serializer.serializeToBytes(profile);
-        profile = (OidcProfile) serializer.deserializeFromBytes(result);
+        var result = JAVA_SERIALIZER.serializeToBytes(profile);
+        profile = (OidcProfile) JAVA_SERIALIZER.deserializeFromBytes(result);
         assertNotNull("accessToken", profile.getAccessToken());
         assertNotNull("value", profile.getAccessToken().getValue());
         assertEquals(profile.getAccessToken().getLifetime(), populatedAccessToken.getLifetime());
@@ -138,8 +138,8 @@ public final class OidcProfileTests implements TestsConstants {
         profile.setAccessToken(populatedAccessToken);
         profile.removeLoginData();
 
-        var result = serializer.serializeToBytes(profile);
-        profile = (OidcProfile) serializer.deserializeFromBytes(result);
+        var result = JAVA_SERIALIZER.serializeToBytes(profile);
+        profile = (OidcProfile) JAVA_SERIALIZER.deserializeFromBytes(result);
         assertNull(profile.getAccessToken());
         assertNull(profile.getIdTokenString());
         assertNull(profile.getRefreshToken());

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
@@ -78,9 +78,9 @@ public class OidcProfileCreatorTests implements TestsConstants {
         ProfileCreator creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
-        credentials.setAccessToken(new BearerAccessToken(UUID.randomUUID().toString()));
+        credentials.setAccessToken(new BearerAccessToken(UUID.randomUUID().toString()).toJSONObject());
         JWT idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
-        credentials.setIdToken(idToken);
+        credentials.setIdToken(idToken.serialize());
         assertTrue(creator.create(new CallContext(webContext, new MockSessionStore()), credentials).isPresent());
     }
 
@@ -91,8 +91,8 @@ public class OidcProfileCreatorTests implements TestsConstants {
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
         credentials.setAccessToken(null);
-        JWT idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
-        credentials.setIdToken(idToken);
+        var idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
+        credentials.setIdToken(idToken.serialize());
         assertTrue(creator.create(new CallContext(webContext, new MockSessionStore()), credentials).isPresent());
     }
 
@@ -105,10 +105,10 @@ public class OidcProfileCreatorTests implements TestsConstants {
 
         var accessTokenClaims = new JWTClaimsSet.Builder(idTokenClaims.toJWTClaimsSet()).claim("client", "pac4j").build();
         var accessTokenToken = new PlainJWT(accessTokenClaims);
-        credentials.setAccessToken(new BearerAccessToken(accessTokenToken.serialize()));
+        credentials.setAccessToken(new BearerAccessToken(accessTokenToken.serialize()).toJSONObject());
 
         JWT idToken = new PlainJWT(idTokenClaims.toJWTClaimsSet());
-        credentials.setIdToken(idToken);
+        credentials.setIdToken(idToken.serialize());
         Optional<UserProfile> profile = creator.create(new CallContext(webContext, new MockSessionStore()), credentials);
         assertTrue(profile.isPresent());
         assertNull(profile.get().getAttribute("client"));

--- a/pac4j-oidc/src/test/resources/logback.xml
+++ b/pac4j-oidc/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>pac4j test %d{HH:mm:ss} [%thread] %-5level %logger{10} - %msg%n%ex{full}</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.pac4j" level="WARN" />
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolverTest.java
@@ -66,7 +66,7 @@ public class SAML2ServiceProviderMetadataResolverTest {
     public void resolveServiceProviderMetadataViaUrl() throws Exception {
         val restBody = IOUtils.toString(
             new ClassPathResource("sample-sp-metadata.xml").getInputStream(), StandardCharsets.UTF_8);
-        val wireMockServer = new WireMockServer(8081);
+        val wireMockServer = new WireMockServer(8181);
         wireMockServer.stubFor(
             get(urlPathEqualTo("/saml"))
                 .willReturn(aResponse()
@@ -89,8 +89,8 @@ public class SAML2ServiceProviderMetadataResolverTest {
         try {
             wireMockServer.start();
             val configuration =
-                initializeConfiguration(new FileUrlResource(new URL("http://localhost:8081/saml")),
-                    "http://localhost:8081/keystore");
+                initializeConfiguration(new FileUrlResource(new URL("http://localhost:8181/saml")),
+                    "http://localhost:8181/keystore");
             final SAML2MetadataResolver metadataResolver = new SAML2ServiceProviderMetadataResolver(configuration);
             assertNotNull(metadataResolver.resolve());
         } finally {


### PR DESCRIPTION
`OidcCredentials` class contains a number of fields from nimbus, such as `JWT`, `AccessToken`, etc that are not easily (or at all) serializable into JSON. Workarounds must be put in place to handle correct serialization of this type, including custom serializer/deserializers, mixins, etc. This pull request switches those field types to plain strings or `Map`s, and then allows for APIs that can reconstruct the actual needed type.

You'll find test cases here that demonstrate JSON serialization with Jackson's `ObjectMapper` with and without typing enabled.

PS It's likely that this problem also exists with other credential and user profile types. We can look at those separately.