### PR TITLE
Force load SAML2 IDP metadata from URLs

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -21,6 +21,7 @@ import org.pac4j.core.resource.SpringResourceLoader;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.util.Configuration;
+import org.springframework.core.io.UrlResource;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLSocketFactory;
@@ -65,17 +66,21 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
         this.configuration = configuration;
     }
 
-    /** {@inheritDoc} */
     @Override
     public final MetadataResolver resolve() {
         return load();
     }
 
-    /**
-     * <p>internalLoad.</p>
-     */
     protected void internalLoad() {
         this.loaded = initializeMetadataResolver();
+    }
+
+    @Override
+    public boolean hasChanged() {
+        if (this.resource instanceof UrlResource) {
+            return true;
+        }
+        return super.hasChanged();
     }
 
     /**


### PR DESCRIPTION
When SAML2 IDP metadata is fetched from a URL, the following snippet presents an NPE:

```java
saml2Client.init();
var identityProviderMetadataResolver = saml2Client.getIdentityProviderMetadataResolver();
identityProviderMetadataResolver.resolve();
var entity = identityProviderMetadataResolver.getEntityDescriptorElement();
```

URL resources do not always present a reliable up-to-date check, which makes pac4j skip the metadata resolution step since it sees no change. In this changeset, if the metadata resource is a URL, the change detection logic is forced to reload the metadata from the URL and always be up to date.