### PR TITLE
Allow WebContext attributes to be fetched with type-safety

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContext.java
@@ -38,6 +38,18 @@ public interface WebContext {
     Optional getRequestAttribute(String name);
 
     /**
+     * Return a request attribute typed to a strong type.
+     * The attribute, if found, will be casted down to the given type.
+     * @param <T>   the type parameter
+     * @param name  the name of the attribute
+     * @param clazz the clazz
+     * @return the attribute
+     */
+    default <T> Optional<T> getRequestAttribute(final String name, final Class<T> clazz) {
+        return getRequestAttribute(name).map(clazz::cast);
+    }
+
+    /**
      * Save a request attribute.
      *
      * @param name  the name of the attribute

--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContextHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContextHelper.java
@@ -17,12 +17,12 @@ import java.util.Locale;
  */
 public final class WebContextHelper implements HttpConstants {
 
-    private static ZoneId GMT = ZoneId.of("GMT");
+    private static final ZoneId GMT = ZoneId.of("GMT");
     /**
      * Date formats with time zone as specified in the HTTP RFC to use for formatting.
      * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">Section 7.1.1.1 of RFC 7231</a>
      */
-    private static DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT);
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT);
 
     /**
      * Get a specific cookie by its name.
@@ -185,9 +185,6 @@ public final class WebContextHelper implements HttpConstants {
      */
     public static boolean isQueryStringParameter(final WebContext context, final String name) {
         val queryString = context.getQueryString();
-        if (queryString.isPresent()) {
-            return context.getRequestParameter(name).isPresent() && queryString.get().contains(name + '=');
-        }
-        return false;
+        return queryString.filter(s -> context.getRequestParameter(name).isPresent() && s.contains(name + '=')).isPresent();
     }
 }

--- a/pac4j-core/src/main/java/org/pac4j/core/context/WebContextHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/context/WebContextHelper.java
@@ -22,7 +22,8 @@ public final class WebContextHelper implements HttpConstants {
      * Date formats with time zone as specified in the HTTP RFC to use for formatting.
      * @see <a href="https://tools.ietf.org/html/rfc7231#section-7.1.1.1">Section 7.1.1.1 of RFC 7231</a>
      */
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT);
+    private static final DateTimeFormatter DATE_FORMATTER =
+        DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US).withZone(GMT);
 
     /**
      * Get a specific cookie by its name.

--- a/pac4j-core/src/main/java/org/pac4j/core/util/HttpActionHelper.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/HttpActionHelper.java
@@ -1,7 +1,7 @@
 package org.pac4j.core.util;
 
 import lombok.val;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.pac4j.core.context.HttpConstants;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.context.WebContextHelper;

--- a/pac4j-core/src/test/java/org/pac4j/core/context/WebContextTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/WebContextTests.java
@@ -1,0 +1,22 @@
+package org.pac4j.core.context;
+
+import lombok.val;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class WebContextTests {
+
+    @Test
+    public void testContextAttributes() {
+        val context = MockWebContext.create();
+        val attribute = Map.of("Hello", "World");
+        context.setRequestAttribute("pac4j", attribute);
+        assertTrue(context.getRequestAttribute("pac4j", Map.class).isPresent());
+        assertThrows(ClassCastException.class, () -> context.getRequestAttribute("pac4j", List.class).isPresent());
+    }
+}

--- a/pac4j-core/src/test/java/org/pac4j/core/context/WebContextTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/WebContextTests.java
@@ -17,6 +17,7 @@ public class WebContextTests {
         val attribute = Map.of("Hello", "World");
         context.setRequestAttribute("pac4j", attribute);
         assertTrue(context.getRequestAttribute("pac4j", Map.class).isPresent());
-        assertThrows(ClassCastException.class, () -> context.getRequestAttribute("pac4j", List.class).isPresent());
+        assertThrows(ClassCastException.class,
+            () -> context.getRequestAttribute("pac4j", List.class).isPresent());
     }
 }


### PR DESCRIPTION
Allow for the operation:

```java
context.getRequestAttribute("pac4j", MyObjectType.class)
```

Also, minor clean-up to remove deprecated elements and warnings.