### PR TITLE
feat: Resolve saml2 metadata url concurrently via ranges

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -8,7 +8,8 @@ title: Release notes&#58;
 **v6.1.2**:
 - Use the configured scope in OpenID Connect authenticator
 - Fix the `getFullRequestURL` method
-- Fixes setting proper implementation of OidcOpMetadataResolver in OidcConfiguration and its descendants when `internalInit` is called with `forceReinit` set to true
+- Fixes setting proper implementation of `OidcOpMetadataResolver` in `OidcConfiguration` and its descendants when `internalInit` is called with `forceReinit` set to true
+- SAML2 metadata URLs can be downloaded and resolved concurrently if the URL resource supports the `Accept-Ranges` header as `bytes`.
 
 **v6.1.1**:
 - Protect the `getRequestAttribute` method for Jetty 12.0.8+

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -21,13 +21,27 @@ import org.pac4j.core.resource.SpringResourceLoader;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.util.Configuration;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 
 import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.RandomAccessFile;
+import java.net.HttpURLConnection;
 import java.net.Proxy;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * Resolve and download idp metadata to form a metadata resolver.
@@ -49,11 +63,6 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
 
     private final SAML2Configuration configuration;
 
-    /**
-     * <p>Constructor for SAML2IdentityProviderMetadataResolver.</p>
-     *
-     * @param configuration a {@link SAML2Configuration} object
-     */
     public SAML2IdentityProviderMetadataResolver(final SAML2Configuration configuration) {
         super(configuration.getIdentityProviderMetadataResource());
         if (configuration.getSslSocketFactory() != null) {
@@ -73,21 +82,104 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
         return load();
     }
 
-    /**
-     * <p>internalLoad.</p>
-     */
     protected void internalLoad() {
-        this.loaded = initializeMetadataResolver();
+        val t0 = System.currentTimeMillis();
+        try {
+            this.loaded = initializeMetadataResolver();
+        } finally {
+            val t1 = System.currentTimeMillis();
+            LOGGER.error("Metadata resolution took: {} ms", t1 - t0);
+        }
+
     }
 
-    /**
-     * <p>initializeMetadataResolver.</p>
-     *
-     * @return a {@link DOMMetadataResolver} object
-     */
     protected DOMMetadataResolver initializeMetadataResolver() {
+        if (configuration.getIdentityProviderMetadataResource() instanceof UrlResource urlResource) {
+            var fileUrl = urlResource.getURL().toString();
+            HttpURLConnection conn = null;
+            try {
+                conn = (HttpURLConnection) new URL(fileUrl).openConnection();
+                if (conn instanceof HttpsURLConnection https) {
+                    if (hostnameVerifier != null) {
+                        https.setHostnameVerifier(hostnameVerifier);
+                    }
+                    if (sslSocketFactory != null) {
+                        https.setSSLSocketFactory(sslSocketFactory);
+                    }
+                }
+                conn.setRequestMethod("HEAD");
+                var supportsRange = "bytes".equalsIgnoreCase(conn.getHeaderField("Accept-Ranges"));
+                if (!supportsRange) {
+                    var contentLength = conn.getContentLengthLong();
+                    conn.disconnect();
+                    return downloadMetadata(contentLength, fileUrl);
+                }
+            } catch (Exception e) {
+                throw new TechnicalException("Error getting idp metadata resource", e);
+            } finally {
+                if (conn != null) {
+                    conn.disconnect();
+                }
+            }
+        }
+
+        return loadMetadataFromResource(configuration.getIdentityProviderMetadataResource());
+    }
+
+    private DOMMetadataResolver downloadMetadata(final long contentLength, final String url) {
+        var numThreads = Runtime.getRuntime().availableProcessors();
+
+        var partSize = contentLength / numThreads;
+        var executor = Executors.newFixedThreadPool(numThreads);
+        try {
+            var destination = Files.createTempFile("idpmetadata", ".xml").toFile();
+            var futures = new ArrayList<Future<Void>>();
+
+            for (var i = 0; i < numThreads; i++) {
+                var start = i * partSize;
+                var end = i == numThreads - 1 ? contentLength - 1 : start + partSize - 1;
+
+                futures.add(executor.submit(() -> {
+                    var conn = (HttpURLConnection) new URL(url).openConnection();
+                    if (conn instanceof HttpsURLConnection https) {
+                        if (hostnameVerifier != null) {
+                            https.setHostnameVerifier(hostnameVerifier);
+                        }
+                        if (sslSocketFactory != null) {
+                            https.setSSLSocketFactory(sslSocketFactory);
+                        }
+                    }
+                    conn.setRequestProperty("Range", "bytes=" + start + '-' + end);
+
+                    try (var in = conn.getInputStream(); var out = new RandomAccessFile(destination, "rw")) {
+                        out.seek(start);
+                        var buffer = new byte[8192];
+                        var bytesRead = 0;
+                        while ((bytesRead = in.read(buffer)) != -1) {
+                            out.write(buffer, 0, bytesRead);
+                        }
+                    } finally {
+                        conn.disconnect();
+                    }
+                    return null;
+                }));
+            }
+
+            for (var future : futures) {
+                future.get();
+            }
+            executor.shutdown();
+
+            var resource = new FileSystemResource(destination);
+            return loadMetadataFromResource(resource);
+        } catch (Exception e) {
+            throw new TechnicalException("Error downloading idp metadata", e);
+        }
+    }
+
+    private DOMMetadataResolver loadMetadataFromResource(final Resource resource) {
         try (var in = SpringResourceHelper.getResourceInputStream(
-            configuration.getIdentityProviderMetadataResource(),
+            resource,
             proxy,
             sslSocketFactory,
             hostnameVerifier,
@@ -136,7 +228,6 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
         return idpEntityId;
     }
 
-    /** {@inheritDoc} */
     @Override
     public String getEntityId() {
         val md = getEntityDescriptorElement();
@@ -149,7 +240,6 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
         throw new SAMLException("No idp entityId found");
     }
 
-    /** {@inheritDoc} */
     @Override
     public String getMetadata() {
         if (getEntityDescriptorElement() != null) {
@@ -158,7 +248,9 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
         throw new TechnicalException("Metadata cannot be retrieved because entity descriptor is null");
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public final XMLObject getEntityDescriptorElement() {
         try {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -128,8 +128,8 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
 
         var partSize = contentLength / numThreads;
         var executor = Executors.newFixedThreadPool(numThreads);
+        var destination = Files.createTempFile("idpmetadata", ".xml").toFile();
         try {
-            var destination = Files.createTempFile("idpmetadata", ".xml").toFile();
             var futures = new ArrayList<Future<Void>>();
 
             for (var i = 0; i < numThreads; i++) {
@@ -171,6 +171,8 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
             return loadMetadataFromResource(resource);
         } catch (Exception e) {
             throw new TechnicalException("Error downloading idp metadata", e);
+        } finally {
+            destination.delete();
         }
     }
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -106,7 +106,7 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
                 }
                 conn.setRequestMethod("HEAD");
                 var supportsRange = "bytes".equalsIgnoreCase(conn.getHeaderField("Accept-Ranges"));
-                if (!supportsRange) {
+                if (supportsRange) {
                     var contentLength = conn.getContentLengthLong();
                     conn.disconnect();
                     return downloadMetadata(contentLength, fileUrl);

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolver.java
@@ -30,7 +30,6 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
@@ -38,8 +37,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
@@ -88,7 +85,7 @@ public class SAML2IdentityProviderMetadataResolver extends SpringResourceLoader<
             this.loaded = initializeMetadataResolver();
         } finally {
             val t1 = System.currentTimeMillis();
-            LOGGER.error("Metadata resolution took: {} ms", t1 - t0);
+            LOGGER.debug("Metadata resolution took: {} ms", t1 - t0);
         }
 
     }

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolverTest.java
@@ -118,6 +118,16 @@ public class SAML2IdentityProviderMetadataResolverTest {
     }
 
     @Test
+    public void resolveMetadataConcurrently() throws Exception {
+        var configuration = new SAML2Configuration();
+        var resource = new UrlResource("https://md.incommon.org/InCommon/InCommon-metadata-idp-only.xml");
+        configuration.setIdentityProviderMetadataResource(resource);
+        metadataResolver = new SAML2IdentityProviderMetadataResolver(configuration);
+        var resolver = metadataResolver.resolve();
+        assertNotNull(resolver);
+    }
+
+    @Test
     public void resolveExpiringMetadata() {
         var configuration = new SAML2Configuration();
         configuration.setIdentityProviderMetadataResource(new ClassPathResource("expired-idp-metadata.xml"));


### PR DESCRIPTION
This pull request attempts to download and resolve metadata concurrently using the number of cores available to the system, if the metadata resource is a URL and supports the `Accept-Ranges` header as `bytes`. When this condition is true, the metadata download is split into multiple threads and downloaded partially, and then assembled into a temporary file before it's parsed and resolved. 

If the resource is not a URL or if the URL does not support this concept, we fall back to the current method.  

This is primarily useful with large metadata artifacts, such as those that are aggregates. 

The test demonstrates the performance improvement using `https://md.incommon.org/InCommon/InCommon-metadata-idp-only.xml` which is approximately 50+ MBs. 

On my workstation with approximately 10 cores:

- Without this change: `Metadata resolution took: 38881 ms`
- With this change: `Metadata resolution took: 8629 ms`

As you observe, the performance gain is roughly 4x. 
