### PR TITLE
InitializableObject: fix thread safety issues

### DIFF
--- a/pac4j-core/src/main/java/org/pac4j/core/util/InitializableObject.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/InitializableObject.java
@@ -19,17 +19,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Getter
 public abstract class InitializableObject {
 
-    private AtomicBoolean initialized = new AtomicBoolean(false);
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
 
     @Setter
-    private int maxAttempts = 3;
+    private volatile int maxAttempts = 3;
 
-    private AtomicInteger nbAttempts = new AtomicInteger(0);
+    private final AtomicInteger nbAttempts = new AtomicInteger(0);
 
     private volatile Long lastAttempt;
 
     @Setter
-    private long minTimeIntervalBetweenAttemptsInMilliseconds = 5000;
+    private volatile long minTimeIntervalBetweenAttemptsInMilliseconds = 5000;
 
     /**
      * Initialize the object.


### PR DESCRIPTION
Given the publicly exposed setters and initial assignments outside of a synchronized block, I believe that maxAttempts and minTimeIntervalBetweenAttemptsInMilliseconds should be declared volatile to guarantee visibility to other threads.