### PR TITLE
 Encoding invalid characters in Microsoft issuer URL

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/AzureAdOpMetadataResolver.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/AzureAdOpMetadataResolver.java
@@ -1,9 +1,19 @@
 package org.pac4j.oidc.metadata;
 
+import lombok.val;
 import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import org.pac4j.core.resource.SpringResourceHelper;
 import org.pac4j.oidc.config.OidcConfiguration;
+import org.pac4j.oidc.exceptions.OidcException;
 import org.pac4j.oidc.profile.azuread.AzureAdTokenValidator;
 import org.pac4j.oidc.profile.creator.TokenValidator;
+
+import com.nimbusds.jose.util.IOUtils;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 
 /**
  * The metadata resolver for AzureAd.
@@ -26,5 +36,25 @@ public class AzureAdOpMetadataResolver extends OidcOpMetadataResolver {
     @Override
     protected TokenValidator createTokenValidator() {
         return new AzureAdTokenValidator(configuration, this.loaded);
+    }
+    
+    @Override
+    protected OIDCProviderMetadata retrieveMetadata() {
+        try (val in = SpringResourceHelper.getResourceInputStream(
+            resource,
+            null,
+            configuration.getSslSocketFactory(),
+            configuration.getHostnameVerifier(),
+            configuration.getConnectTimeout(),
+            configuration.getReadTimeout()
+        )) {
+            String metadata = IOUtils.readInputStreamToString(in);
+            // When using the tenantid "common" an invalid issuer URL is returned containing {}
+            // ULR encode the invalid characters so it wont break the azure flow
+            metadata = metadata.replace("{tenantid}", "%7Btenantid%7D");
+            return OIDCProviderMetadata.parse(metadata);
+        } catch (final IOException | ParseException e) {
+            throw new OidcException("Error getting OP metadata", e);
+        }
     }
 }

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/AzureAdOpMetadataResolverTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/AzureAdOpMetadataResolverTest.java
@@ -1,0 +1,42 @@
+package org.pac4j.oidc.metadata;
+
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.pac4j.oidc.config.AzureAd2OidcConfiguration;
+
+/**
+ * Tests {@link AzureAdOpMetadataResolver}.
+ * 
+ * @author Arjan van de Kamp
+ * @since 6.0.4
+ */
+public class AzureAdOpMetadataResolverTest extends OidcOpMetadataResolverTestBase {
+
+    @Test
+    public void testIfIssuerDoesNotContainBraces() throws URISyntaxException, UnsupportedEncodingException {
+        AzureAd2OidcConfiguration oidcConfiguration = getAzureAd2OidcConfiguration(Set.of(ClientAuthenticationMethod.CLIENT_SECRET_POST, 
+            ClientAuthenticationMethod.CLIENT_SECRET_BASIC));
+        oidcConfiguration.init();
+        
+        AzureAdOpMetadataResolver azureAdOpMetadataResolver = getAzureAdOpMetadataResolver(oidcConfiguration,
+            List.of(ClientAuthenticationMethod.CLIENT_SECRET_POST));
+
+        Issuer issuer = azureAdOpMetadataResolver.load().getIssuer();
+        
+        Assert.assertNotNull(issuer);
+        Assert.assertFalse("Issuer contains '}'", containsCharacter(issuer.toString(), '}'));
+        Assert.assertFalse("Issuer contains '{'", containsCharacter(issuer.toString(), '{'));
+    }
+    
+    public boolean containsCharacter(String string, char character) {
+        return string.indexOf(character) != -1;
+    }
+}

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTestBase.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTestBase.java
@@ -41,7 +41,8 @@ public class OidcOpMetadataResolverTestBase {
         return oidcOpMetadataResolver;
     }
     
-    protected static AzureAd2OidcConfiguration getAzureAd2OidcConfiguration(Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
+    protected static AzureAd2OidcConfiguration getAzureAd2OidcConfiguration(
+        final Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
         AzureAd2OidcConfiguration configuration = new AzureAd2OidcConfiguration();
         configuration.setClientId("clientId");
         configuration.setSecret("secret");

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTestBase.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcOpMetadataResolverTestBase.java
@@ -9,6 +9,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Set;
+
+import org.pac4j.oidc.config.AzureAd2OidcConfiguration;
 import org.pac4j.oidc.config.OidcConfiguration;
 
 /**
@@ -35,6 +37,22 @@ public class OidcOpMetadataResolverTestBase {
         OIDCProviderMetadata providerMetadata = OidcOpMetadataResolverTestBase.getOidcProviderMetadata(supportedAuthMethods);
         StaticOidcOpMetadataResolver oidcOpMetadataResolver = new StaticOidcOpMetadataResolver(configuration, providerMetadata);
 
+        oidcOpMetadataResolver.init();
+        return oidcOpMetadataResolver;
+    }
+    
+    protected static AzureAd2OidcConfiguration getAzureAd2OidcConfiguration(Set<ClientAuthenticationMethod> supportedClientAuthenticationMethods) {
+        AzureAd2OidcConfiguration configuration = new AzureAd2OidcConfiguration();
+        configuration.setClientId("clientId");
+        configuration.setSecret("secret");
+        configuration.setPreferredJwsAlgorithm(OidcOpMetadataResolverTestBase.JWS_ALGORITHM);
+        configuration.setSupportedClientAuthenticationMethods(supportedClientAuthenticationMethods);
+        return configuration;
+    }
+    
+    protected static AzureAdOpMetadataResolver getAzureAdOpMetadataResolver(OidcConfiguration configuration,
+            List<ClientAuthenticationMethod> supportedAuthMethods) throws URISyntaxException {
+        AzureAdOpMetadataResolver oidcOpMetadataResolver = new AzureAdOpMetadataResolver(configuration);
         oidcOpMetadataResolver.init();
         return oidcOpMetadataResolver;
     }


### PR DESCRIPTION
The problem seems to stem from the braces used in the issuer URL (https://login.microsoftonline.com/{tenantid}/v2.0), which are not being accepted. Specifically, we are fetching configuration from the endpoint: https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration