### PR TITLE
Fix: StaticOidcOpMetadataResolver should not enforce a discovery URI

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/OidcOpMetadataResolver.java
@@ -64,7 +64,7 @@ public class OidcOpMetadataResolver extends SpringResourceLoader<OIDCProviderMet
     }
 
     private static Resource buildResource(final OidcConfiguration configuration) {
-        if (configuration != null) {
+        if (configuration != null && configuration.getDiscoveryURI() != null) {
             return SpringResourceHelper.buildResourceFromPath(configuration.getDiscoveryURI());
         }
         return null;

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTest.java
@@ -2,12 +2,7 @@ package org.pac4j.oidc.metadata;
 
 import static org.junit.Assert.assertEquals;
 
-import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
-import com.nimbusds.oauth2.sdk.id.Issuer;
-import com.nimbusds.openid.connect.sdk.SubjectType;
-import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
@@ -20,15 +15,13 @@ import org.pac4j.oidc.config.OidcConfiguration;
  * @author Mathias Loesch
  * @since 6.0.0
  */
-public class OidcOpMetadataResolverTest {
-
-    public static final JWSAlgorithm JWS_ALGORITHM = JWSAlgorithm.HS256;
+public class OidcOpMetadataResolverTest extends OidcOpMetadataResolverTestBase {
 
     @Test
     public void shouldUseFirstServerSupportedAuthMethod() throws URISyntaxException {
-        OidcConfiguration configuration = getOidcConfiguration(null);
+        OidcConfiguration configuration = getOidcConfiguration(null, "test");
 
-        OidcOpMetadataResolver metadataResolver = getMetadataResolver(configuration,
+        OidcOpMetadataResolver metadataResolver = getStaticMetadataResolver(configuration,
             List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST, ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
 
         assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_POST, metadataResolver.getClientAuthentication().getMethod());
@@ -36,9 +29,9 @@ public class OidcOpMetadataResolverTest {
 
     @Test
     public void shouldRespectClientSupportedAuthMethod() throws URISyntaxException {
-        OidcConfiguration configuration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+        OidcConfiguration configuration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC), "test");
 
-        OidcOpMetadataResolver metadataResolver = getMetadataResolver(configuration,
+        OidcOpMetadataResolver metadataResolver = getStaticMetadataResolver(configuration,
             List.of(ClientAuthenticationMethod.PRIVATE_KEY_JWT, ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
 
         assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_BASIC, metadataResolver.getClientAuthentication().getMethod());
@@ -46,42 +39,15 @@ public class OidcOpMetadataResolverTest {
 
     @Test
     public void shouldFailInCaseOfNoCommonAuthMethod() throws URISyntaxException {
-        OidcConfiguration oidcConfiguration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+        OidcConfiguration oidcConfiguration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_BASIC), "test");
 
         try {
-            getMetadataResolver(oidcConfiguration, List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
+            getStaticMetadataResolver(oidcConfiguration, List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
             Assert.fail("TechnicalException expected");
         } catch (TechnicalException e) {
             assertEquals("None of the Token endpoint provider metadata authentication methods are supported: [client_secret_post]",
                 e.getMessage());
         }
-    }
-
-    private static OidcConfiguration getOidcConfiguration(Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
-        OidcConfiguration configuration = new OidcConfiguration();
-        configuration.setClientId("clientId");
-        configuration.setSecret("secret");
-        configuration.setDiscoveryURI("test");
-        configuration.setPreferredJwsAlgorithm(JWS_ALGORITHM);
-        configuration.setSupportedClientAuthenticationMethods(supportedClientAuthenticationMethods);
-        return configuration;
-    }
-
-    private static OidcOpMetadataResolver getMetadataResolver(OidcConfiguration configuration,
-        List<ClientAuthenticationMethod> supportedAuthMethods) throws URISyntaxException {
-        OIDCProviderMetadata providerMetadata = getOidcProviderMetadata(supportedAuthMethods);
-        OidcOpMetadataResolver oidcOpMetadataResolver = new StaticOidcOpMetadataResolver(configuration, providerMetadata);
-
-        oidcOpMetadataResolver.init();
-        return oidcOpMetadataResolver;
-    }
-
-    private static OIDCProviderMetadata getOidcProviderMetadata(List<ClientAuthenticationMethod> supportedClientAuthenticationMethods)
-        throws URISyntaxException {
-        OIDCProviderMetadata providerMetadata = new OIDCProviderMetadata(new Issuer("issuer"), List.of(SubjectType.PUBLIC), new URI(""));
-        providerMetadata.setIDTokenJWSAlgs(List.of(JWS_ALGORITHM));
-        providerMetadata.setTokenEndpointAuthMethods(supportedClientAuthenticationMethods);
-        return providerMetadata;
     }
 
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTest.java
@@ -70,12 +70,7 @@ public class OidcOpMetadataResolverTest {
     private static OidcOpMetadataResolver getMetadataResolver(OidcConfiguration configuration,
         List<ClientAuthenticationMethod> supportedAuthMethods) throws URISyntaxException {
         OIDCProviderMetadata providerMetadata = getOidcProviderMetadata(supportedAuthMethods);
-        OidcOpMetadataResolver oidcOpMetadataResolver = new OidcOpMetadataResolver(configuration) {
-            @Override
-            protected OIDCProviderMetadata retrieveMetadata() {
-                return providerMetadata;
-            }
-        };
+        OidcOpMetadataResolver oidcOpMetadataResolver = new StaticOidcOpMetadataResolver(configuration, providerMetadata);
 
         oidcOpMetadataResolver.init();
         return oidcOpMetadataResolver;

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTestBase.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTestBase.java
@@ -1,0 +1,49 @@
+package org.pac4j.oidc.metadata;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.SubjectType;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import org.pac4j.oidc.config.OidcConfiguration;
+
+/**
+ * @author Mathias Loesch
+ * @since 6.0.4
+ */
+public class OidcOpMetadataResolverTestBase {
+
+    public static final JWSAlgorithm JWS_ALGORITHM = JWSAlgorithm.HS256;
+
+    protected static OidcConfiguration getOidcConfiguration(Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods,
+        String discoveryURI) {
+        OidcConfiguration configuration = new OidcConfiguration();
+        configuration.setClientId("clientId");
+        configuration.setSecret("secret");
+        configuration.setDiscoveryURI(discoveryURI);
+        configuration.setPreferredJwsAlgorithm(OidcOpMetadataResolverTestBase.JWS_ALGORITHM);
+        configuration.setSupportedClientAuthenticationMethods(supportedClientAuthenticationMethods);
+        return configuration;
+    }
+
+    protected static StaticOidcOpMetadataResolver getStaticMetadataResolver(OidcConfiguration configuration,
+        List<ClientAuthenticationMethod> supportedAuthMethods) throws URISyntaxException {
+        OIDCProviderMetadata providerMetadata = OidcOpMetadataResolverTestBase.getOidcProviderMetadata(supportedAuthMethods);
+        StaticOidcOpMetadataResolver oidcOpMetadataResolver = new StaticOidcOpMetadataResolver(configuration, providerMetadata);
+
+        oidcOpMetadataResolver.init();
+        return oidcOpMetadataResolver;
+    }
+
+    protected static OIDCProviderMetadata getOidcProviderMetadata(List<ClientAuthenticationMethod> supportedClientAuthenticationMethods)
+        throws URISyntaxException {
+        OIDCProviderMetadata providerMetadata = new OIDCProviderMetadata(new Issuer("issuer"), List.of(SubjectType.PUBLIC), new URI(""));
+        providerMetadata.setIDTokenJWSAlgs(List.of(OidcOpMetadataResolverTestBase.JWS_ALGORITHM));
+        providerMetadata.setTokenEndpointAuthMethods(supportedClientAuthenticationMethods);
+        return providerMetadata;
+    }
+}

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/StaticOidcOpMetadataResolverTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/StaticOidcOpMetadataResolverTest.java
@@ -1,0 +1,31 @@
+package org.pac4j.oidc.metadata;
+
+import static org.junit.Assert.assertEquals;
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import org.pac4j.oidc.config.OidcConfiguration;
+
+
+/**
+ * @author Mathias Loesch
+ * @since 6.0.4
+ */
+public class StaticOidcOpMetadataResolverTest extends OidcOpMetadataResolverTestBase {
+
+    @Test
+    public void shouldAllowNullDiscoveryURI() throws URISyntaxException {
+        OidcConfiguration oidcConfiguration = getOidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_POST), null);
+
+        StaticOidcOpMetadataResolver staticMetadataResolver = getStaticMetadataResolver(oidcConfiguration,
+            List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
+
+        OIDCProviderMetadata expectedMetadata = getOidcProviderMetadata(List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
+        assertEquals(staticMetadataResolver.load().toString(), expectedMetadata.toString());
+
+    }
+}


### PR DESCRIPTION
Currently it is not possible to use StaticOidcOpMetadataResolver without having a discovery URI on the OIDC configuration, it will fail in [SpringResourceHelper](https://github.com/pac4j/pac4j/blob/master/pac4j-core/src/main/java/org/pac4j/core/resource/SpringResourceHelper.java#L88).

However, since StaticOidcOpMetadataResolver always returns the static OIDC metadata provided during initialization, it should not require a discovery URI.