### PR TITLE
allow access to JEE session-store and its prefix calculation rules

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/session/PrefixedSessionStore.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/session/PrefixedSessionStore.java
@@ -16,7 +16,7 @@ public abstract class PrefixedSessionStore implements SessionStore {
 
     private String prefix = Pac4jConstants.EMPTY_STRING;
 
-    protected String computePrefixedKey(final String key) {
+    public String computePrefixedKey(final String key) {
         return prefix + key;
     }
 }

--- a/pac4j-javaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java
+++ b/pac4j-javaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java
@@ -40,7 +40,7 @@ public class JEESessionStore extends PrefixedSessionStore {
      *
      * @param httpSession a {@link HttpSession} object
      */
-    protected JEESessionStore(final HttpSession httpSession) {
+    public JEESessionStore(final HttpSession httpSession) {
         this.httpSession = httpSession;
     }
 


### PR DESCRIPTION
This is done so we can avoid subclassing the session store, particular for test operations.