### PR TITLE
Create TokenRequest with the configured OIDC scope

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -8,6 +8,7 @@ title: Release notes&#58;
 **v6.1.1**:
 - Protect the `getRequestAttribute` method for Jetty 12.0.8+
 - Fix bug for HTML values in POST forms
+- Use the configured scope in OpenID Connect authenticator
 
 **v6.1.0**:
 - Deprecate basic `CommonHelper` methods in favor of `commons-lang3`

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,10 +5,12 @@ title: Release notes&#58;
 
 ### JDK17:
 
+**v6.1.2**:
+- Use the configured scope in OpenID Connect authenticator
+
 **v6.1.1**:
 - Protect the `getRequestAttribute` method for Jetty 12.0.8+
 - Fix bug for HTML values in POST forms
-- Use the configured scope in OpenID Connect authenticator
 
 **v6.1.0**:
 - Deprecate basic `CommonHelper` methods in favor of `commons-lang3`

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/authenticator/OidcAuthenticator.java
@@ -99,9 +99,11 @@ public class OidcAuthenticator implements Authenticator {
         val tokenEndpointUri = metadataResolver.load().getTokenEndpointURI();
         val clientAuthentication = metadataResolver.getClientAuthentication();
         if (clientAuthentication != null) {
-            return new TokenRequest(tokenEndpointUri, clientAuthentication, grant);
+            return new TokenRequest(
+                    tokenEndpointUri, clientAuthentication, grant, Scope.parse(configuration.getScope()));
         } else {
-            return new TokenRequest(tokenEndpointUri, new ClientID(configuration.getClientId()), grant);
+            return new TokenRequest(
+                    tokenEndpointUri, new ClientID(configuration.getClientId()), grant, Scope.parse(configuration.getScope()));
         }
     }
 
@@ -110,8 +112,7 @@ public class OidcAuthenticator implements Authenticator {
         configuration.configureHttpRequest(tokenHttpRequest);
 
         val httpResponse = tokenHttpRequest.send();
-        LOGGER.debug("Token response: status={}, content={}", httpResponse.getStatusCode(),
-            httpResponse.getContent());
+        LOGGER.debug("Token response: status={}, content={}", httpResponse.getStatusCode(), httpResponse.getBody());
 
         val response = OIDCTokenResponseParser.parse(httpResponse);
         if (response instanceof TokenErrorResponse tokenErrorResponse) {


### PR DESCRIPTION
This PR bears a small change to pass the OIDC scope as configured to the `TokenRequest` constructor.

Side note: it seems that the constructor variants without the `scope` argument were deprecated.