### PR TITLE
fix: SAML2Credentials must be serializable

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/context/SAML2MessageContext.java
@@ -1,6 +1,7 @@
 package org.pac4j.saml.context;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.val;
@@ -35,6 +36,7 @@ import java.util.List;
 @Getter
 @Setter
 @ToString
+@RequiredArgsConstructor
 public class SAML2MessageContext {
 
     /**
@@ -58,14 +60,6 @@ public class SAML2MessageContext {
 
     private SAMLMessageStore samlMessageStore;
 
-    /**
-     * <p>Constructor for SAML2MessageContext.</p>
-     *
-     * @param callContext a {@link CallContext} object
-     */
-    public SAML2MessageContext(final CallContext callContext) {
-        this.callContext = callContext;
-    }
 
     /**
      * <p>getConfigurationContext.</p>

--- a/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/credentials/SAML2Credentials.java
@@ -2,6 +2,7 @@ package org.pac4j.saml.credentials;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.logout.LogoutType;
@@ -17,22 +18,14 @@ import java.io.Serial;
  */
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@RequiredArgsConstructor
 public class SAML2Credentials extends Credentials {
 
     @Serial
     private static final long serialVersionUID = -9127398090736952238L;
 
     @Getter
-    private final SAML2MessageContext context;
-
-    /**
-     * <p>Constructor for SAML2Credentials.</p>
-     *
-     * @param context a {@link SAML2MessageContext} object
-     */
-    public SAML2Credentials(final SAML2MessageContext context) {
-        this.context = context;
-    }
+    private final transient SAML2MessageContext context;
 
     /**
      * <p>Constructor for SAML2Credentials.</p>
@@ -41,7 +34,7 @@ public class SAML2Credentials extends Credentials {
      * @param context a {@link SAML2MessageContext} object
      */
     public SAML2Credentials(final LogoutType type, final SAML2MessageContext context) {
+        this(context);
         this.logoutType = type;
-        this.context = context;
     }
 }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/credentials/SAML2CredentialsSerializationTests.java
@@ -8,6 +8,11 @@ import org.opensaml.saml.common.SAMLObjectBuilder;
 import org.opensaml.saml.saml2.core.Attribute;
 import org.opensaml.saml.saml2.core.Conditions;
 import org.opensaml.saml.saml2.core.NameID;
+import org.pac4j.core.context.CallContext;
+import org.pac4j.core.context.MockWebContext;
+import org.pac4j.core.context.session.MockSessionStore;
+import org.pac4j.core.logout.LogoutType;
+import org.pac4j.saml.context.SAML2MessageContext;
 import org.pac4j.saml.profile.converter.SimpleSAML2AttributeConverter;
 import org.pac4j.saml.util.Configuration;
 
@@ -26,6 +31,15 @@ import static org.junit.Assert.assertNotNull;
  */
 public class SAML2CredentialsSerializationTests {
     private final XMLObjectBuilderFactory builderFactory = Configuration.getBuilderFactory();
+
+    @Test
+    public void verifySerialization() {
+        var mockWebContext = MockWebContext.create();
+        Serializable credentials = new SAML2Credentials(LogoutType.BACK,
+            new SAML2MessageContext(new CallContext(mockWebContext, new MockSessionStore())));
+        val data = SerializationUtils.serialize(credentials);
+        assertNotNull(data);
+    }
 
     @Test
     public void verifyOperation() {


### PR DESCRIPTION
The `SAML2Credentials` class is tagged to be serializable. However, it contains a reference to `SAML2MessageContext`, which is not serializable. 

This PR marks the `SAML2MessageContext` as transient. (Ideally, `SAML2Credentials` should be reworked to remove the reference to the `SAML2MessageContext`)