### PR TITLE
OIDC: Fix issue with rejected logout token (backchannel logout)

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -7,6 +7,7 @@ title: Release notes&#58;
 
 **v6.3.0**:
 - OIDC: Fix rejected logout token (back-channel logout, OIDC)
+- OIDC: Deprecate OidcConfiguration#logoutValidation
 - Use an empty string instead of `null` if need be for the conditional `Authorization` header (issue with Play)
 - Fix uninitialized components required for handling http artifact (SAML protocol)
 - Add `<meta charset>` tag to request saved during authentication

--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,7 +5,8 @@ title: Release notes&#58;
 
 ### JDK17:
 
-**v6.2.3**:
+**v6.3.0**:
+- OIDC: Fix rejected logout token (back-channel logout, OIDC)
 - Use an empty string instead of `null` if need be for the conditional `Authorization` header (issue with Play)
 - Fix uninitialized components required for handling http artifact (SAML protocol)
 - Add `<meta charset>` tag to request saved during authentication

--- a/pac4j-cas/pom.xml
+++ b/pac4j-cas/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-cas</artifactId>

--- a/pac4j-config/pom.xml
+++ b/pac4j-config/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-config</artifactId>

--- a/pac4j-core/pom.xml
+++ b/pac4j-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-core</artifactId>

--- a/pac4j-couch/pom.xml
+++ b/pac4j-couch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-couch</artifactId>

--- a/pac4j-gae/pom.xml
+++ b/pac4j-gae/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-gae</artifactId>

--- a/pac4j-http/pom.xml
+++ b/pac4j-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-http</artifactId>

--- a/pac4j-jakartaee/pom.xml
+++ b/pac4j-jakartaee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-jakartaee</artifactId>

--- a/pac4j-javaee/pom.xml
+++ b/pac4j-javaee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-javaee</artifactId>

--- a/pac4j-jwt/pom.xml
+++ b/pac4j-jwt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-jwt</artifactId>

--- a/pac4j-kerberos/pom.xml
+++ b/pac4j-kerberos/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-kerberos</artifactId>

--- a/pac4j-ldap/pom.xml
+++ b/pac4j-ldap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-ldap</artifactId>

--- a/pac4j-mongo/pom.xml
+++ b/pac4j-mongo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-mongo</artifactId>

--- a/pac4j-oauth/pom.xml
+++ b/pac4j-oauth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-oauth</artifactId>

