### PR TITLE
parameter-less ctr for DefaultRolesAuthorizationGenerator and additional setter

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/DefaultRolesAuthorizationGenerator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/DefaultRolesAuthorizationGenerator.java
@@ -61,13 +61,4 @@ public class DefaultRolesAuthorizationGenerator implements AuthorizationGenerato
     public void setDefaultRoles(final String defaultRolesStr) {
         this.defaultRoles = Arrays.asList(defaultRolesStr.split(","));
     }
-
-    /**
-     * Setter for setDefaultPermissions
-     *
-     * @param defaultPermissionsStr a coma-separated string of permissions
-     */
-    public void setDefaultPermissions(final String defaultPermissionsStr) {
-        this.defaultPermissions = Arrays.asList(defaultPermissionsStr.split(","));
-    }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/DefaultRolesAuthorizationGenerator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/DefaultRolesAuthorizationGenerator.java
@@ -19,6 +19,11 @@ public class DefaultRolesAuthorizationGenerator implements AuthorizationGenerato
 
     /**
      * <p>Constructor for DefaultRolesAuthorizationGenerator.</p>
+     */
+    public DefaultRolesPermissionsAuthorizationGenerator() {}
+
+    /**
+     * <p>Constructor for DefaultRolesAuthorizationGenerator.</p>
      *
      * @param defaultRoles a {@link Collection} object
      */
@@ -46,5 +51,23 @@ public class DefaultRolesAuthorizationGenerator implements AuthorizationGenerato
             profile.addRoles(defaultRoles);
         }
         return Optional.of(profile);
+    }
+
+    /**
+     * Setter for defaultRoles
+     *
+     * @param defaultRolesStr a coma-separated string of role names
+     */
+    public void setDefaultRoles(final String defaultRolesStr) {
+        this.defaultRoles = Arrays.asList(defaultRolesStr.split(","));
+    }
+
+    /**
+     * Setter for setDefaultPermissions
+     *
+     * @param defaultPermissionsStr a coma-separated string of permissions
+     */
+    public void setDefaultPermissions(final String defaultPermissionsStr) {
+        this.defaultPermissions = Arrays.asList(defaultPermissionsStr.split(","));
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/DefaultRolesAuthorizationGenerator.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/authorization/generator/DefaultRolesAuthorizationGenerator.java
@@ -20,7 +20,7 @@ public class DefaultRolesAuthorizationGenerator implements AuthorizationGenerato
     /**
      * <p>Constructor for DefaultRolesAuthorizationGenerator.</p>
      */
-    public DefaultRolesPermissionsAuthorizationGenerator() {}
+    public DefaultRolesAuthorizationGenerator() {}
 
     /**
      * <p>Constructor for DefaultRolesAuthorizationGenerator.</p>


### PR DESCRIPTION
To be able to use the DefaultRolesPermissionsAuthorizationGenerator within shiro.ini, a parameter-less ctr is necessary, that default roles can be defined like this:

```
roleGenerator = org.pac4j.core.authorization.generator.DefaultRolesPermissionsAuthorizationGenerator
roleGenerator.defaultRoles = role_a,role_b,role_c
myClient.authorizationGenerator = $roleGenerator
```
The PR adds the missing ctr + setter