### PR TITLE
OpenID Federationg explicit registration fix

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,6 +5,11 @@ title: Release notes&#58;
 
 ### JDK17:
 
+**v6.5.2**:
+- Fix OpenID federation explicit registration request Content-Type value to `application/entity-statement+jwt`
+- Fix OpenID federation explicit registration response Content-Type validation to expect `application/explicit-registration-response+jwt`
+- Added missing audience claim to the OpenID federation explicit registration request
+
 **v6.5.1**:
 - Security fix on the `pac4j-core` module
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/federation/entity/DefaultEntityConfigurationGenerator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/federation/entity/DefaultEntityConfigurationGenerator.java
@@ -106,6 +106,7 @@ public class DefaultEntityConfigurationGenerator extends InitializableObject imp
             .subject(entityId)
             .jwtID(UUID.randomUUID().toString())
             .issueTime(now)
+            .audience(federation.getTargetOp())
             .expirationTime(expirationDate)
             .notBeforeTime(now);
 

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/registration/ExplicitRegistrationResponse.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/registration/ExplicitRegistrationResponse.java
@@ -18,6 +18,12 @@ import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatementClaims
 import com.nimbusds.openid.connect.sdk.federation.utils.JWTUtils;
 import net.jcip.annotations.Immutable;
 
+/**
+ * OpenID Federation explicit registration response
+ *
+ * @author Jan Pavlíček
+ * @since 6.5.2
+ */
 @Immutable
 public final class ExplicitRegistrationResponse {
     public static final JOSEObjectType EXPLICIT_RESPONSE_JOSE_OBJECT_TYPE = new JOSEObjectType("explicit-registration-response+jwt");

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/registration/ExplicitRegistrationResponse.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/registration/ExplicitRegistrationResponse.java
@@ -1,0 +1,99 @@
+package org.pac4j.oidc.metadata.registration;
+
+import com.nimbusds.common.contenttype.ContentType;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSObject.State;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.openid.connect.sdk.federation.entities.EntityID;
+import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatementClaimsSet;
+import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatementClaimsVerifier;
+import com.nimbusds.openid.connect.sdk.federation.utils.JWTUtils;
+import net.jcip.annotations.Immutable;
+
+@Immutable
+public final class ExplicitRegistrationResponse {
+    public static final JOSEObjectType EXPLICIT_RESPONSE_JOSE_OBJECT_TYPE = new JOSEObjectType("explicit-registration-response+jwt");
+    public static final ContentType CONTENT_TYPE;
+
+    static {
+        CONTENT_TYPE = new ContentType("application", EXPLICIT_RESPONSE_JOSE_OBJECT_TYPE.getType(), new ContentType.Parameter[0]);
+    }
+
+    private final SignedJWT statementJWT;
+    private final EntityStatementClaimsSet claimsSet;
+
+    private ExplicitRegistrationResponse(SignedJWT statementJWT, EntityStatementClaimsSet claimsSet) {
+        if (statementJWT == null) {
+            throw new IllegalArgumentException("The entity statement must not be null");
+        } else if (State.UNSIGNED.equals(statementJWT.getState())) {
+            throw new IllegalArgumentException("The statement is not signed");
+        } else {
+            this.statementJWT = statementJWT;
+            if (claimsSet == null) {
+                throw new IllegalArgumentException("The entity statement claims set must not be null");
+            } else {
+                this.claimsSet = claimsSet;
+            }
+        }
+    }
+
+    public static ExplicitRegistrationResponse sign(EntityStatementClaimsSet claimsSet, JWK signingJWK, JWSAlgorithm jwsAlg)
+        throws JOSEException {
+        if (claimsSet.isSelfStatement() && !claimsSet.getJWKSet().containsJWK(signingJWK)) {
+            throw new JOSEException("Signing JWK not found in JWK set of self-statement");
+        } else {
+            try {
+                return new ExplicitRegistrationResponse(
+                    JWTUtils.sign(signingJWK, jwsAlg, EXPLICIT_RESPONSE_JOSE_OBJECT_TYPE, claimsSet.toJWTClaimsSet()), claimsSet);
+            } catch (ParseException e) {
+                throw new JOSEException(e.getMessage(), e);
+            }
+        }
+    }
+
+    public static ExplicitRegistrationResponse parse(SignedJWT signedStmt) throws ParseException {
+        return new ExplicitRegistrationResponse(signedStmt, new EntityStatementClaimsSet(JWTUtils.parseSignedJWTClaimsSet(signedStmt)));
+    }
+
+    public static ExplicitRegistrationResponse parse(String signedStmtString) throws ParseException {
+        try {
+            return parse(SignedJWT.parse(signedStmtString));
+        } catch (java.text.ParseException e) {
+            throw new ParseException("Invalid entity statement: " + e.getMessage(), e);
+        }
+    }
+
+    public EntityID getEntityID() {
+        return this.getClaimsSet().getSubjectEntityID();
+    }
+
+    public SignedJWT getSignedStatement() {
+        return this.statementJWT;
+    }
+
+    public EntityStatementClaimsSet getClaimsSet() {
+        return this.claimsSet;
+    }
+
+    public Base64URL verifySignatureOfSelfStatement() throws BadJOSEException, JOSEException {
+        if (!this.getClaimsSet().isSelfStatement()) {
+            throw new BadJOSEException("Entity statement not self-issued");
+        } else {
+            return this.verifySignature(this.getClaimsSet().getJWKSet());
+        }
+    }
+
+    public Base64URL verifySignature(JWKSet jwkSet) throws BadJOSEException, JOSEException {
+        return JWTUtils.verifySignature(this.statementJWT, EXPLICIT_RESPONSE_JOSE_OBJECT_TYPE,
+            new EntityStatementClaimsVerifier((Audience) null), jwkSet);
+    }
+}
+

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/registration/FederationClientRegister.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/metadata/registration/FederationClientRegister.java
@@ -1,5 +1,7 @@
 package org.pac4j.oidc.metadata.registration;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
@@ -11,6 +13,9 @@ import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatement;
 import com.nimbusds.openid.connect.sdk.federation.entities.EntityStatementClaimsVerifier;
 import com.nimbusds.openid.connect.sdk.federation.registration.ClientRegistrationType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.text.ParseException;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang3.StringUtils;
@@ -18,12 +23,6 @@ import org.pac4j.core.exception.TechnicalException;
 import org.pac4j.core.util.FileHelper;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.exceptions.OidcException;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.text.ParseException;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Handles OpenID Federation client registration logic for OP in federation.
@@ -78,7 +77,7 @@ public class FederationClientRegister {
         String clientId = null;
         try {
             val request = new HTTPRequest(HTTPRequest.Method.POST, registrationEndpoint);
-            request.setContentType("application/jose");
+            request.setContentType(EntityStatement.CONTENT_TYPE.toString());
             request.setBody(entityConfig);
             configuration.configureHttpRequest(request);
             val response = request.send();
@@ -87,9 +86,10 @@ public class FederationClientRegister {
             val content = response.getContent();
             if (code == 200 || code == 201) {
                 LOGGER.debug("Received response registration: {}", content);
-                val statement = EntityStatement.parse(content);
+                val statement = ExplicitRegistrationResponse.parse(content);
                 val type = statement.getSignedStatement().getHeader().getType();
-                if (type != null && !JOSEObjectType.JWT.equals(type) && !EntityStatement.JOSE_OBJECT_TYPE.equals(type)) {
+                if (type != null && !JOSEObjectType.JWT.equals(type) &&
+                    !ExplicitRegistrationResponse.EXPLICIT_RESPONSE_JOSE_OBJECT_TYPE.equals(type)) {
                     throw new OidcException("Unexpected explicit registration response typ: " + type);
                 }
                 statement.verifySignature(federationJWKS);

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/federation/entity/DefaultEntityConfigurationGeneratorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/federation/entity/DefaultEntityConfigurationGeneratorTests.java
@@ -398,6 +398,7 @@ public final class DefaultEntityConfigurationGeneratorTests {
         federation.setScopes(List.of("openid", "email"));
         federation.setContactName("pac4j buildConfig client");
         federation.setContactEmails(List.of("build@example.org"));
+        federation.setTargetOp("https://op.example.org");
         val generator = newGenerator();
 
         val signingKey = new RSAKeyGenerator(2048)
@@ -414,6 +415,7 @@ public final class DefaultEntityConfigurationGeneratorTests {
 
         assertEquals("https://entity.example.org", claims.getIssuer());
         assertEquals("https://entity.example.org", claims.getSubject());
+        assertEquals(federation.getTargetOp(), claims.getAudience().get(0));
         assertNotNull(claims.getJWTID());
         assertNotNull(claims.getIssueTime());
         assertNotNull(claims.getNotBeforeTime());

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcFederationOpMetadataResolverTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/OidcFederationOpMetadataResolverTests.java
@@ -113,7 +113,7 @@ public final class OidcFederationOpMetadataResolverTests {
         explicitConfiguration.getFederation().setSecretExportFile(secretFile.toString());
 
         val entityConfigurationGenerator = Mockito.mock(EntityConfigurationGenerator.class);
-        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/entity-statement+jwt");
+        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/explicit-registration-response+jwt");
         Mockito.when(entityConfigurationGenerator.generateEntityStatement()).thenReturn("entity-configuration");
         explicitConfiguration.getFederation().setEntityConfigurationGenerator(entityConfigurationGenerator);
 
@@ -122,7 +122,7 @@ public final class OidcFederationOpMetadataResolverTests {
 
         val webServer = new WebServer(0)
             .defineResponse("ok", new ServerResponse(WebServer.Response.Status.CREATED,
-                "application/entity-statement+jwt", registrationResponse));
+                "application/explicit-registration-response+jwt", registrationResponse));
         webServer.start();
         try {
             val metadata = OIDCProviderMetadata.parse(METADATA_CLIENT_SECRET_BASIC);
@@ -310,6 +310,6 @@ public final class OidcFederationOpMetadataResolverTests {
                 "client_id", clientId,
                 "client_secret", clientSecret)))
             .build();
-        return JwkHelper.buildSignedJwt(claims, signingKey, "entity-statement+jwt");
+        return JwkHelper.buildSignedJwt(claims, signingKey, "explicit-registration-response+jwt");
     }
 }

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/registration/FederationClientRegisterTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/metadata/registration/FederationClientRegisterTests.java
@@ -133,7 +133,7 @@ public final class FederationClientRegisterTests {
         configuration.getFederation().setSecretExportFile(secretFile.toString());
 
         val entityConfigurationGenerator = Mockito.mock(EntityConfigurationGenerator.class);
-        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/entity-statement+jwt");
+        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/explicit-registration-response+jwt");
         Mockito.when(entityConfigurationGenerator.generateEntityStatement()).thenReturn("entity-configuration");
         configuration.getFederation().setEntityConfigurationGenerator(entityConfigurationGenerator);
 
@@ -142,7 +142,7 @@ public final class FederationClientRegisterTests {
 
         val webServer = new WebServer(0)
             .defineResponse("ok", new ServerResponse(WebServer.Response.Status.CREATED,
-                "application/entity-statement+jwt", registrationResponse));
+                "application/explicit-registration-response+jwt", registrationResponse));
         webServer.start();
         try {
             val metadata = OIDCProviderMetadata.parse(METADATA_CLIENT_SECRET_BASIC);
@@ -165,7 +165,7 @@ public final class FederationClientRegisterTests {
         configuration.getFederation().setEntityId("https://rp.example.org");
 
         val entityConfigurationGenerator = Mockito.mock(EntityConfigurationGenerator.class);
-        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/entity-statement+jwt");
+        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/explicit-registration-response+jwt");
         Mockito.when(entityConfigurationGenerator.generateEntityStatement()).thenReturn("entity-configuration");
         configuration.getFederation().setEntityConfigurationGenerator(entityConfigurationGenerator);
 
@@ -174,7 +174,7 @@ public final class FederationClientRegisterTests {
 
         val webServer = new WebServer(0)
             .defineResponse("ok", new ServerResponse(WebServer.Response.Status.CREATED,
-                "application/entity-statement+jwt", registrationResponse));
+                "application/explicit-registration-response+jwt", registrationResponse));
         webServer.start();
         try {
             val metadata = OIDCProviderMetadata.parse(METADATA_CLIENT_SECRET_BASIC);
@@ -199,7 +199,7 @@ public final class FederationClientRegisterTests {
         configuration.getFederation().setSecretExportFile(secretFile.toString());
 
         val entityConfigurationGenerator = Mockito.mock(EntityConfigurationGenerator.class);
-        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/entity-statement+jwt");
+        Mockito.when(entityConfigurationGenerator.getContentType()).thenReturn("application/explicit-registration-response+jwt");
         Mockito.when(entityConfigurationGenerator.generateEntityStatement()).thenReturn("entity-configuration");
         configuration.getFederation().setEntityConfigurationGenerator(entityConfigurationGenerator);
 
@@ -208,7 +208,7 @@ public final class FederationClientRegisterTests {
 
         val webServer = new WebServer(0)
             .defineResponse("ok", new ServerResponse(WebServer.Response.Status.CREATED,
-                "application/entity-statement+jwt", registrationResponse));
+                "application/explicit-registration-response+jwt", registrationResponse));
         webServer.start();
         try {
             val metadata = OIDCProviderMetadata.parse(METADATA_CLIENT_SECRET_BASIC);
@@ -241,6 +241,6 @@ public final class FederationClientRegisterTests {
                 "client_id", clientId,
                 "client_secret", clientSecret)))
             .build();
-        return JwkHelper.buildSignedJwt(claims, signingKey, "entity-statement+jwt");
+        return JwkHelper.buildSignedJwt(claims, signingKey, "explicit-registration-response+jwt");
     }
 }


### PR DESCRIPTION
According to the OpenID Federation 1.0 explicit registration request Content type MUST be `application/entity-statement+jwt` https://openid.net/specs/openid-federation-1_0.html#section-12.2.1-6 and explicit registration response Content type must be `application/explicit-registration-response+jwt` https://openid.net/specs/openid-federation-1_0.html#section-12.2.3-9. 

Another issue was the absence of a REQUIRED audience claim in the explicit registration request. 

This PR fixes both issues and also includes updated tests.