### PR TITLE
Update Jooby urls in readme and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It is licensed under the Apache 2 license.
 &bull; [Undertow](https://github.com/pac4j/undertow-pac4j)
 &bull; [Lagom](https://github.com/pac4j/lagom-pac4j)
 &bull; [Akka HTTP](https://github.com/StackVista/akka-http-pac4j)
-&bull; [Jooby](http://jooby.org)
+&bull; [Jooby](https://jooby.io/modules/pac4j)
 
 ## Authentication mechanisms:
 

--- a/documentation/implementations.html
+++ b/documentation/implementations.html
@@ -79,7 +79,7 @@ title: <i class="fa fa-user" aria-hidden="true"></i> All available <i>pac4j</i> 
 		<td><a target="_blank" href="https://github.com/pac4j/undertow-pac4j"><img height="100" src="/img/logo-undertow.png" /></a></td>
         <td><a target="_blank" href="https://github.com/pac4j/lagom-pac4j"><img height="100" src="/img/logo-lagom.png" /></a></td>
         <td><a target="_blank" href="https://github.com/StackVista/akka-http-pac4j"><img height="100" src="/img/logo-akkahttp.png" /></a></td>
-        <td><a target="_blank" href="http://jooby.org"><img height="100" src="/img/logo-jooby.png" /></a></td>
+        <td><a target="_blank" href="https://jooby.io/modules/pac4j"><img height="100" src="/img/logo-jooby.png" /></a></td>
 	</tr>
 	<tr>
         <td><a target="_blank" href="https://github.com/pac4j/javalin-pac4j"><h1>Javalin</h1></a></td>
@@ -87,6 +87,6 @@ title: <i class="fa fa-user" aria-hidden="true"></i> All available <i>pac4j</i> 
 		<td><a target="_blank" href="https://github.com/pac4j/undertow-pac4j"><h1>Undertow</h1></a></td>
         <td><a target="_blank" href="https://github.com/pac4j/lagom-pac4j"><h1>Lagom</h1></a></td>
         <td><a target="_blank" href="https://github.com/StackVista/akka-http-pac4j"><h1>Akka HTTP</h1></a></td>
-        <td><a target="_blank" href="http://jooby.org"><h1>Jooby</h1></a></td>
+        <td><a target="_blank" href="https://jooby.io/modules/pac4j"><h1>Jooby</h1></a></td>
 	</tr>
 </table>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -23,7 +23,7 @@ title: Home
         "https://github.com/pac4j/undertow-pac4j",
         "https://github.com/pac4j/lagom-pac4j",
         "https://github.com/StackVista/akka-http-pac4j",
-        "http://jooby.org",
+        "https://jooby.io/modules/pac4j",
         "https://github.com/pac4j/pac4j"];
 
     var images = ["/img/logo-j2e.png",
@@ -89,7 +89,7 @@ title: Home
         &bull; <a target="_blank" href="https://github.com/pac4j/undertow-pac4j">Undertow</a>
         &bull; <a target="_blank" href="https://github.com/pac4j/lagom-pac4j">Lagom</a>
         &bull; <a target="_blank" href="https://github.com/StackVista/akka-http-pac4j">Akka HTTP</a>
-        &bull; <a target="_blank" href="http://jooby.org">Jooby</a>
+        &bull; <a target="_blank" href="https://jooby.io/modules/pac4j">Jooby</a>
 
      </h2>
 


### PR DESCRIPTION
Jooby maintainer no longer owns jooby.org domain
and the current one is jooby.io. See
https://github.com/jooby-project/jooby/issues/1513 for more details.

Also, link directly to Jooby's pac4j integration
instructions instead of just home page.