### PR TITLE
Introduce intermediary to convert/transform OAuth2 access tokens

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -9,6 +9,7 @@ title: Release notes&#58;
 - Allow to force the reloading of the SAML metadata
 - Reinforce security by checking OIDC logout requests (can be disabled via `OidConfiguration.setLogoutValidation(false)`)
 - Retrieving OIDC resources such as keys from a remote IDP now recognizes the OIDC configuration for remote hostname verification.
+- OAuth2 credentials can now be serialized from/to JSON correctly using an intermediate object to carry the access token.
 
 **v6.0.4**:
 - OIDC support: set the profile identifier from the subject of the userinfo endpoint if need be

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/SessionKeyCredentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/SessionKeyCredentials.java
@@ -2,6 +2,8 @@ package org.pac4j.core.credentials;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.pac4j.core.logout.LogoutType;
 
@@ -13,10 +15,12 @@ import org.pac4j.core.logout.LogoutType;
  */
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@NoArgsConstructor
+@Getter
+@Setter
 public class SessionKeyCredentials extends Credentials {
 
-    @Getter
-    private final String sessionKey;
+    private String sessionKey;
 
     /**
      * <p>Constructor for SessionKeyCredentials.</p>

--- a/pac4j-core/src/main/java/org/pac4j/core/credentials/TokenCredentials.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/credentials/TokenCredentials.java
@@ -19,12 +19,12 @@ import java.io.Serial;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
+@Setter
 public class TokenCredentials extends Credentials {
 
     @Serial
     private static final long serialVersionUID = -4270718634364817595L;
 
-    @Getter
-    @Setter
     private String token;
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/OAuth20Credentials.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/OAuth20Credentials.java
@@ -1,13 +1,18 @@
 package org.pac4j.oauth.credentials;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.With;
 import org.pac4j.core.credentials.Credentials;
 
 import java.io.Serial;
+import java.io.Serializable;
 
 /**
  * This class represents an OAuth credentials for OAuth 2.0 an authorization code.
@@ -15,24 +20,59 @@ import java.io.Serial;
  * @author zhangzhenli
  * @since 1.9.0
  */
-@Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(callSuper = true)
 @ToString
+@NoArgsConstructor
 public class OAuth20Credentials extends Credentials {
 
     @Serial
     private static final long serialVersionUID = -1370874913317625788L;
+
+    @Setter
+    @Getter
     private String code;
 
     @Setter
-    private OAuth2AccessToken accessToken;
+    private OAuth20AccessToken accessToken;
 
     /**
      * For OAuth2 Authorization Code Flow.
      *
      * @param code       the authorization code
      */
-    public OAuth20Credentials(String code) {
+    public OAuth20Credentials(final String code) {
         this.code = code;
+    }
+
+    @JsonIgnore
+    public OAuth2AccessToken toAccessToken() {
+        return new OAuth2AccessToken(accessToken.getAccessToken(),
+            accessToken.getTokenType(), accessToken.getExpiresIn(),
+            accessToken.getRefreshToken(), accessToken.getScope(),
+            accessToken.getRawResponse());
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @With
+    public static class OAuth20AccessToken implements Serializable {
+        @Serial
+        private static final long serialVersionUID = -1370874913317625788L;
+
+        private String accessToken;
+        private String tokenType;
+        private Integer expiresIn;
+        private String refreshToken;
+        private String scope;
+        private String rawResponse;
+
+        public static OAuth20AccessToken from(final OAuth2AccessToken accessToken) {
+            return new OAuth20AccessToken(accessToken.getAccessToken(),
+                accessToken.getTokenType(), accessToken.getExpiresIn(),
+                accessToken.getRefreshToken(), accessToken.getScope(),
+                accessToken.getRawResponse());
+        }
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/OAuth20Credentials.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/OAuth20Credentials.java
@@ -57,6 +57,7 @@ public class OAuth20Credentials extends Credentials {
     @AllArgsConstructor
     @NoArgsConstructor
     @With
+    @EqualsAndHashCode
     public static class OAuth20AccessToken implements Serializable {
         @Serial
         private static final long serialVersionUID = -1370874913317625788L;

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/authenticator/OAuth20Authenticator.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/credentials/authenticator/OAuth20Authenticator.java
@@ -45,6 +45,6 @@ public class OAuth20Authenticator extends OAuthAuthenticator {
             throw new HttpCommunicationException("Error getting token:" + e.getMessage());
         }
         logger.debug("accessToken: {}", accessToken);
-        oAuth20Credentials.setAccessToken(accessToken);
+        oAuth20Credentials.setAccessToken(OAuth20Credentials.OAuth20AccessToken.from(accessToken));
     }
 }

--- a/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/creator/OAuth20ProfileCreator.java
+++ b/pac4j-oauth/src/main/java/org/pac4j/oauth/profile/creator/OAuth20ProfileCreator.java
@@ -39,12 +39,12 @@ public class OAuth20ProfileCreator extends OAuthProfileCreator {
     @Override
     protected OAuth2AccessToken getAccessToken(final Credentials credentials) {
         // we assume the access token only has been passed: it can be a bearer call (HTTP client)
-        if (credentials instanceof TokenCredentials) {
-            val accessToken = ((TokenCredentials) credentials).getToken();
+        if (credentials instanceof TokenCredentials tokenCredentials) {
+            val accessToken = tokenCredentials.getToken();
             return new OAuth2AccessToken(accessToken);
         }
         // regular OAuth flow
-        return ((OAuth20Credentials) credentials).getAccessToken();
+        return ((OAuth20Credentials) credentials).toAccessToken();
     }
 
     /** {@inheritDoc} */

--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/credentials/OAuth20CredentialsTests.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/credentials/OAuth20CredentialsTests.java
@@ -1,0 +1,31 @@
+package org.pac4j.oauth.credentials;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import lombok.val;
+import org.junit.Test;
+import org.pac4j.core.util.TestsConstants;
+import org.pac4j.core.util.serializer.JavaSerializer;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * This class tests the {@link OAuth20Credentials} class.
+ *
+ * @author Misagh Moayyed
+ * @since 6.0.5
+ */
+public final class OAuth20CredentialsTests implements TestsConstants {
+
+    @Test
+    public void testOAuth20Credentials() {
+        val realAccessToken = new OAuth2AccessToken(UUID.randomUUID().toString(), "{'access_token': 'abc'}");
+        val credentials = new OAuth20Credentials(UUID.randomUUID().toString());
+        credentials.setAccessToken(OAuth20Credentials.OAuth20AccessToken.from(realAccessToken));
+        val javaSerializer = new JavaSerializer();
+        val bytes = javaSerializer.serializeToBytes(credentials);
+        val credentials2 = (OAuth20Credentials) javaSerializer.deserializeFromBytes(bytes);
+        assertEquals(credentials2, credentials);
+    }
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import net.minidev.json.JSONObject;
@@ -27,6 +28,7 @@ import java.util.Map;
 @Setter
 @ToString
 @EqualsAndHashCode(callSuper = true, onlyExplicitlyIncluded = true)
+@NoArgsConstructor
 public class OidcCredentials extends Credentials {
 
     @Serial


### PR DESCRIPTION
`OAuth20Credentials` carries a field with type `OAuth2AccessToken`, that cannot be converted into JSON and serialized because it lacks the proper default constructor. In this PR, we track the access token inside a separate holder object is perfectly serializable, and then we convert this object back to the real original object when necessary. 