### PR TITLE
OIDC: prevent creating a profile from an unvalidated access token

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -7,6 +7,7 @@ title: Release notes&#58;
 
 **v6.1.3**:
 - SAML2 operations that use `FilesystemMetadataResolver` are replaced with a DOM parser instead.
+- OIDC: prevent creating a profile from an unvalidated access token
 
 **v6.1.2**:
 - Use the configured scope in OpenID Connect authenticator

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -68,6 +68,13 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
         assertNotNull("configuration", configuration);
 
         setProfileDefinitionIfUndefined(new OidcProfileDefinition());
+
+        if (!configuration.isCallUserInfoEndpoint()
+            && (client.getAuthenticator() == null || client.getAuthenticator() == ALWAYS_VALIDATE)) {
+            // prevent creating a profile from an unvalidated access token
+            throw new OidcConfigurationException("You cannot disable the call to the UserInfo endpoint " +
+                "without providing an authenticator");
+        }
     }
 
     /** {@inheritDoc} */
@@ -137,11 +144,6 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
                         return Optional.empty();
                     }
                 }
-            } else if (oidcCredentials == null
-                && (client.getAuthenticator() == null || client.getAuthenticator().equals(ALWAYS_VALIDATE))) {
-                // prevent creating a profile from an unvalidated access token
-                throw new OidcConfigurationException("You cannot disable the call to the UserInfo endpoint " +
-                    "without providing an authenticator");
             }
 
             // add attributes of the ID token if they don't already exist

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -24,6 +24,7 @@ import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
+import org.pac4j.oidc.exceptions.OidcConfigurationException;
 import org.pac4j.oidc.exceptions.OidcException;
 import org.pac4j.oidc.exceptions.UserInfoErrorResponseException;
 import org.pac4j.oidc.profile.OidcProfile;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 
+import static org.pac4j.core.credentials.authenticator.Authenticator.ALWAYS_VALIDATE;
 import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 import static org.pac4j.core.util.CommonHelper.assertNotNull;
 
@@ -135,6 +137,11 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
                         return Optional.empty();
                     }
                 }
+            } else if (oidcCredentials == null
+                && (client.getAuthenticator() == null || client.getAuthenticator().equals(ALWAYS_VALIDATE))) {
+                // prevent creating a profile from an unvalidated access token
+                throw new OidcConfigurationException("You cannot disable the call to the UserInfo endpoint " +
+                    "without providing an authenticator");
             }
 
             // add attributes of the ID token if they don't already exist

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
@@ -21,6 +21,7 @@ import org.pac4j.core.util.TestsConstants;
 import org.pac4j.oidc.client.OidcClient;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
+import org.pac4j.oidc.credentials.authenticator.OidcAuthenticator;
 import org.pac4j.oidc.exceptions.OidcConfigurationException;
 import org.pac4j.oidc.metadata.OidcOpMetadataResolver;
 
@@ -77,7 +78,9 @@ public class OidcProfileCreatorTests implements TestsConstants {
     @Test
     public void testCreateOidcProfile() throws Exception {
         when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(true);
-        ProfileCreator creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
+        OidcClient client = new OidcClient(configuration);
+        client.setAuthenticator(new OidcAuthenticator(configuration, client));
+        ProfileCreator creator = new OidcProfileCreator(configuration, client);
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
         credentials.setAccessToken(new BearerAccessToken(UUID.randomUUID().toString()).toJSONObject());
@@ -89,7 +92,9 @@ public class OidcProfileCreatorTests implements TestsConstants {
     @Test
     public void testCreateOidcProfileWithoutAccessToken() throws Exception {
         when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(true);
-        ProfileCreator creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
+        OidcClient client = new OidcClient(configuration);
+        client.setAuthenticator(new OidcAuthenticator(configuration, client));
+        ProfileCreator creator = new OidcProfileCreator(configuration, client);
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
         credentials.setAccessToken(null);
@@ -101,7 +106,9 @@ public class OidcProfileCreatorTests implements TestsConstants {
     @Test
     public void testCreateOidcProfileJwtAccessToken() throws Exception {
         when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(false);
-        ProfileCreator creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
+        OidcClient client = new OidcClient(configuration);
+        client.setAuthenticator(new OidcAuthenticator(configuration, client));
+        ProfileCreator creator = new OidcProfileCreator(configuration, client);
         var webContext = MockWebContext.create();
         var credentials = new OidcCredentials();
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
@@ -133,11 +133,7 @@ public class OidcProfileCreatorTests implements TestsConstants {
         var accessTokenToken = new PlainJWT(accessTokenClaims);
         credentials.setToken(accessTokenToken.serialize());
 
-        try {
-            creator.create(new CallContext(webContext, new MockSessionStore()), credentials);
-            fail("The profile must not be created if CallUserInfoEndpoint is disabled and no authenticator is provided");
-        } catch (OidcConfigurationException e) {
-            // Expected
-        }
+        assertThrows(OidcConfigurationException.class,
+            () -> creator.create(new CallContext(webContext, new MockSessionStore()), credentials));
     }
 }


### PR DESCRIPTION
This PR aims at preventing a misconfiguration of the OidcProfileCreator that would allow the creation of a user profile from an unvalidated Bearer access token.

It follows a discussion with J. Leleu.