### PR TITLE
Permits to ignore nonce for idToken on refresh (OIDC)

### DIFF
--- a/documentation/docs/clients/openid-connect.md
+++ b/documentation/docs/clients/openid-connect.md
@@ -170,8 +170,8 @@ Since version 5.2 and to reinforce security, the `none` alogithm for ID tokens (
 config.setAllowUnsignedIdTokens(true);
 ```
 
-Since version 6.0.5 and to reinforce security, the logout requests are validated. This can be disabled using:
+Since version 6.2.2, the nonce for idToken can be ignored on refresh. This can be ignored using:
 
 ```java
-config.setLogoutValidation(false);
+config.setUseNonceOnRefresh(false);
 ```

--- a/documentation/docs/clients/openid-connect.md
+++ b/documentation/docs/clients/openid-connect.md
@@ -170,6 +170,12 @@ Since version 5.2 and to reinforce security, the `none` alogithm for ID tokens (
 config.setAllowUnsignedIdTokens(true);
 ```
 
+Since version 6.0.5 and to reinforce security, the logout requests are validated. This can be disabled using:
+
+```java
+config.setLogoutValidation(false);
+```
+
 Since version 6.2.2, the nonce for idToken can be ignored on refresh. This can be ignored using:
 
 ```java

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -7,7 +7,8 @@ title: Release notes&#58;
 
 **v6.2.2**:
 - Fix the X509 `SubjectDN` parsing
-
+- OIDC: Allow to ignore nonce for idToken on refresh
+ 
 **v6.2.1**:
 - Fix the SAML `IssueInstant` check
 - Fix the conditional `Authorization` header

--- a/pac4j-config/src/main/java/org/pac4j/config/builder/OidcClientBuilder.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/builder/OidcClientBuilder.java
@@ -67,6 +67,10 @@ public class OidcClientBuilder extends AbstractBuilder {
                 if (StringUtils.isNotBlank(useNonce)) {
                     configuration.setUseNonce(Boolean.parseBoolean(useNonce));
                 }
+                val useNonceOnRefresh = getProperty(OIDC_USE_NONCE_ON_REFRESH, i);
+                if (StringUtils.isNotBlank(useNonceOnRefresh)) {
+                    configuration.setUseNonceOnRefresh(Boolean.parseBoolean(useNonceOnRefresh));
+                }
                 val withState = getProperty(OIDC_WITH_STATE, i);
                 if (StringUtils.isNotBlank(withState)) {
                     configuration.setWithState(Boolean.parseBoolean(withState));

--- a/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
+++ b/pac4j-config/src/main/java/org/pac4j/config/client/PropertiesConstants.java
@@ -161,6 +161,8 @@ public interface PropertiesConstants {
     String OIDC_DISCOVERY_URI = "oidc.discoveryUri";
     /** Constant <code>OIDC_USE_NONCE="oidc.useNonce"</code> */
     String OIDC_USE_NONCE = "oidc.useNonce";
+    /** Constant <code>OIDC_USE_NONCE_ON_REFRESH="oidc.useNonceOnRefresh"</code> */
+    String OIDC_USE_NONCE_ON_REFRESH = "oidc.useNonceOnRefresh";
     String OIDC_WITH_STATE = "oidc.withState";
     /** Constant <code>OIDC_PREFERRED_JWS_ALGORITHM="oidc.preferredJwsAlgorithm"</code> */
     String OIDC_PREFERRED_JWS_ALGORITHM = "oidc.preferredJwsAlgorithm";

--- a/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
+++ b/pac4j-config/src/test/java/org/pac4j/config/client/PropertiesConfigFactoryTests.java
@@ -90,6 +90,7 @@ public final class PropertiesConfigFactoryTests implements PropertiesConstants, 
             properties.put(OIDC_CLIENT_AUTHENTICATION_METHOD, "CLIENT_SECRET_POST");
             properties.put(OIDC_CUSTOM_PARAM_KEY + "1", KEY);
             properties.put(OIDC_CUSTOM_PARAM_VALUE + "1", VALUE);
+            properties.put(OIDC_USE_NONCE_ON_REFRESH, "false");
 
             properties.put(CAS_LOGIN_URL.concat(".1"), LOGIN_URL);
             properties.put(CAS_PROTOCOL.concat(".1"), CasProtocol.CAS30.toString());
@@ -164,6 +165,7 @@ public final class PropertiesConfigFactoryTests implements PropertiesConstants, 
             assertEquals(ClientAuthenticationMethod.CLIENT_SECRET_POST.toString(),
                 oidcClient.getConfiguration().getClientAuthenticationMethod().toString().toLowerCase());
             assertFalse(oidcClient.getConfiguration().isWithState());
+            assertFalse(oidcClient.getConfiguration().isUseNonceOnRefresh());
 
             val casClient1 = (CasClient) clients.findClient("CasClient.1").get();
             assertEquals(CasProtocol.CAS30, casClient1.getConfiguration().getProtocol());

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -81,6 +81,7 @@ public class OidcClient extends IndirectClient {
             credentials.setRefreshTokenObject(refreshToken);
             val authenticator = (OidcAuthenticator)getAuthenticator();
             authenticator.refresh(credentials);
+            credentials.setRefreshedCredentials(true);
 
             // Create a profile if the refresh grant was successful
             if (credentials.getAccessToken() != null) {

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -164,6 +164,9 @@ public class OidcConfiguration extends BaseClientConfiguration {
     /* use nonce? */
     private boolean useNonce;
 
+    /* use nonce on token obtained by refresh ? true by default to not change the initial behavior */
+    private boolean useNonceOnRefresh = true;
+
     /* disable PKCE, even when supported by the IdP */
     private boolean disablePkce = false;
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/OidcCredentials.java
@@ -43,6 +43,9 @@ public class OidcCredentials extends Credentials {
 
     private String idToken;
 
+    /** Flag set to true if the OidcCredentials are obtained by refreshing the token */
+    private boolean refreshedCredentials;
+
     @JsonIgnore
     public AuthorizationCode toAuthorizationCode() {
         return code != null ? new AuthorizationCode(this.code) : null;

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -85,7 +85,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
 
         OidcCredentials oidcCredentials = null;
         AccessToken accessToken = null;
-		// credentials were obtained from a refresh token
+        // credentials were obtained from a refresh token
         boolean refreshedCredentials = false;
         val regularOidcFlow = credentials instanceof OidcCredentials;
         if (regularOidcFlow) {


### PR DESCRIPTION
This PR allow to change the OidcConfiguration to ignore the nonce check during a refresh action.
When refreshing the tokens, a "RefreshedCredentials" flag is added to the OidcCredentials object.
When recreating the profile, the nonce is ignored if the credentials.isRefreshedCredentials() is true and configuration.isUseNonceOnRefresh() is false.
I kept the previous behavior if the configuration is unchanged, by default, isUseNonceOnRefresh() is true.

I updated the OidcClientBuilder too (I use it)

I didn't see how to easily create a Unit test for the nonce validation since the JWT validation is ignored with a mock in the existing tests :         when(tokenValidator.validate(any(), any())).thenAnswer(
                a -> IDTokenClaimsSet.parse(((JWT) a.getArgument(0)).getJWTClaimsSet().toString()));

Let me know if you want I change something.

https://groups.google.com/g/pac4j-dev/c/NJpqBQHoiM4