### PR TITLE
Do not create OidcAuthenticator instance in renewUserProfile

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -79,7 +79,7 @@ public class OidcClient extends IndirectClient {
         if (refreshToken != null) {
             val credentials = new OidcCredentials();
             credentials.setRefreshTokenObject(refreshToken);
-            val authenticator = new OidcAuthenticator(getConfiguration(), this);
+            val authenticator = (OidcAuthenticator)getAuthenticator();
             authenticator.refresh(credentials);
 
             // Create a profile if the refresh grant was successful


### PR DESCRIPTION
In order to use custom `Authenticator` when getting new access token, I suggest to use `OidcAuthenticator` from `getAuthenticator`  instead of creating new instance of `OidcAuthenticator` each time