### PR TITLE
Allow SAML2 idp url resource to consider SAML2 connection config

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,6 +5,9 @@ title: Release notes&#58;
 
 ### JDK17:
 
+**v6.1.4**:
+- Downloading SAML2 metadata over a URL is able to support SSL context and hostname verification options when checking for metadata updates.
+
 **v6.1.3**:
 - SAML2 operations that use `FilesystemMetadataResolver` are replaced with a DOM parser instead.
 - OIDC: prevent creating a profile from an unvalidated access token

--- a/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/config/SAML2Configuration.java
@@ -30,6 +30,7 @@ import org.pac4j.saml.sso.impl.SAML2ScopingIdentityProvider;
 import org.pac4j.saml.store.EmptyStoreFactory;
 import org.pac4j.saml.store.SAMLMessageStoreFactory;
 import org.pac4j.saml.util.SAML2HttpClientBuilder;
+import org.pac4j.saml.util.SAML2UrlResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
@@ -246,16 +247,6 @@ public class SAML2Configuration extends BaseClientConfiguration {
             DEFAULT_PROVIDER_NAME, null, null);
     }
 
-    /**
-     * <p>Constructor for SAML2Configuration.</p>
-     *
-     * @param keystoreResource                 a {@link Resource} object
-     * @param keyStoreAlias                    a {@link String} object
-     * @param keyStoreType                     a {@link String} object
-     * @param keystorePassword                 a {@link String} object
-     * @param privateKeyPassword               a {@link String} object
-     * @param identityProviderMetadataResource a {@link Resource} object
-     */
     public SAML2Configuration(final Resource keystoreResource, final String keyStoreAlias,
                               final String keyStoreType, final String keystorePassword, final String privateKeyPassword,
                               final Resource identityProviderMetadataResource) {
@@ -264,21 +255,6 @@ public class SAML2Configuration extends BaseClientConfiguration {
             null, DEFAULT_PROVIDER_NAME, null, null);
     }
 
