### PR TITLE
Ensure TokenCredentials are serializable to JSON

### DIFF
--- a/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProxyProfile.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProxyProfile.java
@@ -17,7 +17,7 @@ import java.io.Serial;
  * @author Jerome Leleu
  * @since 1.4.0
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 public class CasProxyProfile extends CasProfile {
 
     @Serial

--- a/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProxyProfile.java
+++ b/pac4j-cas/src/main/java/org/pac4j/cas/profile/CasProxyProfile.java
@@ -1,5 +1,6 @@
 package org.pac4j.cas.profile;
 
+import lombok.EqualsAndHashCode;
 import lombok.val;
 import org.apereo.cas.client.authentication.AttributePrincipal;
 
@@ -16,6 +17,7 @@ import java.io.Serial;
  * @author Jerome Leleu
  * @since 1.4.0
  */
+@EqualsAndHashCode
 public class CasProxyProfile extends CasProfile {
 
     @Serial

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/TokenCredentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/TokenCredentials.java
@@ -3,6 +3,8 @@ package org.pac4j.core.credentials;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import java.io.Serial;
@@ -13,14 +15,16 @@ import java.io.Serial;
  * @author Jerome Leleu
  * @since 1.7.0
  */
-@EqualsAndHashCode(callSuper = false)
+@EqualsAndHashCode(callSuper = true)
 @ToString
 @AllArgsConstructor
+@NoArgsConstructor
 public class TokenCredentials extends Credentials {
 
     @Serial
     private static final long serialVersionUID = -4270718634364817595L;
 
     @Getter
+    @Setter
     private String token;
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
@@ -2,6 +2,7 @@ package org.pac4j.core.profile;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Streams;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
  * @author Jerome Leleu
  * @since 1.0.0
  */
+@EqualsAndHashCode
 @ToString
 public class BasicUserProfile implements UserProfile, Externalizable {
 

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -14,7 +14,7 @@ import java.util.Set;
  * @author Jerome Leleu
  * @since 4.0.0
  */
-@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="class")
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "class")
 public interface UserProfile extends Serializable {
 
     /**

--- a/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/UserProfile.java
@@ -1,5 +1,7 @@
 package org.pac4j.core.profile;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import java.io.Serializable;
 import java.security.Principal;
 import java.util.Collection;
@@ -12,6 +14,7 @@ import java.util.Set;
  * @author Jerome Leleu
  * @since 4.0.0
  */
+@JsonTypeInfo(use=JsonTypeInfo.Id.CLASS, include=JsonTypeInfo.As.PROPERTY, property="class")
 public interface UserProfile extends Serializable {
 
     /**

--- a/pac4j-core/src/test/java/org/pac4j/core/credentials/TokenCredentialsTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/credentials/TokenCredentialsTests.java
@@ -1,0 +1,33 @@
+package org.pac4j.core.credentials;
+
+import lombok.val;
+import org.junit.Test;
+import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.util.serializer.JsonSerializer;
+import org.pac4j.core.util.TestsConstants;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests {@link TokenCredentials}.
+ *
+ * @author Hayden Sartoris
+ * @since 6.0.0
+ */
+
+public final class TokenCredentialsTests implements TestsConstants {
+
+    @Test
+    public void testJsonSerialization() throws Exception {
+        val tokenCredentials = new TokenCredentials("token");
+        val profile = new CommonProfile();
+        profile.setId("id");
+        tokenCredentials.setUserProfile(profile);
+
+        val jsonSerializer = new JsonSerializer(TokenCredentials.class);
+        val json = jsonSerializer.serializeToString(tokenCredentials);
+        val result = jsonSerializer.deserializeFromString(json);
+        assertEquals(tokenCredentials, result);
+
+    }
+}

--- a/pac4j-core/src/test/java/org/pac4j/core/credentials/TokenCredentialsTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/credentials/TokenCredentialsTests.java
@@ -2,7 +2,7 @@ package org.pac4j.core.credentials;
 
 import lombok.val;
 import org.junit.Test;
-import org.pac4j.core.profile.CommonProfile;
+import org.pac4j.core.profile.AnonymousProfile;
 import org.pac4j.core.util.serializer.JsonSerializer;
 import org.pac4j.core.util.TestsConstants;
 
@@ -20,8 +20,17 @@ public final class TokenCredentialsTests implements TestsConstants {
     @Test
     public void testJsonSerialization() throws Exception {
         val tokenCredentials = new TokenCredentials("token");
-        val profile = new CommonProfile();
-        profile.setId("id");
+        val jsonSerializer = new JsonSerializer(TokenCredentials.class);
+        val json = jsonSerializer.serializeToString(tokenCredentials);
+        val result = jsonSerializer.deserializeFromString(json);
+        assertEquals(tokenCredentials, result);
+
+    }
+
+    @Test
+    public void testJsonSerializationWithProfile() throws Exception {
+        val tokenCredentials = new TokenCredentials("token");
+        val profile = new AnonymousProfile();
         tokenCredentials.setUserProfile(profile);
 
         val jsonSerializer = new JsonSerializer(TokenCredentials.class);

--- a/pac4j-kerberos/src/main/java/org/pac4j/kerberos/profile/KerberosProfile.java
+++ b/pac4j-kerberos/src/main/java/org/pac4j/kerberos/profile/KerberosProfile.java
@@ -1,5 +1,6 @@
 package org.pac4j.kerberos.profile;
 
+import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.ietf.jgss.GSSContext;
 import org.pac4j.core.profile.CommonProfile;
@@ -12,6 +13,7 @@ import java.io.Serial;
  * @author Garry Boyce
  * @since 2.1.0
  */
+@EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public class KerberosProfile extends CommonProfile {
 


### PR DESCRIPTION
See also #2670.

Currently, the second test will fail unless additional typing information is introduced. Happy to tweak as needed.