### PR TITLE
Allow serializing SAML2Profiles using the JsonSerializer with default typing

### DIFF
--- a/pac4j-core/pom.xml
+++ b/pac4j-core/pom.xml
@@ -24,7 +24,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/pac4j-core/src/main/java/org/pac4j/core/util/serializer/JsonSerializer.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/util/serializer/JsonSerializer.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class JsonSerializer extends AbstractSerializer {
     public JsonSerializer() {
         this(Object.class);
         objectMapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL);
+        objectMapper.registerModule(new JavaTimeModule());
     }
 
     /**

--- a/pac4j-core/src/test/java/org/pac4j/core/util/serializer/JsonSerializerTest.java
+++ b/pac4j-core/src/test/java/org/pac4j/core/util/serializer/JsonSerializerTest.java
@@ -6,6 +6,7 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.TestsConstants;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -71,6 +72,25 @@ public class JsonSerializerTest implements TestsConstants {
         val profile = new CommonProfile();
         profile.setId(ID);
         profile.addAttribute(KEY, VALUE);
+        val profiles = new LinkedHashMap<String, UserProfile>();
+        profiles.put("myprofile", profile);
+
+        val serializer = new JsonSerializer();
+        val encoded = serializer.serializeToBytes(profiles);
+        val decoded = serializer.deserializeFromBytes(encoded);
+
+        assertEquals(LinkedHashMap.class, decoded.getClass());
+        val profiles2 = (LinkedHashMap<String, UserProfile>) decoded;
+        assertEquals(1, profiles2.size());
+        assertEquals(profile, profiles2.get("myprofile"));
+    }
+
+    @Test
+    public void testCanSerializeProfilesWithTimeValues() {
+        val now = Instant.now();
+        val profile = new CommonProfile();
+        profile.setId(ID);
+        profile.addAttribute("notOnOrAfter", now);
         val profiles = new LinkedHashMap<String, UserProfile>();
         profiles.put("myprofile", profile);
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2AuthenticationCredentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2AuthenticationCredentials.java
@@ -10,8 +10,7 @@ import org.pac4j.core.profile.converter.AttributeConverter;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -76,11 +75,11 @@ public class SAML2AuthenticationCredentials extends Credentials {
             this.conditions = new SAMLConditions();
 
             if (conditions.getNotBefore() != null) {
-                this.conditions.setNotBefore(ZonedDateTime.ofInstant(conditions.getNotBefore(), ZoneOffset.UTC));
+                this.conditions.setNotBefore(conditions.getNotBefore());
             }
 
             if (conditions.getNotOnOrAfter() != null) {
-                this.conditions.setNotOnOrAfter(ZonedDateTime.ofInstant(conditions.getNotOnOrAfter(), ZoneOffset.UTC));
+                this.conditions.setNotOnOrAfter(conditions.getNotOnOrAfter());
             }
         } else {
             this.conditions = null;
@@ -157,7 +156,7 @@ public class SAML2AuthenticationCredentials extends Credentials {
     public static class SAMLConditions implements Serializable {
         @Serial
         private static final long serialVersionUID = -8966585574672014553L;
-        private ZonedDateTime notBefore;
-        private ZonedDateTime notOnOrAfter;
+        private Instant notBefore;
+        private Instant notOnOrAfter;
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutRequestBuilder.java
@@ -15,8 +15,7 @@ import org.pac4j.saml.profile.SAML2Profile;
 import org.pac4j.saml.util.Configuration;
 import org.pac4j.saml.util.SAML2Utils;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Build a SAML2 Logout Request
@@ -77,7 +76,7 @@ public class SAML2LogoutRequestBuilder {
 
         request.setID(SAML2Utils.generateID());
         request.setIssuer(getIssuer(selfContext.getEntityId()));
-        request.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(this.issueInstantSkewSeconds).toInstant());
+        request.setIssueInstant(Instant.now().plusSeconds(this.issueInstantSkewSeconds));
         request.setVersion(SAMLVersion.VERSION_20);
         request.setDestination(ssoService.getLocation());
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutResponseBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutResponseBuilder.java
@@ -16,8 +16,7 @@ import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.util.Configuration;
 import org.pac4j.saml.util.SAML2Utils;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Build a SAML2 logout response.
@@ -72,7 +71,7 @@ public class SAML2LogoutResponseBuilder {
 
         response.setID(SAML2Utils.generateID());
         response.setIssuer(getIssuer(selfContext.getEntityId()));
-        response.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(this.issueInstantSkewSeconds).toInstant());
+        response.setIssueInstant(Instant.now().plusSeconds(this.issueInstantSkewSeconds));
         response.setVersion(SAMLVersion.VERSION_20);
         response.setDestination(ssoService.getLocation());
         response.setStatus(getSuccess());

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/BaseSAML2MetadataGenerator.java
@@ -32,8 +32,8 @@ import org.pac4j.saml.util.SAML2Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -137,7 +137,7 @@ public abstract class BaseSAML2MetadataGenerator implements SAML2MetadataGenerat
             this.builderFactory.getBuilder(EntityDescriptor.DEFAULT_ELEMENT_NAME);
         val descriptor = Objects.requireNonNull(builder).buildObject();
         descriptor.setEntityID(this.entityId);
-        descriptor.setValidUntil(ZonedDateTime.now(ZoneOffset.UTC).plusYears(20).toInstant());
+        descriptor.setValidUntil(Instant.now().plus(20 * 365, ChronoUnit.DAYS));
         descriptor.setID(SAML2Utils.generateID());
         descriptor.setExtensions(generateMetadataExtensions());
         descriptor.getRoleDescriptors().add(buildSPSSODescriptor());

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/SAML2Profile.java
@@ -5,7 +5,7 @@ import org.pac4j.core.profile.CommonProfile;
 import org.pac4j.saml.credentials.authenticator.SAML2Authenticator;
 
 import java.io.Serial;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -54,36 +54,36 @@ public class SAML2Profile extends CommonProfile {
     /**
      * <p>getNotBefore.</p>
      *
-     * @return a {@link ZonedDateTime} object
+     * @return a {@link Instant} object
      */
