### PR TITLE
Exclude gpl-licensed findbugs-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,12 @@
 				<groupId>org.slf4j</groupId>
 				<artifactId>jcl-over-slf4j</artifactId>
 				<version>${slf4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>findbugs-annotations</artifactId>
+                    </exclusion>
+                </exclusions>
 			</dependency>
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
@@ -358,6 +364,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>findbugs-annotations</artifactId>
             <version>3.0.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
findbugs-annotations is under GPL which is not compatible with Apache v4: 
https://github.com/findbugsproject/findbugs/blob/release-3.0.1/findbugs/licenses/LICENSE.txt

