### PR TITLE
Fixed the OSGi import of the package javax.annotation

### DIFF
--- a/pac4j-javaee/pom.xml
+++ b/pac4j-javaee/pom.xml
@@ -77,7 +77,7 @@
                         <Automatic-Module-Name>pac4j.javaee</Automatic-Module-Name>
                         <Bundle-SymbolicName>org.pac4j.javaee</Bundle-SymbolicName>
                         <Export-Package>org.pac4j.jee.*;version=${project.version}</Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>javax.annotation;version=!,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixed the OSGi import of the package javax.annotation with a version >= 3.0 and < 4.0

This had the same issue as here: https://github.com/jhy/jsoup/issues/1616