### PR TITLE
Support comma for OIDC scope separation when building authz requests

### DIFF
--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/client/OidcRedirectTests.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
  */
 public final class OidcRedirectTests implements TestsConstants {
 
-    private OidcClient getClient() throws URISyntaxException {
+    private static OidcClient getClient() throws URISyntaxException {
 
         var providerMetadata = mock(OIDCProviderMetadata.class);
         when(providerMetadata.getAuthorizationEndpointURI()).thenReturn(new java.net.URI("http://localhost:8080/auth"));

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilderTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilderTests.java
@@ -1,0 +1,47 @@
+package org.pac4j.oidc.redirect;
+
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import lombok.val;
+import org.junit.Test;
+import org.pac4j.core.context.CallContext;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.profile.factory.ProfileManagerFactory;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.oidc.client.OidcClient;
+import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.metadata.OidcOpMetadataResolver;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OidcRedirectionActionBuilderTests implements TestsConstants {
+
+    private static OidcClient getClient() throws Exception {
+        var providerMetadata = mock(OIDCProviderMetadata.class);
+        when(providerMetadata.getAuthorizationEndpointURI()).thenReturn(new java.net.URI("http://localhost:8080/auth"));
+        val configuration = new OidcConfiguration();
+        configuration.setClientId("testClient");
+        configuration.setSecret("secret");
+        configuration.setScope("openid,profile,email");
+        val metadataResolver = mock(OidcOpMetadataResolver.class);
+        when(metadataResolver.load()).thenReturn(providerMetadata);
+        configuration.setOpMetadataResolver(metadataResolver);
+
+        val client = new OidcClient();
+        client.setConfiguration(configuration);
+        client.setCallbackUrl(CALLBACK_URL);
+        return client;
+    }
+
+    @Test
+    public void testOidcRedirectionScopes() throws Exception {
+        var builder = new OidcRedirectionActionBuilder(getClient());
+        val webContext = MockWebContext.create();
+        val sessionStore = new MockSessionStore();
+        val ctx = new CallContext(webContext, sessionStore, ProfileManagerFactory.DEFAULT);
+        var action = builder.getRedirectionAction(ctx).orElseThrow();
+        assertEquals(302, action.getCode());
+    }
+}


### PR DESCRIPTION
The nimbus OIDC library at some point did accept "," when multiple scopes were provided. This appears to no longer be the case. For backward compatibility, this PR restores the old behavior: 

```java
authParams.put(OidcConfiguration.SCOPE, configContext.getScope().replace(",", " "));
```

Otherwise, we get:

```
Caused by: com.nimbusds.oauth2.sdk.ParseException: The scope must include an openid value
	at com.nimbusds.openid.connect.sdk.AuthenticationRequest.parse(AuthenticationRequest.java:2182)
	at com.nimbusds.openid.connect.sdk.AuthenticationRequest.parse(AuthenticationRequest.java:2105)
	at org.pac4j.oidc.redirect.OidcRedirectionActionBuilder.buildAuthenticationRequestUrl(OidcRedirectionActionBuilder.java:145)
```