### PR TITLE
SunJaasKerberosTicketValidator fails with spaces in keytab path

### DIFF
--- a/pac4j-kerberos/src/main/java/org/pac4j/kerberos/credentials/authenticator/SunJaasKerberosTicketValidator.java
+++ b/pac4j-kerberos/src/main/java/org/pac4j/kerberos/credentials/authenticator/SunJaasKerberosTicketValidator.java
@@ -15,6 +15,7 @@ import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.security.Principal;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -67,6 +68,14 @@ public class SunJaasKerberosTicketValidator extends InitializableObject implemen
             if (keyTabLocationAsString.startsWith("file:")) {
                 keyTabLocationAsString = keyTabLocationAsString.substring(5);
             }
+
+            // Add URL decoding, so we don't allow encoded white spaces
+            try {
+                keyTabLocationAsString = URLDecoder.decode(keyTabLocationAsString, "UTF-8");
+            } catch (Exception e) {
+                // Handle appropriately
+            }
+
             var loginConfig = new LoginConfig(keyTabLocationAsString, this.servicePrincipal,
                 this.debug);
             Set<Principal> princ = new HashSet<>(1);


### PR DESCRIPTION
Description: SunJaasKerberosTicketValidator fails to load keytab files when path contains spaces due to URL encoding issue.

Steps to Reproduce:
Place keytab in path with spaces: /Library/Application Support/app/keytab.keytab


1
validator.setKeyTabLocation(new FileSystemResource("/Library/Application Support/app/keytab.keytab"));
Attempt Kerberos authentication
Observe error: Cannot find key of appropriate type to decrypt AP-REQ
 Root Cause:  In internalInit(), the code removes file: prefix but doesn't decode URL-encoded characters like %20: