### PR TITLE
Resolve file-system sp metadata once w/o reloads

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,6 +5,9 @@ title: Release notes&#58;
 
 ### JDK17:
 
+**v6.1.3**:
+- SAML2 operations that use `FilesystemMetadataResolver` are replaced with a DOM parser instead.
+
 **v6.1.2**:
 - Use the configured scope in OpenID Connect authenticator
 - Fix the `getFullRequestURL` method

--- a/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/client/SAML2Client.java
@@ -13,12 +13,7 @@ import org.pac4j.saml.context.SAML2ContextProvider;
 import org.pac4j.saml.context.SAMLContextProvider;
 import org.pac4j.saml.credentials.authenticator.SAML2Authenticator;
 import org.pac4j.saml.credentials.extractor.SAML2CredentialsExtractor;
-import org.pac4j.saml.crypto.DefaultSignatureSigningParametersProvider;
-import org.pac4j.saml.crypto.ExplicitSignatureTrustEngineProvider;
-import org.pac4j.saml.crypto.KeyStoreDecryptionProvider;
-import org.pac4j.saml.crypto.LogOnlySignatureTrustEngineProvider;
-import org.pac4j.saml.crypto.SAML2SignatureTrustEngineProvider;
-import org.pac4j.saml.crypto.SignatureSigningParametersProvider;
+import org.pac4j.saml.crypto.*;
 import org.pac4j.saml.logout.SAML2LogoutActionBuilder;
 import org.pac4j.saml.logout.impl.SAML2LogoutRequestMessageSender;
 import org.pac4j.saml.logout.impl.SAML2LogoutValidator;
@@ -36,8 +31,6 @@ import org.pac4j.saml.sso.impl.SAML2WebSSOMessageSender;
 import org.pac4j.saml.state.SAML2StateGenerator;
 import org.pac4j.saml.util.Configuration;
 
-import java.io.Closeable;
-
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
 /**
@@ -52,7 +45,7 @@ import static org.pac4j.core.util.CommonHelper.assertNotNull;
 @NoArgsConstructor
 @Getter
 @Setter
-public class SAML2Client extends IndirectClient implements Closeable {
+public class SAML2Client extends IndirectClient {
 
     protected SAMLContextProvider contextProvider;
 
@@ -260,10 +253,6 @@ public class SAML2Client extends IndirectClient implements Closeable {
         }
     }
 
-    public void destroy() {
-        ((SAML2ServiceProviderMetadataResolver) serviceProviderMetadataResolver).destroy();
-    }
-
     @Override
     public void notifySessionRenewal(final CallContext ctx, final String oldSessionId) {
         val sessionLogoutHandler = findSessionLogoutHandler();
@@ -278,10 +267,5 @@ public class SAML2Client extends IndirectClient implements Closeable {
 
     public final String getServiceProviderResolvedEntityId() {
         return this.serviceProviderMetadataResolver.getEntityId();
-    }
-
-    @Override
-    public void close() {
-        destroy();
     }
 }

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2FileSystemMetadataGenerator.java
@@ -28,21 +28,19 @@ import java.nio.charset.StandardCharsets;
 public class SAML2FileSystemMetadataGenerator extends BaseSAML2MetadataGenerator {
 
     private final Resource metadataResource;
-    private AbstractMetadataResolver metadataResolver;
 
     @Override
     protected AbstractMetadataResolver createMetadataResolver() throws Exception {
-        if (metadataResolver == null
-            && metadataResource != null
+        if (metadataResource != null
             && metadataResource.exists()
             && metadataResource.isReadable()
             && metadataResource.isFile()) {
             try (val is = metadataResource.getInputStream()) {
                 var document = Configuration.getParserPool().parse(is);
-                metadataResolver = new DOMMetadataResolver(document.getDocumentElement());
+                return new DOMMetadataResolver(document.getDocumentElement());
             }
         }
-        return metadataResolver;
+        return null;
     }
 
     @Override

--- a/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/metadata/SAML2ServiceProviderMetadataResolver.java
@@ -6,7 +6,6 @@ import net.shibboleth.shared.resolver.ResolverException;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.metadata.resolver.MetadataResolver;
-import org.opensaml.saml.metadata.resolver.impl.FilesystemMetadataResolver;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.pac4j.saml.exceptions.SAMLException;
 
@@ -21,27 +20,11 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
     protected final SAML2Configuration configuration;
     private MetadataResolver metadataResolver;
 
-    /**
-     * <p>Constructor for SAML2ServiceProviderMetadataResolver.</p>
-     *
-     * @param configuration a {@link SAML2Configuration} object
-     */
     public SAML2ServiceProviderMetadataResolver(final SAML2Configuration configuration) {
         this.configuration = configuration;
         this.metadataResolver = prepareServiceProviderMetadata();
     }
 
-    /**
-     * <p>destroy.</p>
-     */
-    public void destroy() {
-        if (this.metadataResolver instanceof FilesystemMetadataResolver) {
-            ((FilesystemMetadataResolver) this.metadataResolver).destroy();
-            this.metadataResolver = null;
-        }
-    }
-
-    @SuppressWarnings("unchecked")
     protected MetadataResolver prepareServiceProviderMetadata() {
         try {
             val metadataGenerator = configuration.toMetadataGenerator();
@@ -61,9 +44,6 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final MetadataResolver resolve(final boolean force) {
         if (force) {
@@ -72,17 +52,11 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
         return this.metadataResolver;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final String getEntityId() {
         return configuration.getServiceProviderEntityId();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public String getMetadata() {
         try {
@@ -94,9 +68,6 @@ public class SAML2ServiceProviderMetadataResolver implements SAML2MetadataResolv
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public XMLObject getEntityDescriptorElement() {
         try {


### PR DESCRIPTION
This pull request removes the `FilesystemMetadataResolver` and replaces it with a DOM parser only. This change allows the metadata to only be parsed once, and without background timer threads that tend to refresh the metadata periodically (and cannot be disabled).