### PR TITLE
Track credential source in extractor

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -30,6 +30,7 @@ title: Release notes&#58;
 - The `OidcProfile` will internally encode/decode codes, access and refresh tokens. Asking the profile to return back the actual object will effectively reconstruct it, to avoid  issues with JSON serialization.
 - Added `getQueryString` on the `WebContext`
 - `X509CredentialsExtractor` is now given the ability to specify a custom header for certificate extraction.
+- `Credentials` are now able to specify and carry their source, typically set by the credential extraction process.
 ---
 
 ### JDK11:

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/CredentialSource.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/CredentialSource.java
@@ -3,7 +3,7 @@ package org.pac4j.core.credentials;
 /**
  * The credential source indicates how the credential was extracted.
  *
- * @author Jerome LELEU
+ * @author Misagh Moayyed
  * @since 6.0.0
  */
 public enum CredentialSource {

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/CredentialSource.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/CredentialSource.java
@@ -1,0 +1,11 @@
+package org.pac4j.core.credentials;
+
+/**
+ * The credential source indicates how the credential was extracted.
+ *
+ * @author Jerome LELEU
+ * @since 6.0.0
+ */
+public enum CredentialSource {
+    HEADER, FORM, OTHER
+}

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
@@ -31,6 +31,10 @@ public abstract class Credentials implements Serializable {
     @Getter
     protected LogoutType logoutType = null;
 
+    @Getter
+    @Setter
+    protected CredentialSource source = CredentialSource.OTHER;
+
     /**
      * <p>isForAuthentication.</p>
      *

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/Credentials.java
@@ -31,9 +31,17 @@ public abstract class Credentials implements Serializable {
     @Getter
     protected LogoutType logoutType = null;
 
+    /**
+     * Indicates the source of the credentials.
+     * This is typically configured and set during the credential
+     * extraction process and authentication is then able to accept
+     * or reject a credential based on the source, if necessary.
+     * Values assigned to the source may be defined freely,
+     * though official sources typically should use values from {@link CredentialSource}.
+     */
     @Getter
     @Setter
-    protected CredentialSource source = CredentialSource.OTHER;
+    protected String source = CredentialSource.OTHER.name();
 
     /**
      * <p>isForAuthentication.</p>

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
@@ -3,6 +3,7 @@ package org.pac4j.core.credentials.extractor;
 import lombok.val;
 import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.HttpConstants;
+import org.pac4j.core.credentials.CredentialSource;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.credentials.TokenCredentials;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
@@ -22,24 +23,14 @@ public class BasicAuthExtractor implements CredentialsExtractor {
 
     private final HeaderExtractor extractor;
 
-    /**
-     * <p>Constructor for BasicAuthExtractor.</p>
-     */
     public BasicAuthExtractor() {
         this(HttpConstants.AUTHORIZATION_HEADER, HttpConstants.BASIC_HEADER_PREFIX);
     }
 
-    /**
-     * <p>Constructor for BasicAuthExtractor.</p>
-     *
-     * @param headerName a {@link String} object
-     * @param prefixHeader a {@link String} object
-     */
     public BasicAuthExtractor(final String headerName, final String prefixHeader) {
         this.extractor = new HeaderExtractor(headerName, prefixHeader);
     }
 
-    /** {@inheritDoc} */
     @Override
     public Optional<Credentials> extract(final CallContext ctx) {
         val optCredentials = this.extractor.extract(ctx);
@@ -54,11 +45,13 @@ public class BasicAuthExtractor implements CredentialsExtractor {
             }
             val token = new String(decoded, StandardCharsets.UTF_8);
 
-            val delim = token.indexOf(":");
+            val delim = token.indexOf(':');
             if (delim < 0) {
                 throw new CredentialsException("Bad format of the basic auth header");
             }
-            return new UsernamePasswordCredentials(token.substring(0, delim), token.substring(delim + 1));
+            val upc = new UsernamePasswordCredentials(token.substring(0, delim), token.substring(delim + 1));
+            upc.setSource(CredentialSource.HEADER);
+            return upc;
         });
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/BasicAuthExtractor.java
@@ -50,7 +50,7 @@ public class BasicAuthExtractor implements CredentialsExtractor {
                 throw new CredentialsException("Bad format of the basic auth header");
             }
             val upc = new UsernamePasswordCredentials(token.substring(0, delim), token.substring(delim + 1));
-            upc.setSource(CredentialSource.HEADER);
+            upc.setSource(CredentialSource.HEADER.name());
             return upc;
         });
     }

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/FormExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/FormExtractor.java
@@ -1,8 +1,10 @@
 package org.pac4j.core.credentials.extractor;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.pac4j.core.context.CallContext;
