### PR TITLE
Allow API options for a disabled "never-validate" authenticator

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/authenticator/Authenticator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/authenticator/Authenticator.java
@@ -15,15 +15,9 @@ import java.util.Optional;
 @FunctionalInterface
 public interface Authenticator {
 
-    Authenticator ALWAYS_VALIDATE = new Authenticator() {
-        @Override
-        public Optional<Credentials> validate(CallContext ctx, Credentials credentials) {
-            return Optional.of(credentials);
-        }
-    /** Constant <code>ALWAYS_VALIDATE</code> */
-    /** Constant <code>ALWAYS_VALIDATE</code> */
-    /** Constant <code>ALWAYS_VALIDATE</code> */
-    };
+    Authenticator ALWAYS_VALIDATE = (ctx, credentials) -> Optional.of(credentials);
+
+    Authenticator NEVER_VALIDATE = (ctx, credentials) -> Optional.empty();
 
     /**
      * Validate the credentials. It should throw a {@link org.pac4j.core.exception.CredentialsException} in case of failure.


### PR DESCRIPTION
Provide the counterpart for `ALWAYS_VALIDATE`; which is a disabled authenticator that never validates anything. This is useful in scenarios like this:

```java
if (xyz) {
	return new MyCustomAuthenticator();
}
return Authenticator.NEVER_VALIDATE;
```