### PR TITLE
Record pac4j version into the jar manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,10 @@
 						<supportedProjectTypes>
 							<supportedProjectType>jar</supportedProjectType>
 						</supportedProjectTypes>
+						<instructions>
+							<Specification-Version>${project.version}</Specification-Version>
+							<Implementation-Version>${project.version}</Implementation-Version>
+						</instructions>
 					</configuration>
 				</plugin>
                 <plugin>


### PR DESCRIPTION
Modifies the build so the pac4j version is recorded in JAR manifests under Implementation-Version and Specification-Version attributes. This allows clients to detect which version of the pac4j library they run programmatically using the Package class.