### PR TITLE
OIDC: prevent creating a profile from an unvalidated access token

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -6,6 +6,7 @@ title: Release notes&#58;
 **v5.7.8**:
 - Fix bug for HTML values in POST forms
 - Fix the `getFullRequestURL` method
+- OIDC: prevent creating a profile from an unvalidated access token
 
 **v5.7.7**:
 - Security fix: cannot accept empty OIDC credentials

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
 
+import static org.pac4j.core.credentials.authenticator.Authenticator.ALWAYS_VALIDATE;
 import static org.pac4j.core.profile.AttributeLocation.PROFILE_ATTRIBUTE;
 import static org.pac4j.core.util.CommonHelper.*;
 
@@ -59,6 +60,13 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
         assertNotNull("configuration", configuration);
 
         defaultProfileDefinition(new OidcProfileDefinition());
+
+        if (!configuration.isCallUserInfoEndpoint()
+            && (client.getAuthenticator() == null || client.getAuthenticator() == ALWAYS_VALIDATE)) {
+            // prevent creating a profile from an unvalidated access token
+            throw new TechnicalException("You cannot disable the call to the UserInfo endpoint " +
+                "without providing an authenticator");
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR is the backport to 5.7.x branch of [PR 3370](https://github.com/pac4j/pac4j/pull/3370).
It prevents a misconfiguration of the OidcProfileCreator that would allow the creation of a user profile from an unvalidated Bearer access token.
