### PR TITLE
fix: allow client_secret_basic and client_secret_post for explicitly registered clients

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -10,6 +10,7 @@ title: Release notes&#58;
 - Rework the `SpringResourceLoader` behavior to improve the OIDC/SAML metadata loading resilience:
   - retry every 2 seconds before anything has been loaded
   - retry every 60 seconds after the first loading and return the old data in case of error
+- Fix OpenID federation forced signing of the auth request object for explicitly registered clients when it is not mandatory.
 
 **v6.5.6**:
 - Security fixes/reinforcements:

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilder.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilder.java
@@ -68,16 +68,24 @@ public class OidcRedirectionActionBuilder extends InitializableObject implements
         val config = client.getConfiguration();
         val requestedAlg = config.getRequestObjectSigningAlgorithm();
 
+        val authMethod = config.getClientAuthenticationMethod();
+
+        // Do not require request object signing when having OIDC explicitly registered client
+        val usesClientSecretAuth = config.getSecret() != null && (ClientAuthenticationMethod.CLIENT_SECRET_BASIC.equals(authMethod)
+            || ClientAuthenticationMethod.CLIENT_SECRET_POST.equals(authMethod));
+
         val reqObjSigningRequired = requestedAlg != null;
-        val reqObjSigningMandatoryForFederation = config.isFederation() && !config.isPushedAuthorizationRequest()
-            && !ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(config.getClientAuthenticationMethod());
+        val reqObjSigningMandatoryForFederation = config.isFederation()
+            && !config.isPushedAuthorizationRequest()
+            && !ClientAuthenticationMethod.PRIVATE_KEY_JWT.equals(authMethod)
+            && !usesClientSecretAuth;
         if (reqObjSigningRequired || reqObjSigningMandatoryForFederation) {
             assertTrue(config.getRpJwks().isDefined(), "config.rpJwks must be defined to sign request objects");
 
             config.ensuresMetadataResolverInitialized();
             val opAlgs = config.getOpMetadataResolver().load().getRequestObjectJWSAlgs();
             val matchedAlgs = OidcHelper.matchRPAlgAgainstOPAlgs("Request Object", requestedAlg, opAlgs);
-            assertTrue(matchedAlgs != null && matchedAlgs.size() >= 1, "At least one algorithm is expected");
+            assertTrue(matchedAlgs != null && !matchedAlgs.isEmpty(), "At least one algorithm is expected");
 
             signingAlg = matchedAlgs.get(0);
             LOGGER.debug("Algorithm used for request object signing: {}", signingAlg);


### PR DESCRIPTION
The code was forcing the signing of the auth request object for all OpenID federation clients. When the client is registered using explicit client registration, the auth request object signing does not have to be mandatory, as the client with client credentials can use `client_secret_basic` and `client_secret_post` methods if supported.

This fixes the issue and makes signing of the auth request object optional for explicitly registered clients.