### PR TITLE
Only log saml object when trace level is enabled

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/logout/impl/SAML2LogoutValidator.java
@@ -140,7 +140,9 @@ public class SAML2LogoutValidator extends AbstractSAML2ResponseValidator {
     protected void validateLogoutResponse(final LogoutResponse logoutResponse, final SAML2MessageContext context,
                                           final SignatureTrustEngine engine) {
 
-        logger.trace("Validating logout response:\n{}", Configuration.serializeSamlObject(logoutResponse));
+        if (logger.isTraceEnabled()) {
+            logger.trace("Validating logout response:\n{}", Configuration.serializeSamlObject(logoutResponse));
+        }
         validateSuccess(logoutResponse.getStatus());
 
         validateSignatureIfItExists(logoutResponse.getSignature(), context, engine);


### PR DESCRIPTION
Logging and serializing the SAML object here should only be done when TRACE is enabled. Otherwise there is a performance hit where the object is serialized as a log parameter and yet never actually logged if TRACE is off.