### PR TITLE
[saml] Fix IdP metadata resolver initialization in SAML2Configuration

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -295,7 +295,6 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.providerName = providerName;
         this.authnRequestExtensions = authnRequestExtensions;
         this.attributeAsId = attributeAsId;
-        this.defaultIdentityProviderMetadataResolverSupplier = new SAML2IdentityProviderMetadataResolver(this);
     }
 
     /**
@@ -325,6 +324,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
      */
     @Override
     protected void internalInit(final boolean forceReinit) {
+        this.defaultIdentityProviderMetadataResolverSupplier = new SAML2IdentityProviderMetadataResolver(this);
+
         val keystoreGenerator = getKeystoreGenerator();
         if (keystoreGenerator.shouldGenerate()) {
             LOGGER.warn("Generating keystore one for/via: {}", this.keystoreResource);

--- a/pac4j-saml/src/test/java/org/pac4j/saml/config/SAML2ConfigurationTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/config/SAML2ConfigurationTests.java
@@ -7,6 +7,7 @@ import org.springframework.core.io.FileSystemResource;
 
 import java.io.File;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -52,5 +53,22 @@ public class SAML2ConfigurationTests {
         assertTrue(signingCert.exists());
         val signingCertKey = new File("target/saml-signing-cert-" + certNameResult + ".key");
         assertTrue(signingCertKey.exists());
+    }
+
+    @Test
+    public void shouldBeAbleToUseAnIdpMetadataResourceWithTheDefaultMetadataResolver() {
+        var configuration = new SAML2Configuration();
+        configuration.setKeystorePath("target/keystore.jks");
+        configuration.setKeystorePassword("pac4j");
+        configuration.setPrivateKeyPassword("pac4j");
+
+        configuration.setIdentityProviderMetadataResource(new ClassPathResource("idp-metadata.xml"));
+        configuration.init();
+
+        var idpMetadataResolver = configuration.getIdentityProviderMetadataResolver();
+        idpMetadataResolver.resolve();
+
+        var result = idpMetadataResolver.getMetadata();
+        assertNotNull(result);
     }
 }


### PR DESCRIPTION
Since v6.0.4.1 (https://github.com/pac4j/pac4j/pull/2926/commits/76b511fe6ff5f980e55fa8988ac6bce1cd47b256), it became impossible to properly set an IdP metadata resource on an already initialized `SAML2Configuration`.

The reason is that the `SAML2IdentityProviderMetadataResolver` is now initialized in the class constructor, and immediately depends on the `identityProviderMetadataResource` from the configuration itself.

But the problem is that the `identityProviderMetadataResource` value can be set after the `SAML2Configuration` creation...

Here is a fix proposal.