### PR TITLE
feat: allow login-hint per request attribute

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -12,6 +12,7 @@ title: Release notes&#58;
   - retry every 2 seconds before anything has been loaded
   - retry every 60 seconds after the first loading and return the old data in case of error
 - Fix OpenID federation forced signing of the auth request object for explicitly registered clients when it is not mandatory.
+- OIDC's login hints can be provided dynamically as a `login_hint` request attribute.
 
 **v6.5.7**:
 - OIDC: ProfileCreator - skip nonce when Bearer Access Token is used

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfigurationContext.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/config/OidcConfigurationContext.java
@@ -91,6 +91,16 @@ public class OidcConfigurationContext {
     }
 
     /**
+     * <p>getLoginHint.</p>
+     *
+     * @return a {@link String} object
+     */
+    public String getLoginHint() {
+        return (String) context.getRequestAttribute(OidcConfiguration.LOGIN_HINT)
+            .orElse(configuration.getLoginHint());
+    }
+
+    /**
      * <p>getCustomParams.</p>
      *
      * @return a {@link Map} object

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilder.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/redirect/OidcRedirectionActionBuilder.java
@@ -190,7 +190,7 @@ public class OidcRedirectionActionBuilder extends InitializableObject implements
         val clientId = configContext.getConfiguration().getClientId();
         authParams.requestObject().put(CLIENT_ID, clientId);
         authParams.url().put(CLIENT_ID, clientId);
-        val loginHint = configContext.getConfiguration().getLoginHint();
+        val loginHint = configContext.getLoginHint();
         if (loginHint != null && !loginHint.isEmpty()) {
             authParams.requestObject().put(OidcConfiguration.LOGIN_HINT, loginHint);
         }

--- a/pac4j-oidc/src/test/java/org/pac4j/oidc/config/OidcConfigurationContextTest.java
+++ b/pac4j-oidc/src/test/java/org/pac4j/oidc/config/OidcConfigurationContextTest.java
@@ -46,4 +46,18 @@ public class OidcConfigurationContextTest {
 
         assertEquals("openid profile email", result);
     }
+
+    @Test
+    public void shouldResolveLoginHintFromRequest() {
+        var webContext = MockWebContext.create();
+        webContext.setRequestAttribute(OidcConfiguration.LOGIN_HINT, "user@example.org");
+        var oidcConfiguration = new OidcConfiguration();
+        oidcConfiguration.setLoginHint("user@pac4j.org");
+        var oidcConfigurationContext = new OidcConfigurationContext(webContext, oidcConfiguration);
+        var result = oidcConfigurationContext.getLoginHint();
+        assertEquals("user@example.org", result);
+        webContext.setRequestAttribute(OidcConfiguration.LOGIN_HINT, null);
+        result = oidcConfigurationContext.getLoginHint();
+        assertEquals("user@pac4j.org", result);
+    }
 }


### PR DESCRIPTION
`login_hint` often needs to be determined dynamically, based on user provided input or session data. This change allows it to be found dynamically via request attributes, optionally, rather than just statically configured.