### PR TITLE
Fixes initial init with forceReinit == true

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -8,6 +8,7 @@ title: Release notes&#58;
 **v6.1.2**:
 - Use the configured scope in OpenID Connect authenticator
 - Fix the `getFullRequestURL` method
+- Fixes setting proper implementation of OidcOpMetadataResolver in OidcConfiguration and its descendants when `internalInit` is called with `forceReinit` set to true
 
 **v6.1.1**:
 - Protect the `getRequestAttribute` method for Jetty 12.0.8+
@@ -19,6 +20,7 @@ title: Release notes&#58;
 
 **v6.0.7**:
 - SAML2: `maximumAuthenticationLifetime` is set to `0` by default to disable the validation of `authnInstant` in SAML2 assertions.
+- Fixes setting proper implementation of OidcOpMetadataResolver in OidcConfiguration and its descendants when `internalInit` is called with `forceReinit` set to true
 
 **v6.0.6**:
 - Security fix: cannot accept empty OIDC credentials

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -20,7 +20,6 @@ title: Release notes&#58;
 
 **v6.0.7**:
 - SAML2: `maximumAuthenticationLifetime` is set to `0` by default to disable the validation of `authnInstant` in SAML2 assertions.
-- Fixes setting proper implementation of OidcOpMetadataResolver in OidcConfiguration and its descendants when `internalInit` is called with `forceReinit` set to true
 
 **v6.0.6**:
 - Security fix: cannot accept empty OIDC credentials

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AppleOidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AppleOidcConfiguration.java
@@ -17,6 +17,7 @@ import org.pac4j.core.store.GuavaStore;
 import org.pac4j.core.store.Store;
 import org.pac4j.core.util.CommonHelper;
 import org.pac4j.oidc.exceptions.OidcException;
+import org.pac4j.oidc.metadata.OidcOpMetadataResolver;
 import org.pac4j.oidc.metadata.StaticOidcOpMetadataResolver;
 
 import java.net.URI;
@@ -79,21 +80,31 @@ public class AppleOidcConfiguration extends OidcConfiguration {
         if (store == null) {
             store = new GuavaStore<>(1000, (int) timeout.toSeconds(), TimeUnit.SECONDS);
         }
+
+        setClientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
+
+        super.internalInit(forceReinit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected OidcOpMetadataResolver createNewOpMetadataResolver(){
         val providerMetadata =
             new OIDCProviderMetadata(
                 new Issuer("https://appleid.apple.com"),
                 Collections.singletonList(SubjectType.PAIRWISE),
                 // https://developer.apple.com/documentation/signinwithapplerestapi/fetch_apple_s_public_key_for_verifying_token_signature
                 URI.create("https://appleid.apple.com/auth/keys"));
+
 // https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_js/incorporating_sign_in_with_apple_into_other_platforms
         providerMetadata.setAuthorizationEndpointURI(URI.create("https://appleid.apple.com/auth/authorize"));
         // https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens
         providerMetadata.setTokenEndpointURI(URI.create("https://appleid.apple.com/auth/token"));
         providerMetadata.setIDTokenJWSAlgs(Collections.singletonList(JWSAlgorithm.RS256));
-        this.opMetadataResolver = new StaticOidcOpMetadataResolver(this, providerMetadata);
-        setClientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST);
 
-        super.internalInit(forceReinit);
+        return new StaticOidcOpMetadataResolver(this, providerMetadata);
     }
 
     /**

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAd2OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAd2OidcConfiguration.java
@@ -7,8 +7,6 @@ import org.pac4j.core.util.HttpUtils;
 import org.pac4j.oidc.metadata.AzureAdOpMetadataResolver;
 import org.pac4j.oidc.metadata.OidcOpMetadataResolver;
 
-import static org.pac4j.core.util.CommonHelper.assertNotBlank;
-
 /**
  * Microsoft Azure AD v2 OpenID Connect configuration.
  *

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAd2OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/AzureAd2OidcConfiguration.java
@@ -5,6 +5,7 @@ import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
 import org.pac4j.core.util.HttpUtils;
 import org.pac4j.oidc.metadata.AzureAdOpMetadataResolver;
+import org.pac4j.oidc.metadata.OidcOpMetadataResolver;
 
 import static org.pac4j.core.util.CommonHelper.assertNotBlank;
 
@@ -66,13 +67,15 @@ public class AzureAd2OidcConfiguration extends OidcConfiguration {
             setTenant("common");
         }
 
-        if (this.getOpMetadataResolver() == null) {
-            assertNotBlank("discoveryURI", getDiscoveryURI());
-            this.opMetadataResolver = new AzureAdOpMetadataResolver(this);
-            this.opMetadataResolver.init();
-        }
-
         super.internalInit(forceReinit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected OidcOpMetadataResolver createNewOpMetadataResolver(){
+        return new AzureAdOpMetadataResolver(this);
     }
 
     /** {@inheritDoc} */

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -261,8 +261,16 @@ public class OidcConfiguration extends BaseClientConfiguration {
 
         if (forceReinit || this.getOpMetadataResolver() == null) {
             assertNotBlank("discoveryURI", getDiscoveryURI());
-            this.opMetadataResolver = new OidcOpMetadataResolver(this);
+            this.opMetadataResolver = createNewOpMetadataResolver();
+            this.opMetadataResolver.init();
         }
+    }
+
+    /**
+     * <p>Creates proper implementation of OidcOpMetadataResolver.</p>
+     */
+    protected OidcOpMetadataResolver createNewOpMetadataResolver() {
+        return new OidcOpMetadataResolver(this);
     }
 
     /**


### PR DESCRIPTION
In https://github.com/apereo/cas/blob/master/support/cas-server-support-pac4j-core/src/main/java/org/apereo/cas/web/flow/DefaultDelegatedClientIdentityProviderConfigurationProducer.java in initializeClientIdentityProvider method init is called with forceReinit == true
As client is uninitialized its unnecessary to force reinit although it shouldn't hurt.  
AzureAd2OidcConfiguration properly sets opMetadataResolver with new AzureAdOpMetadataResolver(this) but after this super.internalInit(forceReinit: true);  is called and in OidcConfiguration class proper value of opMetadataResolver is overwritten by new OidcOpMetadataResolver(this). 
Proposed fix makes AzureAd2OidcConfiguration immune for init called with force == true; It still gets proper opMetadataResolver 