--- a/pac4j-oidc/pom.xml
+++ b/pac4j-oidc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-oidc</artifactId>

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/azuread/AzureAdLogoutTokenValidator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/azuread/AzureAdLogoutTokenValidator.java
@@ -1,0 +1,54 @@
+package org.pac4j.oidc.client.azuread;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.openid.connect.sdk.claims.LogoutTokenClaimsSet;
+import com.nimbusds.openid.connect.sdk.validators.LogoutTokenValidator;
+
+import java.text.ParseException;
+
+/**
+ * Specialized logout token validator capable of handling the tenantid placeholder.
+ *
+ * @author Anna Weber
+ * @since 6.3.0
+ */
+public class AzureAdLogoutTokenValidator extends LogoutTokenValidator {
+
+    private LogoutTokenValidator base;
+    private String originalIssuer;
+
+    /**
+     * <p>Constructor for AzureAdLogoutTokenValidator.</p>
+     *
+     * @param base a {@link LogoutTokenValidator} object
+     */
+    public AzureAdLogoutTokenValidator(final LogoutTokenValidator base) {
+        super(base.getExpectedIssuer(), base.getClientID(), base.getJWSKeySelector(), base.getJWEKeySelector());
+        this.base = base;
+        this.originalIssuer = base.getExpectedIssuer().getValue();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public LogoutTokenClaimsSet validate(final JWT logoutToken) throws BadJOSEException, JOSEException {
+        try {
+            if (originalIssuer.contains("%7Btenantid%7D")) {
+                var tid = logoutToken.getJWTClaimsSet().getClaim("tid");
+                if (tid == null) {
+                    throw new BadJWTException("ID token does not contain the 'tid' claim");
+                }
+                base = new LogoutTokenValidator(new Issuer(originalIssuer.replace("%7Btenantid%7D", tid.toString())),
+                    base.getClientID(), base.getJWSKeySelector(), base.getJWEKeySelector());
+                base.setMaxClockSkew(getMaxClockSkew());
+            }
+        } catch (ParseException e) {
+            throw new BadJWTException(e.getMessage(), e);
+        }
+        return base.validate(logoutToken);
+    }
+
+}

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfiguration.java
@@ -232,6 +232,7 @@ public class OidcConfiguration extends BaseClientConfiguration {
 
     protected OidcOpMetadataResolver opMetadataResolver;
 
+    @Deprecated(forRemoval = true)
     private boolean logoutValidation = true;
 
     /**

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcCredentialsExtractor.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/credentials/extractor/OidcCredentialsExtractor.java
@@ -75,7 +75,7 @@ public class OidcCredentialsExtractor implements CredentialsExtractor {
                 }
                 String sessionId;
                 if (configuration.isLogoutValidation()) {
-                    val claims = configuration.getOpMetadataResolver().getTokenValidator().validate(jwt, null);
+                    val claims = configuration.getOpMetadataResolver().getTokenValidator().validateLogoutToken(jwt);
                     if (claims.getClaim(OidcConfiguration.NONCE) != null) {
                         LOGGER.error("The nonce claim should not exist for logout requests");
                         throw new BadRequestAction();

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdTokenValidator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/azuread/AzureAdTokenValidator.java
@@ -4,7 +4,9 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+import com.nimbusds.openid.connect.sdk.validators.LogoutTokenValidator;
 import org.pac4j.oidc.client.azuread.AzureAdIdTokenValidator;
+import org.pac4j.oidc.client.azuread.AzureAdLogoutTokenValidator;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.profile.creator.TokenValidator;
 
@@ -28,7 +30,12 @@ public class AzureAdTokenValidator extends TokenValidator {
 
     /** {@inheritDoc} */
     @Override
-    protected IDTokenValidator createRSATokenValidator(final JWSAlgorithm jwsAlgorithm, final ClientID clientID) {
-        return new AzureAdIdTokenValidator(super.createRSATokenValidator(jwsAlgorithm, clientID));
+    protected IDTokenValidator createRSAIdTokenValidator(final JWSAlgorithm jwsAlgorithm, final ClientID clientID) {
+        return new AzureAdIdTokenValidator(super.createRSAIdTokenValidator(jwsAlgorithm, clientID));
+    }
+
+    @Override
+    protected LogoutTokenValidator createRSALogoutTokenValidator(JWSAlgorithm jwsAlgorithm, ClientID clientID) {
+        return new AzureAdLogoutTokenValidator(super.createRSALogoutTokenValidator(jwsAlgorithm, clientID));
     }
 }

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -127,7 +127,8 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
             }
             // Check ID Token
             if (oidcCredentials != null && oidcCredentials.getIdToken() != null) {
-                val claimsSet = configuration.getOpMetadataResolver().getTokenValidator().validate(oidcCredentials.toIdToken(), nonce);
+                val claimsSet = configuration.getOpMetadataResolver().getTokenValidator()
+                    .validateIdToken(oidcCredentials.toIdToken(), nonce);
                 assertNotNull("claimsSet", claimsSet);
                 profile.setId(ProfileHelper.sanitizeIdentifier(claimsSet.getSubject()));
 
@@ -220,7 +221,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
             var accessToken = credentials.toAccessToken();
             if (accessToken != null) {
                 var accessTokenJwt = JWTParser.parse(accessToken.getValue());
-                var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validate(accessTokenJwt, nonce);
+                var accessTokenClaims = configuration.getOpMetadataResolver().getTokenValidator().validateIdToken(accessTokenJwt, nonce);
 
                 // add attributes of the access token if they don't already exist
                 for (val entry : accessTokenClaims.toJWTClaimsSet().getClaims().entrySet()) {

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
@@ -65,7 +65,7 @@ public class OidcProfileCreatorTests implements TestsConstants {
         when(configuration.getOpMetadataResolver()).thenReturn(metadataResolver);
 
         var tokenValidator = mock(TokenValidator.class);
-        when(tokenValidator.validate(any(), any())).thenAnswer(
+        when(tokenValidator.validateIdToken(any(), any())).thenAnswer(
                 a -> IDTokenClaimsSet.parse(((JWT) a.getArgument(0)).getJWTClaimsSet().toString()));
 
         when(metadataResolver.getTokenValidator()).thenReturn(tokenValidator);

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/TokenValidatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/TokenValidatorTests.java
@@ -5,8 +5,11 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import com.nimbusds.openid.connect.sdk.claims.LogoutTokenClaimsSet;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+import com.nimbusds.openid.connect.sdk.validators.LogoutTokenValidator;
+import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.pac4j.core.exception.TechnicalException;
@@ -71,9 +74,11 @@ public final class TokenValidatorTests implements TestsConstants {
         algorithms.add(JWSAlgorithm.parse("none"));
         when(configuration.isAllowUnsignedIdTokens()).thenReturn(true);
         final TokenValidator validator = new TokenValidator(configuration, metadata);
-        final List<IDTokenValidator> validators = validator.getIdTokenValidators();
-        assertEquals(1, validators.size());
-        assertTrue(validators.get(0) instanceof IDTokenValidator);
+        final List<IDTokenValidator> idTokenValidators = validator.getIdTokenValidators();
+        assertEquals(1, idTokenValidators.size());
+        assertTrue(idTokenValidators.get(0) instanceof IDTokenValidator);
+        final List<LogoutTokenValidator> logoutTokenValidators = validator.getLogoutTokenValidators();
+        assertEquals(0, logoutTokenValidators.size());
     }
 
     @Test
@@ -90,19 +95,29 @@ public final class TokenValidatorTests implements TestsConstants {
     public void testTwoAlgorithms() {
         algorithms.add(JWSAlgorithm.HS256);
         algorithms.add(JWSAlgorithm.RS256);
+        when(metadata.supportsBackChannelLogout()).thenReturn(true);
+
         final TokenValidator validator = new TokenValidator(configuration, metadata);
-        final List<IDTokenValidator> validators = validator.getIdTokenValidators();
-        assertEquals(2, validators.size());
+        final List<IDTokenValidator> idTokenValidators = validator.getIdTokenValidators();
+        assertEquals(2, idTokenValidators.size());
+
+        final List<LogoutTokenValidator> logoutTokenValidators = validator.getLogoutTokenValidators();
+        assertEquals(2, logoutTokenValidators.size());
     }
 
     @Test
     public void testTwoAlgorithmsOnePreferred() {
         algorithms.add(JWSAlgorithm.HS256);
         algorithms.add(JWSAlgorithm.RS256);
+        when(metadata.supportsBackChannelLogout()).thenReturn(true);
+
         when(configuration.getPreferredJwsAlgorithm()).thenReturn(JWSAlgorithm.HS256);
         final TokenValidator validator = new TokenValidator(configuration, metadata);
-        final List<IDTokenValidator> validators = validator.getIdTokenValidators();
-        assertEquals(1, validators.size());
+        final List<IDTokenValidator> idTokenValidators = validator.getIdTokenValidators();
+        assertEquals(1, idTokenValidators.size());
+
+        final List<LogoutTokenValidator> logoutTokenValidators = validator.getLogoutTokenValidators();
+        assertEquals(1, logoutTokenValidators.size());
     }
 
     @Test
@@ -122,12 +137,50 @@ public final class TokenValidatorTests implements TestsConstants {
         claims.put("nonce", nonce.toString());
         final String idToken = generator.generate(claims);
 
-        final IDTokenClaimsSet claimsSet = validator.validate(SignedJWT.parse(idToken), nonce);
+        final IDTokenClaimsSet claimsSet = validator.validateIdToken(SignedJWT.parse(idToken), nonce);
         assertEquals(KEY, claimsSet.getSubject().toString());
         assertEquals(PAC4J_URL, claimsSet.getIssuer().toString());
         assertEquals(ID, claimsSet.getAudience().get(0).toString());
         assertNotNull(claimsSet.getExpirationTime());
         assertNotNull(claimsSet.getIssueTime());
         assertEquals(nonce, claimsSet.getNonce());
+    }
+
+    @Test
+    public void testValidateLogoutToken() throws Exception {
+        algorithms.add(JWSAlgorithm.HS256);
+        when(metadata.supportsBackChannelLogout()).thenReturn(true);
+
+        final TokenValidator validator = new TokenValidator(configuration, metadata);
+
+        final JwtGenerator generator = new JwtGenerator(new SecretSignatureConfiguration(CLIENT_SECRET, JWSAlgorithm.HS256));
+        final Map<String, Object> claims = new HashMap<>();
+        claims.put("iss", PAC4J_URL);
+        claims.put("sub", KEY);
+        claims.put("aud", ID);
+        final long now = new Date().getTime() / 1000;
+        claims.put("exp", now + 1000);
+        claims.put("iat", now);
+
+        JSONObject events = new JSONObject();
+        events.put(LogoutTokenClaimsSet.EVENT_TYPE, new JSONObject());
+        claims.put(LogoutTokenClaimsSet.EVENTS_CLAIM_NAME, events);
+
+        final String jti = UUID.randomUUID().toString();
+        claims.put("jti", jti);
+
+        String sessionId = UUID.randomUUID().toString();
+        claims.put("sid", sessionId);
+        final String logoutToken = generator.generate(claims);
+
+        final LogoutTokenClaimsSet claimsSet = validator.validateLogoutToken(SignedJWT.parse(logoutToken));
+        assertEquals(KEY, claimsSet.getSubject().toString());
+        assertEquals(PAC4J_URL, claimsSet.getIssuer().toString());
+        assertEquals(ID, claimsSet.getAudience().get(0).toString());
+        assertNotNull(claimsSet.getExpirationTime());
+        assertNotNull(claimsSet.getIssueTime());
+        assertEquals(claimsSet.getClaim(LogoutTokenClaimsSet.EVENTS_CLAIM_NAME), events);
+        assertEquals(jti, claimsSet.getJWTID().toString());
+        assertEquals(sessionId, claimsSet.getSessionID().toString());
     }
 }

--- a/pac4j-saml/pom.xml
+++ b/pac4j-saml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-saml</artifactId>

--- a/pac4j-springboot/pom.xml
+++ b/pac4j-springboot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-springboot</artifactId>

--- a/pac4j-sql/pom.xml
+++ b/pac4j-sql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.pac4j</groupId>
         <artifactId>pac4j-parent</artifactId>
-        <version>6.2.3-SNAPSHOT</version>
+        <version>6.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>pac4j-sql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>pac4j-parent</artifactId>
 	<packaging>pom</packaging>
 	<name>pac4j parent</name>
-	<version>6.2.3-SNAPSHOT</version>
+	<version>6.3.0-SNAPSHOT</version>
 	<description>Profile &amp; Authentication Client for Java</description>
 	<url>https://github.com/pac4j/pac4j</url>
 


### PR DESCRIPTION
Reported issue in https://groups.google.com/g/pac4j-dev/c/uohUZnxw0Dc .

Fix proposal:

- Use `LogoutTokenValidators`. I decided to provide separate lists for `LogoutTokenValidators` and  `IDTokenValidators`. 
 `LogoutTokenValidators` are created only in case backchannel logout is supported by the `OIDCProvider`.
Verified with local setup that with this change, backchannel logout works (=users are logged out immediatly).

- Also adapt `AzureAdTokenValidator` accordingly.