### PR TITLE
Force initialize the idp metadata resolver if specified as a flag

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -115,7 +115,7 @@ public class SAML2Client extends IndirectClient implements Closeable {
 
         initDecrypter();
         initSignatureSigningParametersProvider();
-        initIdentityProviderMetadataResolver();
+        initIdentityProviderMetadataResolver(forceReinit);
         initServiceProviderMetadataResolver();
         initSAMLContextProvider();
         initSignatureTrustEngineProvider();
@@ -216,12 +216,9 @@ public class SAML2Client extends IndirectClient implements Closeable {
         this.serviceProviderMetadataResolver.resolve();
     }
 
-    /**
-     * <p>initIdentityProviderMetadataResolver.</p>
-     */
-    protected void initIdentityProviderMetadataResolver() {
+    protected void initIdentityProviderMetadataResolver(final boolean forceReinit) {
         this.identityProviderMetadataResolver = this.configuration.getIdentityProviderMetadataResolver();
-        this.identityProviderMetadataResolver.resolve();
+        this.identityProviderMetadataResolver.resolve(forceReinit);
     }
 
     /**


### PR DESCRIPTION
Note that this change is already covered in the release notes and is just a small refinement. 