-    public ZonedDateTime getNotBefore() {
-        return (ZonedDateTime) getAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_BEFORE_ATTRIBUTE);
+    public Instant getNotBefore() {
+        return (Instant) getAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_BEFORE_ATTRIBUTE);
     }
 
     /**
      * <p>setNotBefore.</p>
      *
-     * @param notBefore a {@link ZonedDateTime} object
+     * @param notBefore a {@link Instant} object
      */
-    public void setNotBefore(ZonedDateTime notBefore) {
+    public void setNotBefore(Instant notBefore) {
         addAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_BEFORE_ATTRIBUTE, notBefore);
     }
 
     /**
      * <p>getNotOnOrAfter.</p>
      *
-     * @return a {@link ZonedDateTime} object
+     * @return a {@link Instant} object
      */
-    public ZonedDateTime getNotOnOrAfter() {
-        return (ZonedDateTime) getAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE);
+    public Instant getNotOnOrAfter() {
+        return (Instant) getAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE);
     }
 
     /**
      * <p>setNotOnOrAfter.</p>
      *
-     * @param notOnOrAfter a {@link ZonedDateTime} object
+     * @param notOnOrAfter a {@link Instant} object
      */
-    public void setNotOnOrAfter(ZonedDateTime notOnOrAfter) {
+    public void setNotOnOrAfter(Instant notOnOrAfter) {
         addAuthenticationAttribute(SAML2Authenticator.SAML_CONDITION_NOT_ON_OR_AFTER_ATTRIBUTE, notOnOrAfter);
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/profile/impl/AbstractSAML2ResponseValidator.java
@@ -36,8 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Collection;
 
 /**
@@ -216,11 +214,11 @@ public abstract class AbstractSAML2ResponseValidator implements SAML2ResponseVal
      * @return a boolean
      */
     protected boolean isDateValid(final Instant issueInstant, final long interval) {
-        val now = ZonedDateTime.now(ZoneOffset.UTC);
+        val now = Instant.now();
         val before = now.plusSeconds(acceptedSkew);
         val after = now.minusSeconds(acceptedSkew + interval);
 
-        val issueInstanceUtc = ZonedDateTime.ofInstant(issueInstant, ZoneOffset.UTC);
+        val issueInstanceUtc = Instant.now();
 
         val isDateValid = issueInstanceUtc.isBefore(before) && issueInstanceUtc.isAfter(after);
         if (!isDateValid) {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnRequestBuilder.java
@@ -18,8 +18,7 @@ import org.pac4j.saml.util.SAML2Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Build a SAML2 Authn Request from the given {@link org.opensaml.messaging.context.MessageContext}.
@@ -83,7 +82,7 @@ public class SAML2AuthnRequestBuilder implements SAML2ObjectBuilder<AuthnRequest
 
         request.setID(SAML2Utils.generateID());
         request.setIssuer(getIssuer(context, selfContext.getEntityId()));
-        request.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).plusSeconds(this.issueInstantSkewSeconds).toInstant());
+        request.setIssueInstant(Instant.now().plusSeconds(this.issueInstantSkewSeconds));
         request.setVersion(SAMLVersion.VERSION_20);
 
         request.setIsPassive(configContext.isPassive());

--- a/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/sso/impl/SAML2AuthnResponseValidator.java
@@ -28,8 +28,6 @@ import org.pac4j.saml.util.SAML2Utils;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -509,7 +507,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
             return false;
         }
 
-        val now = ZonedDateTime.now(ZoneOffset.UTC).toInstant();
+        val now = Instant.now();
         val expired = data.getNotOnOrAfter().plusSeconds(acceptedSkew).isBefore(now);
 
         if (expired) {
@@ -581,7 +579,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
             return;
         }
 
-        val now = ZonedDateTime.now(ZoneOffset.UTC).toInstant();
+        val now = Instant.now();
         if (conditions.getNotBefore() != null) {
             val expired = conditions.getNotBefore().minusSeconds(acceptedSkew).isAfter(now);
             if (expired) {
@@ -638,7 +636,7 @@ public class SAML2AuthnResponseValidator extends AbstractSAML2ResponseValidator 
     protected void validateAuthenticationStatements(final Iterable<AuthnStatement> authnStatements,
                                                     final SAML2MessageContext context) {
         final List<String> authnClassRefs = new ArrayList<>();
-        val now = ZonedDateTime.now(ZoneOffset.UTC).toInstant();
+        val now = Instant.now();
         for (val statement : authnStatements) {
             if (!isAuthnInstantValid(context, statement.getAuthnInstant())) {
                 throw new SAMLAuthnInstantException("Authentication issue instant is too old or in the future");

--- a/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPArtifactDecoder.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/transport/Pac4jHTTPArtifactDecoder.java
@@ -52,8 +52,7 @@ import org.pac4j.core.context.WebContext;
 import org.pac4j.saml.util.SAML2Utils;
 
 import javax.xml.namespace.QName;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 
 /**
  * Decoder for the artifact binding: it's like the original {@link org.opensaml.saml.saml2.binding.decoding.impl.HTTPArtifactDecoder}
@@ -396,7 +395,7 @@ public class Pac4jHTTPArtifactDecoder extends AbstractMessageDecoder implements 
 
         request.setID(idStrategy.generateIdentifier(true));
         request.setDestination(endpoint);
-        request.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+        request.setIssueInstant(Instant.now());
         request.setIssuer(buildIssuer(selfEntityID));
 
         return request;

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
@@ -12,8 +12,7 @@ import org.pac4j.saml.profile.converter.SimpleSAML2AttributeConverter;
 import org.pac4j.saml.util.Configuration;
 
 import java.io.Serializable;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -45,8 +44,8 @@ public class SAML2CredentialsSerializationTests {
         assertNotNull(conditionsBuilder);
 
         val conditions = conditionsBuilder.buildObject();
-        conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
-        conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+        conditions.setNotBefore(Instant.now());
+        conditions.setNotOnOrAfter(Instant.now());
 
         final List<String> contexts = new ArrayList<>();
         contexts.add("cas-context");

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/authenticator/SAML2AuthenticatorTests.java
@@ -18,8 +18,7 @@ import org.w3c.dom.Element;
 
 import javax.xml.namespace.QName;
 import java.net.URISyntaxException;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -180,11 +179,11 @@ public class SAML2AuthenticatorTests {
         val conditions = conditionsBuilder.buildObject();
 
         if (includeNotBefore) {
-            conditions.setNotBefore(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+            conditions.setNotBefore(Instant.now());
         }
 
         if (includeNotOnOrAfter) {
-            conditions.setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+            conditions.setNotOnOrAfter(Instant.now());
         }
 
         final List<String> contexts = new ArrayList<>();

--- a/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/sso/impl/SAML2DefaultResponseValidatorTests.java
@@ -36,8 +36,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -91,15 +91,15 @@ public class SAML2DefaultResponseValidatorTests {
             new InputStreamReader(new FileInputStream(file), Charset.defaultCharset()));
 
         val response = (Response) xmlObject;
-        response.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+        response.setIssueInstant(Instant.now());
         response.getAssertions().forEach(assertion -> {
-            assertion.setIssueInstant(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+            assertion.setIssueInstant(Instant.now());
             assertion.getSubject().getSubjectConfirmations().get(0).setMethod(SubjectConfirmation.METHOD_BEARER);
             assertion.getSubject().getSubjectConfirmations().get(0).
-                getSubjectConfirmationData().setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
-            assertion.getConditions().setNotOnOrAfter(ZonedDateTime.now(ZoneOffset.UTC).toInstant());
+                getSubjectConfirmationData().setNotOnOrAfter(Instant.now());
+            assertion.getConditions().setNotOnOrAfter(Instant.now());
             assertion.getAuthnStatements().forEach(authnStatement -> authnStatement.setAuthnInstant(
-                ZonedDateTime.now(ZoneOffset.UTC).toInstant()));
+                Instant.now()));
         });
         return response;
     }
@@ -375,7 +375,7 @@ public class SAML2DefaultResponseValidatorTests {
         // Move the authn-instant back many years to simulate an "expired" assertion.
         response.getAssertions().forEach(assertion ->
             assertion.getAuthnStatements().forEach(authnStatement -> authnStatement.setAuthnInstant(
-                ZonedDateTime.now(ZoneOffset.UTC).minusYears(10).toInstant())));
+                Instant.now().minus(10 * 365, ChronoUnit.DAYS))));
         response.setSignature(null);
         response.getAssertions().get(0).setSignature(null);
 

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,11 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>${reflections.version}</version>


### PR DESCRIPTION
Allow serializing SAML2Profiles using the JsonSerializer with default typing

* Adding the jackson-datatype-jsr310 dependency, using its JavaTimeModule to the JsonSerializer to enable (de-)serializing of java.time classes
* Changing the SAML2Profile#notBefore and SAML2Profile#notOnOrAfter properties to java.time.Instant as they don't need time-zone information

See https://github.com/pac4j/play-pac4j/issues/705 for context

Before submitting any pull request, please read the contribution guide: https://www.pac4j.org/docs/contribute.html