+import org.pac4j.core.credentials.CredentialSource;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 
@@ -15,24 +17,13 @@ import java.util.Optional;
  * @since 1.8.0
  */
 @Getter
+@RequiredArgsConstructor
 public class FormExtractor implements CredentialsExtractor {
 
     private final String usernameParameter;
 
     private final String passwordParameter;
 
-    /**
-     * <p>Constructor for FormExtractor.</p>
-     *
-     * @param usernameParameter a {@link String} object
-     * @param passwordParameter a {@link String} object
-     */
-    public FormExtractor(final String usernameParameter, final String passwordParameter) {
-        this.usernameParameter = usernameParameter;
-        this.passwordParameter = passwordParameter;
-    }
-
-    /** {@inheritDoc} */
     @Override
     public Optional<Credentials> extract(final CallContext ctx) {
         val webContext = ctx.webContext();
@@ -41,7 +32,8 @@ public class FormExtractor implements CredentialsExtractor {
         if (username.isEmpty() || password.isEmpty()) {
             return Optional.empty();
         }
-
-        return Optional.of(new UsernamePasswordCredentials(username.get(), password.get()));
+        val upc = new UsernamePasswordCredentials(username.get(), password.get());
+        upc.setSource(CredentialSource.FORM);
+        return Optional.of(upc);
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/FormExtractor.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/extractor/FormExtractor.java
@@ -33,7 +33,7 @@ public class FormExtractor implements CredentialsExtractor {
             return Optional.empty();
         }
         val upc = new UsernamePasswordCredentials(username.get(), password.get());
-        upc.setSource(CredentialSource.FORM);
+        upc.setSource(CredentialSource.FORM.name());
         return Optional.of(upc);
     }
 }

--- a/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBasicAuthClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/direct/DirectBasicAuthClientTests.java
@@ -6,6 +6,7 @@ import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.credentials.CredentialSource;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.profile.CommonProfile;
@@ -55,10 +56,10 @@ public final class DirectBasicAuthClientTests implements TestsConstants {
         context.addRequestHeader(HttpConstants.AUTHORIZATION_HEADER,
             "Basic " + Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8)));
         val ctx = new CallContext(context, new MockSessionStore());
-        val credentials =
-            (UsernamePasswordCredentials) client.getCredentials(ctx).get();
+        val credentials = (UsernamePasswordCredentials) client.getCredentials(ctx).get();
+        assertEquals(CredentialSource.HEADER.name(), credentials.getSource());
         val authnCredentials = client.validateCredentials(ctx, credentials).get();
-        UserProfile profile = (CommonProfile) client.getUserProfile(ctx, authnCredentials).get();
+        val profile = (CommonProfile) client.getUserProfile(ctx, authnCredentials).get();
         assertEquals(USERNAME, profile.getId());
     }
 

--- a/pac4j-http/src/test/java/org/pac4j/http/client/indirect/FormClientTests.java
+++ b/pac4j-http/src/test/java/org/pac4j/http/client/indirect/FormClientTests.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.pac4j.core.context.CallContext;
 import org.pac4j.core.context.MockWebContext;
 import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.credentials.CredentialSource;
 import org.pac4j.core.credentials.UsernamePasswordCredentials;
 import org.pac4j.core.exception.CredentialsException;
 import org.pac4j.core.exception.TechnicalException;
@@ -119,6 +120,7 @@ public final class FormClientTests implements TestsConstants {
                 .addRequestParameter(formClient.getPasswordParameter(), USERNAME), new MockSessionStore())).get();
         assertEquals(USERNAME, credentials.getUsername());
         assertEquals(USERNAME, credentials.getPassword());
+        assertEquals(CredentialSource.FORM.name(), credentials.getSource());
     }
 
     @Test


### PR DESCRIPTION
UsernamePasswordCredentials is used in many places by different extractors. It's useful to know how the credential was extracted and track its source so that follow-up processes may be able to determine if they can accept and authenticate the credential given its source.

PS Can update release notes + tests if you think this is a good approach to continue.