### PR TITLE
Updates AzureAdProfile.

### DIFF
--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfile.java
@@ -17,15 +17,6 @@ public class AzureAdProfile extends OidcProfile {
     private static final long serialVersionUID = -8659029290353954198L;
 
     /**
-     * <p>getEmail.</p>
-     *
-     * @return a {@link String} object
-     */
-    public String getEmail() {
-        return (String) getAttribute(AzureAdProfileDefinition.EMAIL);
-    }
-
-    /**
      * <p>getIdp.</p>
      *
      * @return a {@link String} object

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfile.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfile.java
@@ -17,6 +17,15 @@ public class AzureAdProfile extends OidcProfile {
     private static final long serialVersionUID = -8659029290353954198L;
 
     /**
+     * <p>getEmail.</p>
+     *
+     * @return a {@link String} object
+     */
+    public String getEmail() {
+        return (String) getAttribute(AzureAdProfileDefinition.EMAIL);
+    }
+
+    /**
      * <p>getIdp.</p>
      *
      * @return a {@link String} object
@@ -82,6 +91,6 @@ public class AzureAdProfile extends OidcProfile {
     /** {@inheritDoc} */
     @Override
     public String getUsername() {
-        return (String) getAttribute(AzureAdProfileDefinition.UPN);
+        return (String) getAttribute(AzureAdProfileDefinition.PREFERRED_USERNAME);
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileDefinition.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileDefinition.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
  */
 public class AzureAdProfileDefinition extends OidcProfileDefinition {
 
+    /** Constant <code>EMAIL="email"</code> */
+    public static final String EMAIL = "email";
     /** Constant <code>IDP="idp"</code> */
     public static final String IDP = "idp";
     /** Constant <code>OID="oid"</code> */
@@ -33,7 +35,8 @@ public class AzureAdProfileDefinition extends OidcProfileDefinition {
      */
     public AzureAdProfileDefinition() {
         super();
-        Arrays.stream(new String[] {IDP, OID, TID, VER, UNQIUE_NAME, IPADDR, UPN}).forEach(a -> primary(a, Converters.STRING));
+        Arrays.stream(new String[] {EMAIL, IDP, OID, PREFERRED_USERNAME, TID, VER, UNQIUE_NAME, IPADDR, UPN})
+            .forEach(a -> primary(a, Converters.STRING));
         setProfileFactory(x -> new AzureAdProfile());
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileDefinition.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdProfileDefinition.java
@@ -13,8 +13,6 @@ import java.util.Arrays;
  */
 public class AzureAdProfileDefinition extends OidcProfileDefinition {
 
-    /** Constant <code>EMAIL="email"</code> */
-    public static final String EMAIL = "email";
     /** Constant <code>IDP="idp"</code> */
     public static final String IDP = "idp";
     /** Constant <code>OID="oid"</code> */
@@ -35,7 +33,7 @@ public class AzureAdProfileDefinition extends OidcProfileDefinition {
      */
     public AzureAdProfileDefinition() {
         super();
-        Arrays.stream(new String[] {EMAIL, IDP, OID, PREFERRED_USERNAME, TID, VER, UNQIUE_NAME, IPADDR, UPN})
+        Arrays.stream(new String[] {IDP, OID, PREFERRED_USERNAME, TID, VER, UNQIUE_NAME, IPADDR, UPN})
             .forEach(a -> primary(a, Converters.STRING));
         setProfileFactory(x -> new AzureAdProfile());
     }


### PR DESCRIPTION
I am in the process of upgrading from pac4j-oidc 5.7.2 -> 6.0.6

Which also means Microsoft Azure AD v1 -> Microsoft Azure AD v2.

Azure AD v1 provided "upn", this is no longer provided in Azure AD v2 - "preferred_username" seems to be the only replacement.