-    /**
-     * <p>Constructor for SAML2Configuration.</p>
-     *
-     * @param keyStoreAlias                    a {@link String} object
-     * @param keyStoreType                     a {@link String} object
-     * @param keystoreResource                 a {@link Resource} object
-     * @param keystorePassword                 a {@link String} object
-     * @param privateKeyPassword               a {@link String} object
-     * @param identityProviderMetadataResource a {@link Resource} object
-     * @param identityProviderEntityId         a {@link String} object
-     * @param serviceProviderEntityId          a {@link String} object
-     * @param providerName                     a {@link String} object
-     * @param authnRequestExtensions           a {@link Supplier} object
-     * @param attributeAsId                    a {@link String} object
-     */
     protected SAML2Configuration(final String keyStoreAlias, final String keyStoreType,
                                  final Resource keystoreResource, final String keystorePassword,
                                  final String privateKeyPassword, final Resource identityProviderMetadataResource,
@@ -290,7 +266,11 @@ public class SAML2Configuration extends BaseClientConfiguration {
         this.keystoreResource = keystoreResource;
         this.keystorePassword = keystorePassword;
         this.privateKeyPassword = privateKeyPassword;
-        this.identityProviderMetadataResource = identityProviderMetadataResource;
+        if (identityProviderMetadataResource instanceof UrlResource urlResource) {
+            this.identityProviderMetadataResource = new SAML2UrlResource(urlResource.getURL(), this);
+        } else {
+            this.identityProviderMetadataResource = identityProviderMetadataResource;
+        }
         this.identityProviderEntityId = identityProviderEntityId;
         this.serviceProviderEntityId = serviceProviderEntityId;
         this.providerName = providerName;

--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/SAML2UrlResource.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/SAML2UrlResource.java
@@ -1,5 +1,6 @@
 package org.pac4j.saml.util;
 
+import lombok.EqualsAndHashCode;
 import org.pac4j.saml.config.SAML2Configuration;
 import org.springframework.core.io.UrlResource;
 
@@ -13,6 +14,7 @@ import java.net.URL;
  *
  * @author Misagh Moayyed
  */
+@EqualsAndHashCode(callSuper = true)
 public class SAML2UrlResource extends UrlResource {
     private final SAML2Configuration saml2Configuration;
 

--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/SAML2UrlResource.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/SAML2UrlResource.java
@@ -13,6 +13,7 @@ import java.net.URL;
  * This is {@link SAML2UrlResource}.
  *
  * @author Misagh Moayyed
+ * @since 6.1.4
  */
 @EqualsAndHashCode(callSuper = true)
 public class SAML2UrlResource extends UrlResource {

--- a/pac4j-saml/src/main/java/org/pac4j/saml/util/SAML2UrlResource.java
+++ b/pac4j-saml/src/main/java/org/pac4j/saml/util/SAML2UrlResource.java
@@ -1,0 +1,36 @@
+package org.pac4j.saml.util;
+
+import org.pac4j.saml.config.SAML2Configuration;
+import org.springframework.core.io.UrlResource;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * This is {@link SAML2UrlResource}.
+ *
+ * @author Misagh Moayyed
+ */
+public class SAML2UrlResource extends UrlResource {
+    private final SAML2Configuration saml2Configuration;
+
+    public SAML2UrlResource(final URL url, final SAML2Configuration saml2Configuration) {
+        super(url);
+        this.saml2Configuration = saml2Configuration;
+    }
+
+    @Override
+    protected void customizeConnection(final HttpURLConnection connection) throws IOException {
+        super.customizeConnection(connection);
+        if (connection instanceof HttpsURLConnection httpsURLConnection) {
+            if (saml2Configuration.getSslSocketFactory() != null) {
+                httpsURLConnection.setSSLSocketFactory(saml2Configuration.getSslSocketFactory());
+            }
+            if (saml2Configuration.getHostnameVerifier() != null) {
+                httpsURLConnection.setHostnameVerifier(saml2Configuration.getHostnameVerifier());
+            }
+        }
+    }
+}

--- a/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolverTest.java
+++ b/pac4j-saml/src/test/java/org/pac4j/saml/metadata/SAML2IdentityProviderMetadataResolverTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.opensaml.core.criterion.EntityIdCriterion;
 import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.saml.config.SAML2Configuration;
+import org.pac4j.saml.util.SAML2UrlResource;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.UrlResource;
@@ -16,6 +17,7 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.net.URL;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 
@@ -120,7 +122,9 @@ public class SAML2IdentityProviderMetadataResolverTest {
     @Test
     public void resolveMetadataConcurrently() throws Exception {
         var configuration = new SAML2Configuration();
-        var resource = new UrlResource("https://md.incommon.org/InCommon/InCommon-metadata-idp-only.xml");
+        configuration.setSslSocketFactory(disabledSslContext().getSocketFactory());
+        configuration.setHostnameVerifier((s, sslSession) -> true);
+        var resource = new SAML2UrlResource(new URL("https://md.incommon.org/InCommon/InCommon-metadata-idp-only.xml"), configuration);
         configuration.setIdentityProviderMetadataResource(resource);
         metadataResolver = new SAML2IdentityProviderMetadataResolver(configuration);
         var resolver = metadataResolver.resolve();
@@ -135,4 +139,6 @@ public class SAML2IdentityProviderMetadataResolverTest {
         metadataResolver.init();
         assertNull(metadataResolver.getEntityDescriptorElement());
     }
+
+
 }


### PR DESCRIPTION
## Problem

This patch fixes a minor problem (or adds an enhancement) when the SAML2 identity provider metadata is configured using a URL. When the resolution process kicks in, the loading process attempts to check for changes by invoking `hasChanged()` and eventually `lastModified` on the URL resource. If the URL causes a SSL handshake exception, metadata is never downloaded which eventually causes the application to error out.

This generally is expected; however if the SAML2 configuration is configured to use a custom SSL context and hostname verifier, these are ignored during this step. They are only taken into account when the metadata is itself downloaded, but we are not quite there while checking for changes to determine the need for the download.

## Fix

The fix here wraps the current URL resource into one that is aware of the SAML2 configuration, and customizes the connection as necessary before interacting with the real source.

Tests are provided to demonstrate the difference with or without configuration options.