### PR TITLE
Allow AWS S3 buckets to store SAML2 SP metadata

### DIFF
--- a/documentation/docs/clients/saml.md
+++ b/documentation/docs/clients/saml.md
@@ -284,6 +284,35 @@ You will need to include the following module, at a minimum, in your build:
 </dependency>
 ```
 
+### Managing metadata via AWS S3 Buckets
+
+Service provider metadata can alternatively be stored and managed via AWS S3 buckets.
+
+```java
+var configuration = new SAML2Configuration();
+...
+var generator = new SAML2S3MetadataGenerator(this.s3Client, entityId);
+generator.setCreateBucketIfNecessary(true);
+...
+configuration.setMetadataGenerator(generator);
+...
+configuration.init();
+```
+
+As you see above, the `SAML2S3MetadataGenerator` has the ability to create the bucket if necessary. The default bucket name
+is set to be `pac4j-saml-metadata`.
+
+This functionality expects S3 dependencies to already be available and does not explicitly declare or export those.
+You will need to include the following module, at a minimum, in your build:
+
+```xml
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>s3</artifactId>
+    <version>...</version>
+</dependency>
+```
+
 ## 3.2) Identity provider metadata resolution:
 
 Resolution of identity provider metadata can also be controlled and overridden as shown below:

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -9,6 +9,7 @@ title: Release notes&#58;
 - OIDC support: set the profile identifier from the subject of the userinfo endpoint if need be
 - Fix: `StaticOidcOpMetadataResolver` should not enforce a discovery URI
 - `OidcOpMetadataResolver`: secret is not mandatory for `private_key_jwt` client authentication method
+- SAML2 support: service provider metadata can now be stored in AWS S3 buckets.
 
 **v6.0.3**:
 - Only 'SAML version 2' in metadata

--- a/pac4j-core/src/test/java/org/pac4j/core/context/WebContextTests.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/context/WebContextTests.java
@@ -18,6 +18,6 @@ public class WebContextTests {
         context.setRequestAttribute("pac4j", attribute);
         assertTrue(context.getRequestAttribute("pac4j", Map.class).isPresent());
         assertThrows(ClassCastException.class,
-            () -> context.getRequestAttribute("pac4j", List.class).isPresent());
+            () -> context.getRequestAttribute("pac4j", List.class));
     }
 }

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -197,6 +197,11 @@
             <artifactId>mongodb-driver-core</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- for testing -->
         <dependency>
             <groupId>org.pac4j</groupId>

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -30,6 +30,9 @@ import org.pac4j.saml.sso.impl.SAML2WebSSOMessageSender;
 import org.pac4j.saml.state.SAML2StateGenerator;
 import org.pac4j.saml.util.Configuration;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
 /**
@@ -41,7 +44,7 @@ import static org.pac4j.core.util.CommonHelper.assertNotNull;
  * @author Jerome Leleu
  * @since 1.5.0
  */
-public class SAML2Client extends IndirectClient {
+public class SAML2Client extends IndirectClient implements Closeable {
 
     @Getter
     protected SAMLContextProvider contextProvider;
@@ -276,4 +279,8 @@ public class SAML2Client extends IndirectClient {
         return this.serviceProviderMetadataResolver.getEntityId();
     }
 
+    @Override
+    public void close() throws IOException {
+        destroy();
+    }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -186,6 +186,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private String certificateSignatureAlg = "SHA1WithRSA";
 
+    private SAML2MetadataResolver defaultIdentityProviderMetadataResolverSupplier;
+
     private int privateKeySize = 2048;
 
     private List<SAML2MetadataContactPerson> contactPersons = new ArrayList<>();
@@ -293,6 +295,7 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.providerName = providerName;
         this.authnRequestExtensions = authnRequestExtensions;
         this.attributeAsId = attributeAsId;
+        this.defaultIdentityProviderMetadataResolverSupplier = new SAML2IdentityProviderMetadataResolver(this);
     }
 
     /**
@@ -564,6 +567,6 @@ public class SAML2Configuration extends BaseClientConfiguration {
      * @return a {@link SAML2MetadataResolver} object
      */
     public SAML2MetadataResolver getIdentityProviderMetadataResolver() {
-        return Objects.requireNonNullElseGet(identityProviderMetadataResolver, () -> new SAML2IdentityProviderMetadataResolver(this));
+        return Objects.requireNonNullElse(identityProviderMetadataResolver, defaultIdentityProviderMetadataResolverSupplier);
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGenerator.java
@@ -1,0 +1,137 @@
+package org.pac4j.saml.metadata.s3;
+
+import com.google.common.net.MediaType;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
+import org.opensaml.saml.metadata.resolver.impl.DOMMetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.pac4j.core.util.CommonHelper;
+import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.metadata.BaseSAML2MetadataGenerator;
+import org.pac4j.saml.util.Configuration;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * This is {@link SAML2S3MetadataGenerator}
+ * that stores service provider metadata in AWS S3 Buckets.
+ *
+ * @author Misagh Moayyed
+ * @since 6.0.4
+ */
+@RequiredArgsConstructor
+@Getter
+@Setter
+@Slf4j
+public class SAML2S3MetadataGenerator extends BaseSAML2MetadataGenerator {
+    /**
+     * Bucket name prefix.
+     */
+    static final String BUCKET_NAME_PREFIX = "pac4j-saml-metadata";
+
+    private final S3Client s3Client;
+
+    private final String entityId;
+
+    @Override
+    public AbstractMetadataResolver createMetadataResolver() throws Exception {
+        var bucketName = buildBucketName();
+        var result = s3Client.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).build());
+        if (!result.hasContents()) {
+            throw new SAMLException("No metadata bucket with valid contents can be found for " + bucketName);
+        }
+        var objects = result.contents();
+        LOGGER.debug("Located {} S3 object(s) from bucket {}", objects.size(), bucketName);
+        if (objects.size() != 1) {
+            throw new SAMLException("No metadata objects could be found in bucket " + bucketName);
+        }
+        val objectKey = objects.get(0);
+        LOGGER.debug("Fetching object {} from bucket {}", objectKey.key(), bucketName);
+        var object = s3Client.getObject(GetObjectRequest.builder().bucket(bucketName).key(objectKey.key()).build());
+        if (object != null && object.available() > 0) {
+            return buildMetadataResolver(object);
+        }
+        throw new SAMLException("Unable to locate metadata document for key " + objectKey);
+    }
+
+    protected AbstractMetadataResolver buildMetadataResolver(final ResponseInputStream<GetObjectResponse> object) throws Exception {
+        try (var is = new ByteArrayInputStream(object.readAllBytes())) {
+            var document = Configuration.getParserPool().parse(is);
+            var root = document.getDocumentElement();
+            return new DOMMetadataResolver(root);
+        }
+    }
+
+    @Override
+    public boolean storeMetadata(final String metadata, final boolean force) {
+        if (CommonHelper.isBlank(metadata)) {
+            logger.info("No metadata is provided");
+            return false;
+        }
+
+        var metadataToUse = isSignMetadata() ? getMetadataSigner().sign(metadata) : metadata;
+        CommonHelper.assertNotBlank("metadata", metadataToUse);
+
+        var entityDescriptor = Configuration.deserializeSamlObject(metadataToUse)
+            .map(EntityDescriptor.class::cast)
+            .orElseThrow();
+        var metadataEntityId = entityDescriptor.getEntityID();
+        if (!Objects.requireNonNull(metadataEntityId).equals(this.entityId)) {
+            throw new SAMLException("Entity id from metadata " + metadataEntityId
+                + " does not match supplied entity id " + this.entityId);
+        }
+        createMetadataBucketIfNecessary();
+        return putMetadataInBucket(entityDescriptor, metadataToUse);
+    }
+
+    protected void createMetadataBucketIfNecessary() {
+        val bucketNameToUse = buildBucketName();
+        if (s3Client.listBuckets(ListBucketsRequest.builder().build())
+            .buckets().stream().noneMatch(b -> b.name().equalsIgnoreCase(bucketNameToUse))) {
+            LOGGER.debug("Bucket {} does not exist. Creating...", bucketNameToUse);
+            var bucket = s3Client.createBucket(CreateBucketRequest.builder().bucket(bucketNameToUse).build());
+            LOGGER.debug("Created bucket {} with name {}", bucket.location(), bucketNameToUse);
+        }
+    }
+
+    protected boolean putMetadataInBucket(final EntityDescriptor entityDescriptor, final String metadataToUse) {
+        var bucketMetadata = buildBucketMetadata(entityDescriptor);
+        val bucketNameToUse = buildBucketName();
+        val request = PutObjectRequest.builder()
+            .key(entityDescriptor.getEntityID())
+            .bucket(bucketNameToUse)
+            .contentType(MediaType.XML_UTF_8.toString())
+            .metadata(bucketMetadata)
+            .build();
+        LOGGER.debug("Saving metadata {} in bucket {}", metadataToUse, bucketNameToUse);
+        var putResponse = s3Client.putObject(request, RequestBody.fromString(metadataToUse));
+        return putResponse != null && putResponse.sdkHttpResponse().isSuccessful();
+    }
+
+    protected Map<String, String> buildBucketMetadata(final EntityDescriptor entityDescriptor) {
+        var bucketMetadata = new HashMap<String, String>();
+        bucketMetadata.put("entityId", entityDescriptor.getEntityID());
+        return bucketMetadata;
+    }
+
+    protected String buildBucketName() {
+        return (BUCKET_NAME_PREFIX + '-' + this.entityId).toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGeneratorIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGeneratorIT.java
@@ -1,0 +1,96 @@
+package org.pac4j.saml.metadata.s3;
+
+import lombok.val;
+import org.junit.Before;
+import org.junit.Test;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.exceptions.SAMLException;
+import org.pac4j.saml.util.DefaultConfigurationManager;
+import org.springframework.core.io.ClassPathResource;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketResponse;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListBucketsRequest;
+import software.amazon.awssdk.services.s3.model.ListBucketsResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.io.InputStream;
+import java.util.UUID;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * This is {@link SAML2S3MetadataGeneratorIT}.
+ *
+ * @author Misagh Moayyed
+ * @since 6.0.4
+ */
+public class SAML2S3MetadataGeneratorIT implements TestsConstants {
+    private static final String ENTITY_ID = "org:pac4j:example";
+
+    private String metadata;
+    private final SAML2Configuration configuration = new SAML2Configuration();
+
+    @Before
+    public void setUp() throws Exception {
+        var metadataGenerator = new SAML2S3MetadataGenerator(getClient(), ENTITY_ID);
+        var mgr = new DefaultConfigurationManager();
+        mgr.configure();
+
+        configuration.setForceKeystoreGeneration(true);
+        configuration.setKeystorePath("target/keystore.jks");
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+        configuration.setSignMetadata(true);
+        configuration.setServiceProviderEntityId(ENTITY_ID);
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.setMetadataGenerator(metadataGenerator);
+        configuration.init();
+    }
+
+    private static S3Client getClient() {
+        var client = mock(S3Client.class);
+        var response = ListBucketsResponse.builder().build();
+        when(client.listBuckets(any(ListBucketsRequest.class))).thenReturn(response);
+        when(client.createBucket(any(CreateBucketRequest.class))).thenReturn(CreateBucketResponse.builder().build());
+
+        var sdkResponse = SdkHttpResponse.builder().statusCode(200).build();
+        when(client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+            .thenReturn(PutObjectResponse.builder().applyMutation(r -> r.sdkHttpResponse(sdkResponse)).build());
+
+        when(client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(
+            ListObjectsV2Response.builder()
+                .contents(S3Object.builder().key(UUID.randomUUID().toString()).build())
+                .build());
+        when(client.getObject(any(GetObjectRequest.class))).thenReturn(
+            new ResponseInputStream<>(GetObjectResponse.builder().build(), InputStream.nullInputStream()));
+        return client;
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        var metadataGenerator = configuration.toMetadataGenerator();
+        val entity = metadataGenerator.buildEntityDescriptor();
+        assertNotNull(entity);
+        var metadata = metadataGenerator.getMetadata(entity);
+        assertNotNull(metadata);
+
+        assertTrue(metadataGenerator.storeMetadata(metadata, true));
+        assertThrows(SAMLException.class, metadataGenerator::buildMetadataResolver);
+    }
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGeneratorIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGeneratorIT.java
@@ -27,12 +27,9 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import java.io.InputStream;
 import java.util.UUID;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * This is {@link SAML2S3MetadataGeneratorIT}.
@@ -43,7 +40,6 @@ import static org.mockito.Mockito.when;
 public class SAML2S3MetadataGeneratorIT implements TestsConstants {
     private static final String ENTITY_ID = "org:pac4j:example";
 
-    private String metadata;
     private final SAML2Configuration configuration = new SAML2Configuration();
 
     @Before

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGeneratorIT.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/s3/SAML2S3MetadataGeneratorIT.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.util.UUID;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 	</modules>
 
 	<properties>
+        <awssdk.version>2.26.0</awssdk.version>
         <mongo-driver.version>5.1.1</mongo-driver.version>
         <flapdoodle.version>3.5.4</flapdoodle.version>
 		<junit.version>4.13.2</junit.version>
@@ -157,6 +158,11 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongodb-driver-core</artifactId>
                 <version>${mongo-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>s3</artifactId>
+                <version>${awssdk.version}</version>
             </dependency>
             <dependency>
 				<groupId>org.slf4j</groupId>


### PR DESCRIPTION
Allow Pac4j to provide an option to store SAML2 SP metadata in S3 buckets.  There is a default bucket that can optionally be created and each object inside the bucket belongs to an SP entity id.

Please note that tests are provided using mocks; writing real integration tests requires something like localstack as a docker container which pac4j is not fit to handle yet, and is beyond the scope of this PR. This functionality has been fully tested in CAS with proper integration tests using the localstack docker image. This feature will be available in CAS 7.1.x.
