### PR TITLE
De-duplicate user profile attribute values

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/profile/BasicUserProfile.java
@@ -159,7 +159,7 @@ public class BasicUserProfile implements UserProfile, Externalizable {
 
     private static <T> Collection<T> mergeCollectionAttributes(final Collection<T> existingCollection, final Collection<T> newCollection)
     {
-        return Streams.concat(existingCollection.stream(), newCollection.stream()).collect(Collectors.toList());
+        return Streams.concat(existingCollection.stream(), newCollection.stream()).distinct().collect(Collectors.toList());
     }
 
     @Override

--- a/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/profile/CommonProfileTests.java
@@ -147,6 +147,24 @@ public final class CommonProfileTests implements TestsConstants {
     }
 
     @Test
+    public void testAddAttributeDuplicateValues() {
+        UserProfile userProfile = new CommonProfile(true);
+        userProfile.addAttribute(KEY, List.of(VALUE));
+        userProfile.addAttribute(KEY, List.of(VALUE));
+        assertEquals(1, userProfile.getAttributes().size());
+        assertEquals(Arrays.asList(VALUE), userProfile.getAttribute(KEY));
+    }
+
+    @Test
+    public void testAddAttributeDeDuplicateValues() {
+        UserProfile userProfile = new CommonProfile(true);
+        userProfile.addAttribute(KEY, List.of(VALUE, "Value2"));
+        userProfile.addAttribute(KEY, List.of(VALUE, "Value3"));
+        assertEquals(1, userProfile.getAttributes().size());
+        assertEquals(Arrays.asList(VALUE, "Value2", "Value3"), userProfile.getAttribute(KEY));
+    }
+
+    @Test
     public void testAddAuthenticationAttribute() {
         val userProfile = new CommonProfile();
         assertEquals(0, userProfile.getAuthenticationAttributes().size());


### PR DESCRIPTION
I've discovered what I think is an issue with deserialization of the ``SAML2Profile`` class involving the ``authnContexts`` property.  When it is deserialized, Jackson will populate the ``authenticationAttributes`` map in the object normally.  But when it tries to populate the ``authnContexts`` property by calling its setter, it inserts a duplicate value into the ``authenticationAttributes`` map, as it tries to "merge" the multiple values.

As this happens on every read from JSON storage, the ``authenticationAttributes`` map gets really big  really quickly (doubles on every serialization round trip). This causes big issues in my CAS ticket registry storage for a fairly common usage
pattern (user logs in to 5 or 6 different services on a single SSO session).

To fix, I made a small change to ``BasicUserProfile.mergeCollectionAttributes()`` which simply deduplicates multiple values from the two ``Collections``.  I'm thinking there's not a use case out there where somebody needs to have duplicate attribute values.  I've done some testing in my nonproduction deployments, and it fixes the problem.
