### PR TITLE
SAML2 entity metadata resolver to consider entity criteria

### DIFF
--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2DelegatingMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2DelegatingMetadataResolver.java
@@ -2,16 +2,11 @@ package org.pac4j.saml.metadata;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import net.shibboleth.shared.resolver.CriteriaSet;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
 import org.opensaml.saml.metadata.resolver.impl.AbstractMetadataResolver;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.pac4j.saml.exceptions.SAMLException;
 import org.pac4j.saml.util.Configuration;
-
-import javax.annotation.Nonnull;
-import java.util.List;
-import java.util.Objects;
 
 /**
  * A metadata resolver that delegates to an existing one.
@@ -28,7 +23,7 @@ public class SAML2DelegatingMetadataResolver implements SAML2MetadataResolver {
     public MetadataResolver resolve(final boolean force) {
         if (metadataResolver == null) {
             try {
-                metadataResolver = new EntityDescriptorMetadataResolver(entityDescriptorElement);
+                metadataResolver = new SAML2EntityDescriptorMetadataResolver(entityDescriptorElement);
                 metadataResolver.initialize();
             } catch (Exception e) {
                 throw new SAMLException("Unable to initialize metadata resolver for " + entityDescriptorElement.getEntityID(), e);
@@ -45,24 +40,6 @@ public class SAML2DelegatingMetadataResolver implements SAML2MetadataResolver {
     @Override
     public String getMetadata() {
         return Configuration.serializeSamlObject(entityDescriptorElement).toString();
-    }
-
-    private static class EntityDescriptorMetadataResolver extends AbstractMetadataResolver {
-        private final EntityDescriptor entityDescriptor;
-
-        public EntityDescriptorMetadataResolver(final EntityDescriptor entityDescriptor) {
-            this.entityDescriptor = entityDescriptor;
-            setId(Objects.requireNonNull(entityDescriptor.getEntityID()));
-            setRequireValidMetadata(true);
-            setParserPool(Configuration.getParserPool());
-            setFailFastInitialization(true);
-        }
-
-        @Nonnull
-        @Override
-        protected Iterable<EntityDescriptor> doResolve(final CriteriaSet criteria) {
-            return List.of(entityDescriptor);
-        }
     }
 
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2EntityDescriptorMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2EntityDescriptorMetadataResolver.java
@@ -13,12 +13,6 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * This is {@link SAML2EntityDescriptorMetadataResolver}.
- *
- * @author Misagh Moayyed
- * @since 7.2.0
- */
 @Slf4j
 @Getter
 public class SAML2EntityDescriptorMetadataResolver extends AbstractBatchMetadataResolver {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2EntityDescriptorMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2EntityDescriptorMetadataResolver.java
@@ -1,0 +1,44 @@
+package org.pac4j.saml.metadata;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import net.shibboleth.shared.resolver.CriteriaSet;
+import net.shibboleth.shared.resolver.ResolverException;
+import org.opensaml.core.criterion.EntityIdCriterion;
+import org.opensaml.saml.metadata.resolver.impl.AbstractBatchMetadataResolver;
+import org.opensaml.saml.saml2.metadata.EntityDescriptor;
+import org.pac4j.saml.util.Configuration;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This is {@link SAML2EntityDescriptorMetadataResolver}.
+ *
+ * @author Misagh Moayyed
+ * @since 7.2.0
+ */
+@Slf4j
+@Getter
+public class SAML2EntityDescriptorMetadataResolver extends AbstractBatchMetadataResolver {
+    private final EntityDescriptor entityDescriptor;
+
+    public SAML2EntityDescriptorMetadataResolver(final EntityDescriptor entityDescriptor) {
+        this.entityDescriptor = entityDescriptor;
+        setId(Objects.requireNonNull(entityDescriptor.getEntityID()));
+        setRequireValidMetadata(true);
+        setParserPool(Configuration.getParserPool());
+        setFailFastInitialization(true);
+    }
+
+    @Nonnull
+    @Override
+    protected Iterable<EntityDescriptor> doResolve(final CriteriaSet criteria) throws ResolverException {
+        var entityIdCriterion = criteria != null ? criteria.get(EntityIdCriterion.class) : null;
+        if (entityIdCriterion == null || entityIdCriterion.getEntityId().equals(entityDescriptor.getEntityID())) {
+            return List.of(entityDescriptor);
+        }
+        return List.of();
+    }
+}


### PR DESCRIPTION
`SAML2EntityDescriptorMetadataResolver` blindly returns the resolved entity descriptor regardless of what criteria is passed. In this pull request, it will return the entity if criteria is specified and entity id is a match. If no criteria is found, it will fall back on the previous behavior.