### PR TITLE
JEESessionStore - Check if session is already invalidated

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -10,6 +10,7 @@ title: Release notes&#58;
 - Rework the `SpringResourceLoader` behavior to improve the OIDC/SAML metadata loading resilience:
   - retry every 2 seconds before anything has been loaded
   - retry every 60 seconds after the first loading and return the old data in case of error
+- JEESessionStore: Consider invalidated session in set method (handle IllegalStateException)
 
 **v6.5.5**:
 - OpenID federation: trust anchors can now be defined only by their URLs (without specifying the JWKS) although it is better to have the JWKS out of band

--- a/pac4j-jakartaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java
+++ b/pac4j-jakartaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java
@@ -107,7 +107,11 @@ public class JEESessionStore extends PrefixedSessionStore {
             } else {
                 LOGGER.debug("Set key: {} for value: {}", prefixedKey, value);
             }
-            httpSession.get().setAttribute(prefixedKey, value);
+            try {
+                httpSession.get().setAttribute(prefixedKey, value);
+            } catch (IllegalStateException e) {
+                LOGGER.debug("Session has already been invalidated.");
+            }
         }
     }
 

--- a/pac4j-javaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java
+++ b/pac4j-javaee/src/main/java/org/pac4j/jee/context/session/JEESessionStore.java
@@ -110,7 +110,11 @@ public class JEESessionStore extends PrefixedSessionStore {
             } else {
                 LOGGER.debug("Set key: {} for value: {}", prefixedKey, value);
             }
-            httpSession.get().setAttribute(prefixedKey, value);
+            try {
+                httpSession.get().setAttribute(prefixedKey, value);
+            } catch (IllegalStateException e) {
+                LOGGER.debug("Session has already been invalidated.");
+            }
         }
     }
 


### PR DESCRIPTION
Use case OIDC backchannel logout: This may happen when we configure e.g. back channel logout and central logout, where is necessary to use JEESessionStore to track sessions. A user may click logout button, invalidating the session. The IdP may send another request for logout (backchannel logout). If this happens and do not check whether session is invalidated, we may run into an `IllegalStateException` as the code tries to remove the session again, calling the set method in JEESessionStore.

See https://openid.net/specs/openid-connect-backchannel-1_0.html#BCActions:

>  If the identified End-User is already logged out at the RP when the logout request is received, the logout is considered to have succeeded.

Maybe there is a quicker way to avoid calling the destroy method altogether (OidcLogoutProcessor) to comply with the spec.