### PR TITLE
Return only SAML 2.0 support in the sp-metadata.xml

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -205,8 +205,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
      */
     private Boolean nameIdPolicyAllowCreate = Boolean.TRUE;
 
-    private List<String> supportedProtocols = new ArrayList<>(Arrays.asList(SAMLConstants.SAML20P_NS,
-        SAMLConstants.SAML10P_NS, SAMLConstants.SAML11P_NS));
+    private List<String> supportedProtocols = List.of(SAMLConstants.SAML20P_NS);
 
     private SAML2MetadataResolver identityProviderMetadataResolver;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
@@ -92,8 +92,7 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
 
     private List<SAML2MetadataUIInfo> metadataUIInfos = new ArrayList<>();
 
-    private List<String> supportedProtocols = new ArrayList<>(Arrays.asList(SAMLConstants.SAML20P_NS,
-        SAMLConstants.SAML10P_NS, SAMLConstants.SAML11P_NS));
+    private List<String> supportedProtocols = List.of(SAMLConstants.SAML20P_NS);
 
     private SAML2MetadataSigner metadataSigner;
 


### PR DESCRIPTION
According to the [latest pac4j SAML documentation](https://www.pac4j.org/docs/clients/saml.html), only SAML 2.0 is supported. In the `sp-metadata.xml` this is defined by protocolSupportEnumeration. Currently, the default configuration claims the support of SAML 1.0, SAML 1.1, and SAML 2.0. The default is changed to SAML 2.0 support only.