### PR TITLE
Add `createTokenValidator` method in `OidcOpMetadataResolver` in order to reduce copy-pasted code

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/AzureAdOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/AzureAdOpMetadataResolver.java
@@ -3,6 +3,7 @@ package org.pac4j.oidc.metadata;
 import lombok.extern.slf4j.Slf4j;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.azuread.AzureAdTokenValidator;
+import org.pac4j.oidc.profile.creator.TokenValidator;
 
 /**
  * The metadata resolver for AzureAd.
@@ -22,13 +23,8 @@ public class AzureAdOpMetadataResolver extends OidcOpMetadataResolver {
         super(configuration);
     }
 
-    /** {@inheritDoc} */
     @Override
-    protected void internalLoad() {
-        this.loaded = retrieveMetadata();
-
-        this.clientAuthentication = computeClientAuthentication();
-
-        this.tokenValidator = new AzureAdTokenValidator(configuration, this.loaded);
+    protected TokenValidator createTokenValidator() {
+        return new AzureAdTokenValidator(configuration, this.loaded);
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
@@ -77,7 +77,7 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
 
         this.clientAuthentication = computeClientAuthentication();
 
-        this.tokenValidator = new TokenValidator(configuration, this.loaded);
+        this.tokenValidator = createTokenValidator();
     }
 
     /**
@@ -175,8 +175,8 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
     }
 
     private static ClientAuthenticationMethod firstSupportedMethod(
-            final Collection<ClientAuthenticationMethod> serverSupportedAuthMethods,
-            Collection<ClientAuthenticationMethod> clientSupportedAuthMethods) {
+        final Collection<ClientAuthenticationMethod> serverSupportedAuthMethods,
+        Collection<ClientAuthenticationMethod> clientSupportedAuthMethods) {
         Collection<ClientAuthenticationMethod> supportedMethods =
             clientSupportedAuthMethods != null ? clientSupportedAuthMethods : SUPPORTED_METHODS;
         var firstSupported =
@@ -187,5 +187,14 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
             throw new OidcUnsupportedClientAuthMethodException("None of the Token endpoint provider metadata authentication methods are "
                 + "supported: " + serverSupportedAuthMethods);
         }
+    }
+
+    /**
+     * <p>createTokenValidator.</p>
+     *
+     * @return a {@link TokenValidator} object
+     */
+    protected TokenValidator createTokenValidator() {
+        return new TokenValidator(configuration, this.loaded);
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/StaticOidcOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/StaticOidcOpMetadataResolver.java
@@ -32,6 +32,6 @@ public class StaticOidcOpMetadataResolver extends OidcOpMetadataResolver {
 
         this.clientAuthentication = computeClientAuthentication();
 
-        this.tokenValidator = new TokenValidator(configuration, this.loaded);
+        this.tokenValidator = createTokenValidator();
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/StaticOidcOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/StaticOidcOpMetadataResolver.java
@@ -2,7 +2,6 @@ package org.pac4j.oidc.metadata;
 
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import org.pac4j.oidc.config.OidcConfiguration;
-import org.pac4j.oidc.profile.creator.TokenValidator;
 
 /**
  * An OP metadata resolver with static metadata.


### PR DESCRIPTION
I suggest to add new protected method that allows to override `TokenValidator` creation logic in `OidcOpMetadataResolver` subclasses like `AzureAdOpMetadataResolver`