### PR TITLE
Conditionally enable SAML2 SP metadata merging per generator

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2InMemoryMetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2InMemoryMetadataGenerator.java
@@ -27,4 +27,9 @@ public class SAML2InMemoryMetadataGenerator extends BaseSAML2MetadataGenerator {
         metadataResource = new ByteArrayResource(metadata.getBytes(StandardCharsets.UTF_8));
         return metadataResource.exists();
     }
+
+    @Override
+    public boolean canMerge() {
+        return false;
+    }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2MetadataGenerator.java
@@ -51,4 +51,8 @@ public interface SAML2MetadataGenerator {
      * @throws Exception the exception
      */
     boolean merge(SAML2Configuration configuration) throws Exception ;
+
+    default boolean canMerge() {
+        return true;
+    }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -52,7 +52,7 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
                 val metadata = metadataGenerator.getMetadata(entity);
                 metadataGenerator.storeMetadata(metadata,
                     configuration.isForceServiceProviderMetadataGeneration());
-            } else if (resource.exists()) {
+            } else if (resource.exists() && metadataGenerator.canMerge()) {
                 metadataGenerator.merge(configuration);
             }
             return metadataGenerator.buildMetadataResolver();


### PR DESCRIPTION
 Small change to mainly remove and disable merging support for generators that don't need it. 