### PR TITLE
Removed version range for OSGi import of guava

### DIFF
--- a/pac4j-core/pom.xml
+++ b/pac4j-core/pom.xml
@@ -75,7 +75,7 @@
                         <Automatic-Module-Name>pac4j.core</Automatic-Module-Name>
                         <Bundle-SymbolicName>org.pac4j.core</Bundle-SymbolicName>
                         <Export-Package>org.pac4j.core.*;version=${project.version}</Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>com.google.common.cache;version=!,com.google.common.collect;version=!,*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pac4j-saml-opensamlv5/pom.xml
+++ b/pac4j-saml-opensamlv5/pom.xml
@@ -253,7 +253,7 @@
                         <Automatic-Module-Name>pac4j.saml</Automatic-Module-Name>
                         <Bundle-SymbolicName>org.pac4j.saml2</Bundle-SymbolicName>
                         <Export-Package>org.pac4j.saml.*;version=${project.version}</Export-Package>
-                        <Import-Package>org.joda.time;version="[1.6,3)",*</Import-Package>
+                        <Import-Package>com.google.common.base;version=!,com.google.common.collect;version=!,org.joda.time;version="[1.6,3)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -237,7 +237,7 @@
                         <Automatic-Module-Name>pac4j.saml</Automatic-Module-Name>
                         <Bundle-SymbolicName>org.pac4j.saml2</Bundle-SymbolicName>
                         <Export-Package>org.pac4j.saml.*;version=${project.version}</Export-Package>
-                        <Import-Package>org.joda.time;version="[1.6,3)",*</Import-Package>
+                        <Import-Package>com.google.common.base;version=!,com.google.common.collect;version=!,org.joda.time;version="[1.6,3)",*</Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Removed version range for OSGi import of guava.
This allows it to be compatible with newer versions.
We had some issues with the default version range that was provided.