### PR TITLE
Fix: Clear attemptedAuthentication flag on OIDC validation failure in callback to prevent 401 on retry

### DIFF
--- a/documentation/docs/release-notes.md
+++ b/documentation/docs/release-notes.md
@@ -5,6 +5,9 @@ title: Release notes&#58;
 
 ### JDK17:
 
+**v6.5.8**:
+- Fix: OIDC - Clear attemptedAuthentication flag on OIDC validation failure in callback to prevent 401 on retry
+
 **v6.5.7**:
 - OIDC: ProfileCreator - skip nonce when Bearer Access Token is used
 - SAML: OpenSAML can again be initialized when a standalone Apache Xerces is on the classpath

--- a/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
+++ b/pac4j-core/src/main/java/org/pac4j/core/client/IndirectClient.java
@@ -188,7 +188,7 @@ public abstract class IndirectClient extends BaseClient {
         sessionStore.set(context, Pac4jConstants.REQUESTED_URL, null);
     }
 
-    private void cleanAttemptedAuthentication(final WebContext context, final SessionStore sessionStore) {
+    protected void cleanAttemptedAuthentication(final WebContext context, final SessionStore sessionStore) {
         logger.debug("clean authentication attempt from session");
         sessionStore.set(context, getName() + ATTEMPTED_AUTHENTICATION_SUFFIX, null);
     }
@@ -220,7 +220,7 @@ public abstract class IndirectClient extends BaseClient {
         return getName() + CODE_VERIFIER_SESSION_PARAMETER;
     }
 
-    private void saveAttemptedAuthentication(final WebContext context, final SessionStore sessionStore) {
+    protected void saveAttemptedAuthentication(final WebContext context, final SessionStore sessionStore) {
         if (checkAuthenticationAttempt) {
             logger.debug("save authentication attempt in session");
             sessionStore.set(context, getName() + ATTEMPTED_AUTHENTICATION_SUFFIX, "true");

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -6,6 +6,7 @@ import lombok.val;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.CallContext;
 import org.pac4j.core.credentials.Credentials;
+import org.pac4j.core.http.url.DefaultUrlResolver;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
@@ -93,10 +94,11 @@ public class OidcClient extends IndirectClient {
 
         if (credentials == null && getProfileFactoryWhenNotAuthenticated() == null) {
             val currentPath = webContext.getPath();
+            val defaultUrlResolver = new DefaultUrlResolver(true);
             val resolver = this.getCallbackUrlResolver();
             if (resolver != null && currentPath != null) {
                 val computedCallbackUrl = resolver.compute(
-                    this.getUrlResolver(),
+                    defaultUrlResolver,
                     this.getCallbackUrl(),
                     this.getName(),
                     webContext

--- a/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
+++ b/pac4j-oidc/src/main/java/org/pac4j/oidc/client/OidcClient.java
@@ -5,6 +5,7 @@ import lombok.ToString;
 import lombok.val;
 import org.pac4j.core.client.IndirectClient;
 import org.pac4j.core.context.CallContext;
+import org.pac4j.core.credentials.Credentials;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.oidc.config.OidcConfiguration;
 import org.pac4j.oidc.credentials.OidcCredentials;
@@ -83,6 +84,39 @@ public class OidcClient extends IndirectClient {
         if (federation.getEntityId() == null) {
             federation.setEntityId(callbackUrl);
         }
+    }
+
+    @Override
+    protected void checkCredentials(CallContext ctx, Credentials credentials) {
+        val webContext = ctx.webContext();
+        val sessionStore = ctx.sessionStore();
+
+        if (credentials == null && getProfileFactoryWhenNotAuthenticated() == null) {
+            val currentPath = webContext.getPath();
+            val resolver = this.getCallbackUrlResolver();
+            if (resolver != null && currentPath != null) {
+                val computedCallbackUrl = resolver.compute(
+                    this.getUrlResolver(),
+                    this.getCallbackUrl(),
+                    this.getName(),
+                    webContext
+                );
+                if (computedCallbackUrl != null) {
+                    try {
+                        val expectedCallbackPath = new java.net.URI(computedCallbackUrl).getPath();
+                        if (currentPath.equals(expectedCallbackPath)) {
+                            logger.debug("OIDC callback execution failed validation on explicit path '{}'. " +
+                                "Cleaning attempted authentication to prevent 401 error.", currentPath);
+                            cleanAttemptedAuthentication(webContext, sessionStore);
+                            return;
+                        }
+                    } catch (java.net.URISyntaxException e) {
+                        logger.error("Failed to parse computed callback URL: {}", computedCallbackUrl, e);
+                    }
+                }
+            }
+        }
+        super.checkCredentials(ctx, credentials);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
Problem:
We recently stumbled over this problem when retrying a login:
When OIDC token validation fails, `validateCredentials` returns null. This triggers a cascade into the finally block, where `IndirectClient#checkCredentials` blindly writes `attemptedAuthentication = "true"` into the session. If the application routes the user to an error page, any manual retry link immediately hits a 401 Unauthorized in the `SecurityFilter`. The framework mistakes the user's manual action for an redirect to 401 because of the leftover session flag.

Solution:
Overrode `checkCredentials` in OidcClient to intercept this specific failure state. If a validation fails on the callback path, the method actively clears the `attemptedAuthentication` flag from the session store and aborts execution. This short-circuits the base class logic and prevents the blocking flag from being written.