### PR TITLE
OIDC: Fix nonce requirmemt for stateless api access via bearer token

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -12,6 +12,9 @@ title: Release notes&#58;
   - retry every 60 seconds after the first loading and return the old data in case of error
 - Fix OpenID federation forced signing of the auth request object for explicitly registered clients when it is not mandatory.
 
+**v6.5.7**:
+- OIDC: ProfileCreator - skip nonce when Bearer Access Token is used
+
 **v6.5.6**:
 - Security fixes/hardenings:
   - an unsigned SAML `LogoutRequest` can no longer destroy a session based on the `NameID` (when the IdP sends no `SessionIndex`) unless the signature is validated

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/profile/creator/OidcProfileCreator.java
@@ -88,7 +88,7 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
         init();
 
         OidcCredentials oidcCredentials = null;
-        AccessToken accessToken = null;
+        AccessToken accessToken;
         // credentials were obtained from a refresh token
         boolean refreshedCredentials = false;
         val regularOidcFlow = credentials instanceof OidcCredentials;
@@ -119,28 +119,29 @@ public class OidcProfileCreator extends ProfileDefinitionAware implements Profil
         }
 
         try {
+            Nonce nonce = null;
+            if (regularOidcFlow) {
+                // skipRefreshedNonce is true when the token was created with the refresh token and we don't want to check nonce
+                // in idToken in this case
+                val skipRefreshedNonce = refreshedCredentials && !configuration.isUseNonceOnRefresh();
+                if (configuration.isUseNonce() && !skipRefreshedNonce) {
+                    nonce = new Nonce(
+                        (String) ctx.sessionStore().get(ctx.webContext(), client.getNonceSessionAttributeName()).orElse(null)
+                    );
+                }
+                // Check ID Token
+                if (oidcCredentials.getIdToken() != null) {
+                    val claimsSet = configuration.getOpMetadataResolver().getTokenValidator()
+                        .validateIdToken(oidcCredentials.toIdToken(), nonce);
+                    assertNotNull("claimsSet", claimsSet);
+                    profile.setId(ProfileHelper.sanitizeIdentifier(claimsSet.getSubject()));
 
-            final Nonce nonce;
-            // skipRefreshedNonce is true when the token was created with the refresh token and we don't want to check nonce
-            // in idToken in this case
-            val skipRefreshedNonce = refreshedCredentials && !configuration.isUseNonceOnRefresh();
-            if (configuration.isUseNonce() && !skipRefreshedNonce) {
-                nonce = new Nonce((String) ctx.sessionStore().get(ctx.webContext(), client.getNonceSessionAttributeName()).orElse(null));
-            } else {
-                nonce = null;
-            }
-            // Check ID Token
-            if (oidcCredentials != null && oidcCredentials.getIdToken() != null) {
-                val claimsSet = configuration.getOpMetadataResolver().getTokenValidator()
-                    .validateIdToken(oidcCredentials.toIdToken(), nonce);
-                assertNotNull("claimsSet", claimsSet);
-                profile.setId(ProfileHelper.sanitizeIdentifier(claimsSet.getSubject()));
-
-                // keep the session ID if provided
-                val sid = (String) claimsSet.getClaim(Pac4jConstants.OIDC_CLAIM_SESSIONID);
-                val sessionLogoutHandler = client.findSessionLogoutHandler();
-                if (StringUtils.isNotBlank(sid) && sessionLogoutHandler != null) {
-                    sessionLogoutHandler.recordSession(ctx, sid);
+                    // keep the session ID if provided
+                    val sid = (String) claimsSet.getClaim(Pac4jConstants.OIDC_CLAIM_SESSIONID);
+                    val sessionLogoutHandler = client.findSessionLogoutHandler();
+                    if (StringUtils.isNotBlank(sid) && sessionLogoutHandler != null) {
+                        sessionLogoutHandler.recordSession(ctx, sid);
+                    }
                 }
             }
 

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/profile/creator/OidcProfileCreatorTests.java
@@ -202,4 +202,23 @@ public class OidcProfileCreatorTests implements TestsConstants {
         assertThrows(OidcConfigurationException.class,
             () -> creator.create(new CallContext(webContext, new MockSessionStore()), credentials));
     }
+
+    @Test
+    public void testBearerAccessTokenSkipNonce() throws Exception {
+        when(configuration.isIncludeAccessTokenClaimsInProfile()).thenReturn(true);
+        when(configuration.isCallUserInfoEndpoint()).thenReturn(true);
+        when(configuration.isUseNonce()).thenReturn(true);
+        ProfileCreator creator = new OidcProfileCreator(configuration, new OidcClient(configuration));
+        var webContext = MockWebContext.create();
+        var credentials = new TokenCredentials();
+
+        var accessTokenClaims = new JWTClaimsSet.Builder(idTokenClaims.toJWTClaimsSet()).claim("client", "pac4j").build();
+        var accessTokenToken = new PlainJWT(accessTokenClaims);
+        credentials.setToken(accessTokenToken.serialize());
+
+        // create does not throw exception in this case and we do not extract the token claims
+        var profile = creator.create(new CallContext(webContext, new MockSessionStore()), credentials);
+        assertTrue(profile.isPresent());
+        assertNull(profile.get().getAttribute("client"));
+    }
 }


### PR DESCRIPTION
`OidcProfileCreator` attempts to look up a session-bound nonce even when processing a stateless API request using a `BearerAccessToken`. In stateless environments, this triggers unnecessary session lookups and forces developers to manually disable` setUseNonce(false)` globally.

Solution:Reuse the existing `regularOidcFlow` flag to gate the nonce lookup. The session check now runs only for standard browser authentication (`OidcCredentials`). For direct bearer tokens, we now skip the logic that applies to regular oidc flow only.