### PR TITLE
Load saml2 credential provider once

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -141,6 +141,8 @@ public class SAML2Configuration extends BaseClientConfiguration {
 
     private SAML2MetadataGenerator metadataGenerator;
 
+    private CredentialProvider credentialProvider;
+
     private boolean authnRequestSigned;
 
     private boolean spLogoutRequestSigned;
@@ -486,7 +488,10 @@ public class SAML2Configuration extends BaseClientConfiguration {
      * @return a {@link CredentialProvider} object
      */
     public CredentialProvider getCredentialProvider() {
-        return new KeyStoreCredentialProvider(this);
+        if (credentialProvider == null) {
+            credentialProvider = new KeyStoreCredentialProvider(this);
+        }
+        return credentialProvider;
     }
 
     /**


### PR DESCRIPTION
If `getCredentialProvider()` is called multiple times, the keystore is parsed every time. This PR changes this behavior so the credential provider is created only once when necessary.